### PR TITLE
[bugfix] distributed gauc: use forward instead of update for batch-wise synchronize

### DIFF
--- a/tzrec/metrics/grouped_auc.py
+++ b/tzrec/metrics/grouped_auc.py
@@ -65,7 +65,9 @@ class GroupedAUC(Metric):
     """Grouped AUC."""
 
     def __init__(self, **kwargs: Any) -> None:
+        kwargs.pop("grouping_key")
         super().__init__(**kwargs)
+        self.dist_sync_on_step = kwargs.get("dist_sync_on_step", False)
 
         self.add_state("eval_data", default=[], dist_reduce_fx=custom_reduce_fx)
 

--- a/tzrec/protos/metric.proto
+++ b/tzrec/protos/metric.proto
@@ -31,6 +31,7 @@ message Accuracy {
 
 message GroupedAUC {
     required string grouping_key = 1;
+    optional bool dist_sync_on_step = 2 [default = false];
 }
 
 message XAUC {


### PR DESCRIPTION
all-gather operation may cause NCCL timeout error when the data is large, so we use metrics.forward instead of metrics.update since forward can offer batch-wise synchronization and thus be more stable. 