### PR TITLE
[feat] switch create_test_model to unified single-stage AOTI export

### DIFF
--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -21,9 +21,8 @@ from hypothesis.utils.conventions import not_set as _not_set
 from torch import nn
 from torch.fx import GraphModule
 
-from tzrec.acc.aot_utils import export_model_aot, load_model_aot
+from tzrec.acc.aot_utils import export_unified_model_aot, load_model_aot
 from tzrec.models.model import ScriptWrapper
-from tzrec.utils.export_util import split_model
 from tzrec.utils.fx_util import symbolic_trace
 
 nv_gpu_unavailable: Tuple[bool, str] = (
@@ -79,8 +78,7 @@ def create_test_model(
         model = ScriptWrapper(model)
         assert data is not None
         assert test_dir, "test_dir must be specified for AOT_INDUCTOR"
-        sparse, dense, meta_info = split_model(data, model, test_dir)
-        export_model_aot(sparse, dense, data, meta_info, test_dir)
+        export_unified_model_aot(model, data, test_dir)
         model = load_model_aot(test_dir, torch.device("cuda:0"))
         return model
     else:


### PR DESCRIPTION
## Summary
- Replace legacy two-stage AOT export (`split_model` + `export_model_aot`) with unified single-stage `export_unified_model_aot` in `create_test_model`, so unit tests exercise the same fused sparse+dense AOTI compilation path used in production.
- Remove unused `split_model` import from `test_util.py`.

## Test plan
- [x] `MultiTowerDINTest.test_multi_tower_din_3` (AOT_INDUCTOR) — passed (18s, real AOTI compilation)
- [x] `DlrmHSTUTest.test_dlrm_hstu` (Hypothesis with AOT_INDUCTOR examples) — passed (190s)
- [x] All 4 multi_tower_din graph type variants (NORMAL, FX_TRACE, JIT_SCRIPT, AOT_INDUCTOR) — passed
- [x] Ruff lint — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)