### PR TITLE
[bugfix] add heartbeat thread to prevent Kafka MAX_POLL_EXCEEDED

### DIFF
--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -299,8 +299,8 @@ class KafkaReader(BaseReader):
                         )
                         tp.offset = OFFSET_INVALID
 
-            consumer.assign(partitions)
             with consumer_lock:
+                consumer.assign(partitions)
                 if is_paused[0]:
                     consumer.pause(consumer.assignment())
             logger.info(
@@ -313,22 +313,30 @@ class KafkaReader(BaseReader):
         def _heartbeat() -> None:
             """Keep consumer alive when generator is blocked at yield."""
             while not stop_event.is_set():
-                elapsed = time.monotonic() - last_consume_time[0]
-                if elapsed > idle_threshold:
-                    with consumer_lock:
-                        # Re-check elapsed inside lock to avoid racing with
-                        # the main thread that updates last_consume_time
-                        # under the same lock before calling consume().
-                        elapsed = time.monotonic() - last_consume_time[0]
-                        if elapsed > idle_threshold:
-                            if not is_paused[0]:
-                                assignment = consumer.assignment()
-                                if assignment:
-                                    consumer.pause(assignment)
-                                is_paused[0] = True
-                            msg = consumer.poll(0)
-                            if msg is not None:
-                                stolen_msgs.append(msg)
+                try:
+                    elapsed = time.monotonic() - last_consume_time[0]
+                    if elapsed > idle_threshold:
+                        with consumer_lock:
+                            # Re-check elapsed inside lock to avoid racing
+                            # with the main thread that updates
+                            # last_consume_time under the same lock.
+                            elapsed = time.monotonic() - last_consume_time[0]
+                            if elapsed > idle_threshold:
+                                if not is_paused[0]:
+                                    assignment = consumer.assignment()
+                                    if assignment:
+                                        consumer.pause(assignment)
+                                    is_paused[0] = True
+                                    logger.debug(
+                                        f"heartbeat: paused {len(assignment)}"
+                                        f" partitions after {elapsed:.1f}s"
+                                        f" idle"
+                                    )
+                                msg = consumer.poll(0)
+                                if msg is not None and not msg.error():
+                                    stolen_msgs.append(msg)
+                except Exception:
+                    logger.warning("heartbeat error", exc_info=True)
                 stop_event.wait(1.0)
 
         heartbeat_thread = threading.Thread(
@@ -356,6 +364,7 @@ class KafkaReader(BaseReader):
                         if assignment:
                             consumer.resume(assignment)
                         is_paused[0] = False
+                        logger.debug("heartbeat: resumed partitions")
                     last_consume_time[0] = time.monotonic()
                     pending = list(stolen_msgs)
                     stolen_msgs.clear()
@@ -437,10 +446,16 @@ class KafkaReader(BaseReader):
         finally:
             stop_event.set()
             heartbeat_thread.join(timeout=5.0)
-            try:
-                consumer.close()
-            except Exception as e:
-                logger.warning(f"consumer.close() failed: {e}")
+            if heartbeat_thread.is_alive():
+                logger.warning(
+                    "Heartbeat thread did not exit within timeout; "
+                    "skipping consumer.close() to avoid race."
+                )
+            else:
+                try:
+                    consumer.close()
+                except Exception as e:
+                    logger.warning(f"consumer.close() failed: {e}")
 
     def to_batches(
         self, worker_id: int = 0, num_workers: int = 1

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -341,6 +341,15 @@ class KafkaReader(BaseReader):
         batch_size_per_msg = None
         try:
             while True:
+                num_messages = (
+                    int(math.ceil(self._batch_size / batch_size_per_msg))
+                    if batch_size_per_msg
+                    else 2
+                )
+                # Hold consumer_lock during consume() so the heartbeat
+                # thread cannot call pause() concurrently.
+                # rd_kafka_consume_batch_queue() (used by consume()) is
+                # not thread-safe with concurrent pause/resume/seek.
                 with consumer_lock:
                     if is_paused[0]:
                         assignment = consumer.assignment()
@@ -350,14 +359,8 @@ class KafkaReader(BaseReader):
                     last_consume_time[0] = time.monotonic()
                     pending = list(stolen_msgs)
                     stolen_msgs.clear()
-
-                num_messages = (
-                    int(math.ceil(self._batch_size / batch_size_per_msg))
-                    if batch_size_per_msg
-                    else 2
-                )
-                messages = pending
-                messages.extend(consumer.consume(num_messages))
+                    messages = pending
+                    messages.extend(consumer.consume(num_messages, timeout=1.0))
 
                 current_batch_size = 0
                 record_batchs = []

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -266,6 +266,7 @@ class KafkaReader(BaseReader):
         is_paused = [False]
         last_consume_time = [time.monotonic()]
         idle_threshold = max_poll_interval_ms / 1000.0 * 0.8
+        stolen_msgs: List = []
 
         # Define on_assign callback to seek to checkpointed offsets
         def on_assign(consumer: Consumer, partitions: List[TopicPartition]) -> None:
@@ -315,12 +316,19 @@ class KafkaReader(BaseReader):
                 elapsed = time.monotonic() - last_consume_time[0]
                 if elapsed > idle_threshold:
                     with consumer_lock:
-                        if not is_paused[0]:
-                            assignment = consumer.assignment()
-                            if assignment:
-                                consumer.pause(assignment)
-                            is_paused[0] = True
-                        consumer.poll(0)
+                        # Re-check elapsed inside lock to avoid racing with
+                        # the main thread that updates last_consume_time
+                        # under the same lock before calling consume().
+                        elapsed = time.monotonic() - last_consume_time[0]
+                        if elapsed > idle_threshold:
+                            if not is_paused[0]:
+                                assignment = consumer.assignment()
+                                if assignment:
+                                    consumer.pause(assignment)
+                                is_paused[0] = True
+                            msg = consumer.poll(0)
+                            if msg is not None:
+                                stolen_msgs.append(msg)
                 stop_event.wait(1.0)
 
         heartbeat_thread = threading.Thread(
@@ -339,14 +347,17 @@ class KafkaReader(BaseReader):
                         if assignment:
                             consumer.resume(assignment)
                         is_paused[0] = False
+                    last_consume_time[0] = time.monotonic()
+                    pending = list(stolen_msgs)
+                    stolen_msgs.clear()
 
                 num_messages = (
                     int(math.ceil(self._batch_size / batch_size_per_msg))
                     if batch_size_per_msg
                     else 2
                 )
-                last_consume_time[0] = time.monotonic()
-                messages = consumer.consume(num_messages)
+                messages = pending
+                messages.extend(consumer.consume(num_messages))
 
                 current_batch_size = 0
                 record_batchs = []

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -12,6 +12,8 @@
 
 import math
 import os
+import threading
+import time
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import parse_qsl, urlparse
 
@@ -240,6 +242,14 @@ class KafkaReader(BaseReader):
     ) -> Iterator[pa.RecordBatch]:
         """Read Arrow batches from Kafka.
 
+        A background heartbeat thread monitors idle time (time since the last
+        ``consume()`` call).  When the generator is blocked at ``yield`` for
+        longer than 80% of ``max.poll.interval.ms``, the heartbeat thread
+        pauses all partitions and calls ``consumer.poll(0)`` periodically to
+        reset the application poll timer and keep the consumer in its group.
+        This prevents ``MAX_POLL_EXCEEDED`` errors during long downstream
+        pauses (checkpoint saves, evaluation, compilation warmup, etc.).
+
         Args:
             worker_id: Worker ID
             num_workers: Total number of workers
@@ -248,7 +258,14 @@ class KafkaReader(BaseReader):
             PyArrow RecordBatch
         """
         topic, config, start_timestamp_ms = _parse_kafka_uri(self._input_path)
+        max_poll_interval_ms = int(config.get("max.poll.interval.ms", "300000"))
         consumer = Consumer(config)
+
+        stop_event = threading.Event()
+        consumer_lock = threading.RLock()
+        is_paused = [False]
+        last_consume_time = [time.monotonic()]
+        idle_threshold = max_poll_interval_ms / 1000.0 * 0.8
 
         # Define on_assign callback to seek to checkpointed offsets
         def on_assign(consumer: Consumer, partitions: List[TopicPartition]) -> None:
@@ -282,6 +299,9 @@ class KafkaReader(BaseReader):
                         tp.offset = OFFSET_INVALID
 
             consumer.assign(partitions)
+            with consumer_lock:
+                if is_paused[0]:
+                    consumer.pause(consumer.assignment())
             logger.info(
                 f"KafkaReader[rank-{os.environ.get('RANK', 0)}|worker-{worker_id}] "
                 f"assignment: {consumer.assignment()}"
@@ -289,14 +309,43 @@ class KafkaReader(BaseReader):
 
         consumer.subscribe([topic], on_assign=on_assign)
 
+        def _heartbeat() -> None:
+            """Keep consumer alive when generator is blocked at yield."""
+            while not stop_event.is_set():
+                elapsed = time.monotonic() - last_consume_time[0]
+                if elapsed > idle_threshold:
+                    with consumer_lock:
+                        if not is_paused[0]:
+                            assignment = consumer.assignment()
+                            if assignment:
+                                consumer.pause(assignment)
+                            is_paused[0] = True
+                        consumer.poll(0)
+                stop_event.wait(1.0)
+
+        heartbeat_thread = threading.Thread(
+            target=_heartbeat,
+            name=f"kafka-hb-w{worker_id}",
+            daemon=True,
+        )
+        heartbeat_thread.start()
+
         batch_size_per_msg = None
         try:
             while True:
+                with consumer_lock:
+                    if is_paused[0]:
+                        assignment = consumer.assignment()
+                        if assignment:
+                            consumer.resume(assignment)
+                        is_paused[0] = False
+
                 num_messages = (
                     int(math.ceil(self._batch_size / batch_size_per_msg))
                     if batch_size_per_msg
                     else 2
                 )
+                last_consume_time[0] = time.monotonic()
                 messages = consumer.consume(num_messages)
 
                 current_batch_size = 0
@@ -372,7 +421,12 @@ class KafkaReader(BaseReader):
             logger.error(f"KafkaReader exception: {e}", flush=True)
             raise e
         finally:
-            consumer.close()
+            stop_event.set()
+            heartbeat_thread.join(timeout=5.0)
+            try:
+                consumer.close()
+            except Exception as e:
+                logger.warning(f"consumer.close() failed: {e}")
 
     def to_batches(
         self, worker_id: int = 0, num_workers: int = 1

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -463,6 +463,72 @@ class KafkaDatasetTest(unittest.TestCase):
         for label in labels:
             self.assertEqual(label, 1)
 
+    @unittest.skipIf(
+        os.environ.get("CI_ALIKAFKA_INSTANCE_ID", "") == "", "ci kafka is not exists."
+    )
+    def test_kafka_dataset_heartbeat_no_max_poll_exceeded(self):
+        """Test heartbeat prevents MAX_POLL_EXCEEDED during long idle."""
+        feature_cfgs, input_fields, _ = self._create_test_table_and_feature_cfgs()
+        features = create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+
+        # Use a low max.poll.interval.ms (10s) so idle_threshold = 8s.
+        # Sleep 12s between reads to exceed max.poll.interval.ms.
+        # Without the heartbeat, this would trigger MAX_POLL_EXCEEDED.
+        dataset = KafkaDataset(
+            data_config=data_pb2.DataConfig(
+                batch_size=8196,
+                dataset_type=data_pb2.DatasetType.KafkaDataset,
+                input_fields=input_fields,
+                fg_mode=FgMode.FG_DAG,
+                label_fields=["label"],
+            ),
+            features=features,
+            input_path=(
+                f"kafka://{self.brokers}/{self.test_topic}"
+                f"?group.id=tzrec_test_group"
+                f"&auto.offset.reset=earliest"
+                f"&max.poll.interval.ms=10000"
+            ),
+        )
+        dataloader = DataLoader(
+            dataset=dataset,
+            batch_size=None,
+            num_workers=0,
+            pin_memory=True,
+            collate_fn=lambda x: x,
+        )
+        iterator = iter(dataloader)
+
+        # Read first batch
+        batch1 = next(iterator)
+        data_dict1 = batch1.to_dict()
+        self.assertEqual(len(data_dict1["id_a.lengths"]), 8196)
+
+        # Sleep longer than max.poll.interval.ms (10s).
+        # Heartbeat should activate at 8s (80% of 10s) and keep alive.
+        time.sleep(12)
+
+        # Read second batch — should succeed without MAX_POLL_EXCEEDED
+        batch2 = next(iterator)
+        data_dict2 = batch2.to_dict()
+        self.assertEqual(len(data_dict2["id_a.lengths"]), 8196)
+        self.assertEqual(
+            sorted(data_dict2.keys()),
+            [
+                "id_a.lengths",
+                "id_a.values",
+                "label",
+                "lookup_h.values",
+                "raw_c.values",
+                "raw_d.values",
+                "raw_e.values",
+                "raw_f.values",
+                "raw_g.values",
+                "tag_b.lengths",
+                "tag_b.values",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -487,6 +487,7 @@ class KafkaDatasetTest(unittest.TestCase):
                 f"kafka://{self.brokers}/{self.test_topic}"
                 f"?group.id=tzrec_test_group"
                 f"&auto.offset.reset=earliest"
+                f"&session.timeout.ms=6000"
                 f"&max.poll.interval.ms=10000"
             ),
         )


### PR DESCRIPTION
## Summary

- Add a background heartbeat thread to `KafkaReader._reader()` that prevents `MAX_POLL_EXCEEDED` errors when downstream pauses (checkpoint save, eval, compile warmup)
- When idle time exceeds 80% of `max.poll.interval.ms`, the thread pauses partitions and calls `consumer.poll(0)` to keep the consumer alive without fetching data
- Zero overhead during normal operation — heartbeat only activates after prolonged idle
- Handles partition changes during pause via `on_assign` re-pause

## Test plan

- [ ] Existing `ParseKafkaUriTest` and `KafkaDatasetTest` pass
- [ ] End-to-end DLC training with KafkaReader + slow checkpoint save confirms no `MAX_POLL_EXCEEDED`
- [ ] Verify no rebalance storm in logs during checkpoint save

🤖 Generated with [Claude Code](https://claude.com/claude-code)