### PR TITLE
[chore] bump pyfg to 1.0.4

### DIFF
--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -253,11 +253,11 @@ pipeline.global-job-parameters: |
     - --ODPS_CONFIG_FILE_PATH: 该环境变量指向的是odpscmd的配置文件
   - 在[DataWorks](https://workbench.data.aliyun.com/)的独享资源组中安装pyfg，「资源组列表」- 在一个调度资源组的「操作」栏 点「运维助手」-「创建命令」（选手动输入）-「运行命令」
     ```shell
-    /home/tops/bin/pip3 install http://tzrec.oss-cn-beijing.aliyuncs.com/third_party/pyfg102-1.0.2-cp37-cp37m-linux_x86_64.whl --index-url=https://mirrors.aliyun.com/pypi/simple/ --trusted-host=mirrors.cloud.aliyuncs.com
+    /home/tops/bin/pip3 install http://tzrec.oss-cn-beijing.aliyuncs.com/third_party/pyfg104-1.0.4-cp37-cp37m-linux_x86_64.whl --index-url=https://mirrors.aliyun.com/pypi/simple/ --trusted-host=mirrors.cloud.aliyuncs.com
     ```
   - 在DataWorks中建立`PyODPS 3`节点运行FG，节点调度参数中配置好bizdate参数
     ```
-    from pyfg102 import offline_pyfg
+    from pyfg104 import offline_pyfg
     offline_pyfg.run(
       o,
       input_table="YOU_PROJECT.TABLE_NAME",

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -12,9 +12,9 @@ numpy<2
 packaging
 pandas<3
 psutil
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.2-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.2-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.2-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.4-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.4-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.4-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
 pyodps>=0.12.4
 safetensors
 scikit-learn


### PR DESCRIPTION
## Summary
- Bump pinned pyfg wheels from 1.0.2 → 1.0.4 in `requirements/runtime.txt` (cp310/cp311/cp312 Linux x86_64).
- Update DataWorks install snippet in `docs/source/feature/data.md` from `pyfg102-1.0.2` → `pyfg104-1.0.4` (both the pip URL and the `from pyfg104 import offline_pyfg` line).

## Test plan
- [x] Verified all four wheels resolve (HTTP 200 HEAD checks on the 3 runtime wheels + the DataWorks cp37 wheel).
- [ ] CI runs against new pyfg 1.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)