### PR TITLE
[bugfix] fix two-stage AOTI predict hang under multi-thread workers

### DIFF
--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -61,7 +61,10 @@ def load_model_aot(
         )
         return UnifiedAOTIModelWrapper(model)
     else:
-        # Legacy two-stage path: sparse JIT + dense AOTI
+        # Legacy two-stage path: sparse JIT + dense AOTI.
+        # Disable TensorExpr fuser: its lazy first-call compile is not
+        # thread-safe under the predict worker pool.
+        torch._C._jit_set_texpr_fuser_enabled(False)
         sparse_model: torch.jit.ScriptModule = torch.jit.load(
             os.path.join(model_path, "scripted_sparse_model.pt"),
             map_location=device,

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -440,10 +440,36 @@ class CombinedModelWrapper(nn.Module):
         dense_model (nn.Module): dense part AOTInductor model.
     """
 
+    _dense_is_aoti: bool
+
     def __init__(self, sparse_model: nn.Module, dense_model: nn.Module) -> None:
         super().__init__()
         self.sparse_model = sparse_model
         self.dense_model = dense_model
+        # Only AOTI dense models need the GIL + model-pool-mutex guard:
+        # AOTI extern ops release the GIL and then block on the AOTI
+        # model-pool mutex, deadlocking the predict forward workers.
+        dense_is_aoti = False
+        try:
+            from torch.export.pt2_archive._package import AOTICompiledModel
+
+            dense_is_aoti = isinstance(dense_model, AOTICompiledModel)
+        except ImportError:
+            pass
+        self._dense_is_aoti = dense_is_aoti
+        if dense_is_aoti:
+            object.__setattr__(self, "_lock", threading.Lock())
+
+    @torch.jit.unused
+    def _locked_dense(
+        self,
+        sparse_out: Dict[str, torch.Tensor],
+        # pyre-ignore [9]
+        device: torch.device,
+    ) -> Dict[str, torch.Tensor]:
+        torch.cuda.set_device(device)
+        with self._lock:
+            return self.dense_model(sparse_out)
 
     def forward(
         self,
@@ -461,8 +487,9 @@ class CombinedModelWrapper(nn.Module):
             predictions (dict): a dict of predicted result.
         """
         sparse_out, _ = self.sparse_model(data, device)
-        outputs = self.dense_model(sparse_out)
-        return outputs
+        if self._dense_is_aoti:
+            return self._locked_dense(sparse_out, device)
+        return self.dense_model(sparse_out)
 
 
 class UnifiedAOTIModelWrapper(nn.Module):

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -1061,13 +1061,6 @@ class RankIntegrationTest(unittest.TestCase):
                 reserved_columns="user_id,cand_seq__video_id",
                 output_columns="",
                 test_dir=self.test_dir,
-                # The cutlass custom op path is not safe to call concurrently
-                # through an AOT-Inductor compiled model yet (hstu_attn_cuda's
-                # pybind11 binding does not release the GIL and the AOTI
-                # runtime then deadlocks between the two predict forward
-                # worker threads). Restrict predict to a single worker until
-                # the underlying multi-threading issue is addressed upstream.
-                predict_threads=1,
             )
         self.assertTrue(self.success)
 

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.12"
+__version__ = "1.1.13"


### PR DESCRIPTION
## Summary

Two-stage AOTI predict jobs (sparse JIT + dense AOTI) silently hang on the first `_forward_loop` worker-thread call to `sparse_model`. Two thread-safety issues on this path:

1. **JIT TensorExpr fuser** is not thread-safe on its lazy first-call compile — deadlocks the first worker-thread invocation against the main thread's warmup. Disable it before `torch.jit.load(scripted_sparse_model.pt)` in `load_model_aot`.
2. **AOTI model-pool C++ mutex + GIL deadlock** (same scenario `UnifiedAOTIModelWrapper` was hardened against in 5a3580c). `CombinedModelWrapper` now serialises the AOTI dense-model call with a Python `Lock` + `torch.cuda.set_device(device)`, gated on `isinstance(dense_model, AOTICompiledModel)` so TRT-compiled dense modules take the unlocked path.

`CombinedModelWrapper` stays `torch.jit.script`-friendly for TRT export: `_dense_is_aoti` is a class-annotated `bool`, and the locked call lives on a `@torch.jit.unused` helper method. `_lock` is attached via `object.__setattr__` so it stays invisible to scripting. The TRT caller has `_dense_is_aoti=False` at runtime, so the scripted forward never enters the helper.

Also drops the `predict_threads=1` workaround from `test_rank_dlrm_hstu_cutlass_train_eval_export`, and bumps version `1.1.12` → `1.1.13`.

## Test plan

- [x] Verified the hang reproduces on the original PAI-DLC job `dlcn2o2yyp3utxgv` (`hstu_v3_predict_clone1`) against the nightly without this fix.
- [x] Verified the fix works **without `--predict_threads 1`** on the same job — Succeeded in ~85 s with `Predict Finished.`.
- [x] Smoke-tested `torch.jit.script(CombinedModelWrapper)` with a non-AOTI dense model: scripts cleanly, scripted forward code has zero references to `_lock` or `torch.cuda.set_device`.
- [ ] CI: `test_rank_dlrm_hstu_cutlass_train_eval_export` now exercises the default multi-worker predict path.