### PR TITLE
[bugfix] fix parse batch empty MapArray error in NegativeSampler

### DIFF
--- a/tzrec/datasets/sampler.py
+++ b/tzrec/datasets/sampler.py
@@ -154,12 +154,16 @@ def _to_arrow_array(
             kv = pa.compute.split_pattern_regex(x, pattern=multival_sep)
             offsets = kv.offsets
             kv_list = pa.compute.split_pattern(kv.values, ":").values
-            keys = kv_list.take(list(range(0, len(kv_list), 2))).cast(
-                field_type.key_type, safe=False
-            )
-            items = kv_list.take(list(range(1, len(kv_list), 2))).cast(
-                field_type.item_type, safe=False
-            )
+            if len(kv_list) > 0:
+                keys = kv_list.take(list(range(0, len(kv_list), 2))).cast(
+                    field_type.key_type, safe=False
+                )
+                items = kv_list.take(list(range(1, len(kv_list), 2))).cast(
+                    field_type.item_type, safe=False
+                )
+            else:
+                keys = pa.array([], type=field_type.key_type)
+                items = pa.array([], type=field_type.item_type)
             result = pa.MapArray.from_arrays(offsets, keys, items)
 
     elif np.issubdtype(x.dtype, np.str_) and not pa.types.is_string(field_type):


### PR DESCRIPTION
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/tzrec/datasets/sampler.py", line 157, in _to_arrow_array                                                                                                
[rank0]:     keys = kv_list.take(list(range(0, len(kv_list), 2))).cast(                                                                                                                                          
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                
[rank0]:   File "pyarrow/array.pxi", line 1472, in pyarrow.lib.Array.take                                                                                                                                        
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pyarrow/compute.py", line 487, in take
[rank0]:     return call_function('take', [data, indices], options, memory_pool)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "pyarrow/_compute.pyx", line 590, in pyarrow._compute.call_function
[rank0]:   File "pyarrow/_compute.pyx", line 385, in pyarrow._compute.Function.call
[rank0]:   File "pyarrow/error.pxi", line 155, in pyarrow.lib.pyarrow_internal_check_status
[rank0]:   File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
[rank0]: pyarrow.lib.ArrowNotImplementedError: Function 'array_take' has no kernel matching input types (string, null)