### PR TITLE
[bugfix] share Dim across grouped-sequence tensors in legacy AOT export

### DIFF
--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -107,19 +107,33 @@ def export_model_aot(
     sparse_model_scripted.save(os.path.join(save_dir, "scripted_sparse_model.pt"))
 
     batch = torch.export.Dim("batch", min=1, max=499999999)
-    dynamic_shapes = {}
+    dynamic_shapes: Dict[str, Dict[int, torch.export.Dim]] = {}
     seq_tensor_names = meta_info.get("seq_tensor_names", [])
     jagged_seq_tensor_names = meta_info.get("jagged_seq_tensor_names", [])
+    seq_share_groups = meta_info.get("seq_share_groups", {})
+
+    # Separate caches per axis: a SEQUENCE group and a JAGGED_SEQUENCE
+    # group from the same parent SequenceFeature share a lengths source,
+    # but the Dims they need are different symbolic quantities — max
+    # seq_len (axis 1, padded) vs total nnz (axis 0, jagged).
+    seq_len_dims: Dict[str, torch.export.Dim] = {}
+    jagged_batch_dims: Dict[str, torch.export.Dim] = {}
+
     for key in sparse_output.keys():
         if key in seq_tensor_names:
-            dynamic_shapes[key] = {
-                0: batch,
-                1: torch.export.Dim(f"{key}__seq_len", min=1, max=999999993),
-            }
+            share_key = seq_share_groups.get(key, key)
+            if share_key not in seq_len_dims:
+                seq_len_dims[share_key] = torch.export.Dim(
+                    f"{share_key}__seq_len", min=1, max=999999993
+                )
+            dynamic_shapes[key] = {0: batch, 1: seq_len_dims[share_key]}
         elif key in jagged_seq_tensor_names:
-            dynamic_shapes[key] = {
-                0: torch.export.Dim(f"{key}__batch", min=1, max=999999993)
-            }
+            share_key = seq_share_groups.get(key, key)
+            if share_key not in jagged_batch_dims:
+                jagged_batch_dims[share_key] = torch.export.Dim(
+                    f"{share_key}__batch", min=1, max=999999993
+                )
+            dynamic_shapes[key] = {0: jagged_batch_dims[share_key]}
         else:
             dynamic_shapes[key] = {0: batch}
 

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -48,6 +48,36 @@ def _build_model(
     concat_contextual_features: bool = False,
 ) -> DlrmHSTU:
     """Build a DlrmHSTU model with standard test configuration."""
+    uih_seq_features = [
+        feature_pb2.SeqFeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="video_id",
+                embedding_dim=16,
+                embedding_name="video_id_emb",
+                num_buckets=1000,
+            )
+        ),
+        feature_pb2.SeqFeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="video_cat",
+                embedding_dim=16,
+                embedding_name="video_cat_emb",
+                num_buckets=100,
+            )
+        ),
+        feature_pb2.SeqFeatureConfig(
+            raw_feature=feature_pb2.RawFeature(feature_name="action_timestamp")
+        ),
+        feature_pb2.SeqFeatureConfig(
+            raw_feature=feature_pb2.RawFeature(feature_name="action_weight")
+        ),
+    ]
+    if has_watchtime:
+        uih_seq_features.append(
+            feature_pb2.SeqFeatureConfig(
+                raw_feature=feature_pb2.RawFeature(feature_name="watch_time")
+            )
+        )
     feature_cfgs = [
         feature_pb2.FeatureConfig(
             id_feature=feature_pb2.IdFeature(
@@ -62,50 +92,38 @@ def _build_model(
             )
         ),
         feature_pb2.FeatureConfig(
-            sequence_id_feature=feature_pb2.IdFeature(
-                feature_name="video_id",
-                embedding_dim=16,
-                embedding_name="video_id_emb",
-                num_buckets=1000,
+            sequence_feature=feature_pb2.SequenceFeature(
+                sequence_name="uih_seq",
+                features=uih_seq_features,
             )
         ),
         feature_pb2.FeatureConfig(
-            sequence_id_feature=feature_pb2.IdFeature(
-                feature_name="video_cat",
-                embedding_dim=16,
-                embedding_name="video_cat_emb",
-                num_buckets=100,
+            sequence_feature=feature_pb2.SequenceFeature(
+                sequence_name="cand_seq",
+                features=[
+                    feature_pb2.SeqFeatureConfig(
+                        id_feature=feature_pb2.IdFeature(
+                            feature_name="item_video_id",
+                            embedding_dim=16,
+                            embedding_name="video_id_emb",
+                            num_buckets=1000,
+                        )
+                    ),
+                    feature_pb2.SeqFeatureConfig(
+                        id_feature=feature_pb2.IdFeature(
+                            feature_name="item_video_cat",
+                            embedding_dim=16,
+                            embedding_name="video_cat_emb",
+                            num_buckets=100,
+                        )
+                    ),
+                    feature_pb2.SeqFeatureConfig(
+                        raw_feature=feature_pb2.RawFeature(
+                            feature_name="item_query_time"
+                        )
+                    ),
+                ],
             )
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_id_feature=feature_pb2.IdFeature(
-                feature_name="item_video_id",
-                embedding_dim=16,
-                embedding_name="video_id_emb",
-                num_buckets=1000,
-            )
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_id_feature=feature_pb2.IdFeature(
-                feature_name="item_video_cat",
-                embedding_dim=16,
-                embedding_name="video_cat_emb",
-                num_buckets=100,
-            )
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_raw_feature=feature_pb2.RawFeature(feature_name="action_timestamp")
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_raw_feature=feature_pb2.RawFeature(feature_name="item_query_time")
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_raw_feature=feature_pb2.RawFeature(
-                feature_name="action_weight",
-            )
-        ),
-        feature_pb2.FeatureConfig(
-            sequence_raw_feature=feature_pb2.RawFeature(feature_name="watch_time")
         ),
     ]
     features = create_features(feature_cfgs)
@@ -117,35 +135,35 @@ def _build_model(
         ),
         model_pb2.FeatureGroupConfig(
             group_name="uih",
-            feature_names=["video_id", "video_cat"],
+            feature_names=["uih_seq__video_id", "uih_seq__video_cat"],
             group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
         ),
         model_pb2.FeatureGroupConfig(
             group_name="candidate",
             feature_names=[
-                "item_video_id",
-                "item_video_cat",
+                "cand_seq__item_video_id",
+                "cand_seq__item_video_cat",
             ],
             group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
         ),
         model_pb2.FeatureGroupConfig(
             group_name="uih_timestamp",
             feature_names=[
-                "action_timestamp",
+                "uih_seq__action_timestamp",
             ],
             group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
         ),
         model_pb2.FeatureGroupConfig(
             group_name="candidate_timestamp",
             feature_names=[
-                "item_query_time",
+                "cand_seq__item_query_time",
             ],
             group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
         ),
         model_pb2.FeatureGroupConfig(
             group_name="uih_action",
             feature_names=[
-                "action_weight",
+                "uih_seq__action_weight",
             ],
             group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
         ),
@@ -155,7 +173,7 @@ def _build_model(
             model_pb2.FeatureGroupConfig(
                 group_name="uih_watchtime",
                 feature_names=[
-                    "watch_time",
+                    "uih_seq__watch_time",
                 ],
                 group_type=model_pb2.FeatureGroupType.JAGGED_SEQUENCE,
             )
@@ -230,8 +248,18 @@ def _build_model(
                 input_preprocessor=module_pb2.GRInputPreprocessor(
                     contextual_preprocessor=module_pb2.GRContextualPreprocessor(
                         action_encoder=module_pb2.GRActionEncoder(
+                            # has_watchtime also enables the watchtime->action
+                            # bitwise-OR so AOT export traces the cross-sequence
+                            # op that constrains uih_action and uih_watchtime nnz.
                             simple_action_encoder=module_pb2.GRSimpleActionEncoder(
-                                action_embedding_dim=8, action_weights=[1, 2, 4]
+                                action_embedding_dim=8,
+                                action_weights=[1, 2, 4],
+                                watchtime_to_action_thresholds=(
+                                    [60, 300] if has_watchtime else []
+                                ),
+                                watchtime_to_action_weights=(
+                                    [256, 512] if has_watchtime else []
+                                ),
                             )
                         ),
                         action_mlp=module_pb2.GRContextualizedMLP(
@@ -282,32 +310,33 @@ def _build_batch(
         keys=[
             "user_id",
             "user_active_degree",
-            "video_id",
-            "item_video_id",
-            "video_cat",
-            "item_video_cat",
+            "uih_seq__video_id",
+            "cand_seq__item_video_id",
+            "uih_seq__video_cat",
+            "cand_seq__item_video_cat",
         ],
         values=torch.tensor(list(range(26))),
         lengths=torch.tensor([1, 1, 1, 1, 2, 3, 2, 4, 2, 3, 2, 4]),
     )
     sequence_dense_features = {
-        "action_timestamp": JaggedTensor(
+        "uih_seq__action_timestamp": JaggedTensor(
             values=torch.tensor([[1], [2], [3], [4], [5]]),
             lengths=torch.tensor([2, 3]),
         ),
-        "item_query_time": JaggedTensor(
+        "cand_seq__item_query_time": JaggedTensor(
             values=torch.tensor([[6], [7], [8], [9], [10], [11]]),
             lengths=torch.tensor([2, 4]),
         ),
-        "action_weight": JaggedTensor(
+        "uih_seq__action_weight": JaggedTensor(
             values=torch.tensor([[0], [1], [0], [1], [0]]),
             lengths=torch.tensor([2, 3]),
         ),
-        "watch_time": JaggedTensor(
+    }
+    if has_watchtime:
+        sequence_dense_features["uih_seq__watch_time"] = JaggedTensor(
             values=torch.tensor([[0.1], [0.2], [0.3], [0.4], [0.5]]),
             lengths=torch.tensor([2, 3]),
-        ),
-    }
+        )
     jagged_labels = {
         "item_action_weight": JaggedTensor(
             values=torch.tensor([0, 1, 0, 0, 1, 0]),

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -990,6 +990,37 @@ def export_rtp_model(
                 json.dump(fg_json, f, indent=4)
 
 
+def _compute_seq_share_groups(
+    features: List[BaseFeature],
+    model_config: Any,
+) -> Dict[str, str]:
+    """Map ``{group_name}__sequence`` to a share_key.
+
+    Feature groups whose first feature comes from the same parent
+    SequenceFeature share per-sample lengths and therefore must share
+    a torch.export.Dim on the lengths-derived axis.
+    """
+    from tzrec.protos.model_pb2 import FeatureGroupType
+
+    feat_by_name = {f.name: f for f in features}
+    share: Dict[str, str] = {}
+    for fg in model_config.feature_groups:
+        if fg.group_type not in (
+            FeatureGroupType.SEQUENCE,
+            FeatureGroupType.JAGGED_SEQUENCE,
+        ):
+            continue
+        if not fg.feature_names:
+            continue
+        first = feat_by_name.get(fg.feature_names[0])
+        if first is not None and getattr(first, "_is_grouped_seq", False):
+            share_key = f"seq_{first.sequence_name}"
+        else:
+            share_key = f"fg_{fg.group_name}"
+        share[f"{fg.group_name}__sequence"] = share_key
+    return share
+
+
 def split_model(
     data: Dict[str, torch.Tensor], model: BaseModule, save_dir: str
 ) -> Tuple[nn.Module, nn.Module, Dict[str, Any]]:
@@ -1120,8 +1151,13 @@ def split_model(
     dense_gm.graph.eliminate_dead_code()
     dense_gm = _prune_unused_param_and_buffer(dense_gm)
 
+    seq_share_groups = _compute_seq_share_groups(
+        features=cast(List[BaseFeature], model._features),
+        model_config=model.model._base_model_config,
+    )
     meta_info = {
         "seq_tensor_names": seq_tensor_names,
         "jagged_seq_tensor_names": jagged_seq_tensor_names,
+        "seq_share_groups": seq_share_groups,
     }
     return sparse_gm, dense_gm, meta_info

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.13"
+__version__ = "1.1.14"


### PR DESCRIPTION
## Summary

- Legacy `export_model_aot` (the two-stage `ENABLE_AOT=1` path) gave each `*__sequence` tensor its own `torch.export.Dim`. When several JAGGED_SEQUENCE feature_groups draw their first feature from the same parent `SequenceFeature` (HSTU's `uih`, `uih_action`, `uih_timestamp`, `uih_watchtime` all from `uih_seq`), they share per-sample lengths in the data parser, so cross-sequence ops in the dense graph (e.g. `bitwise_or` between `seq_actions` and `seq_watchtimes` in `SimpleActionEncoder`) trigger `ConstraintViolationError` during `torch.export.export`.
- `split_model` now derives a per-`{group_name}__sequence` `share_key` from the first feature's `_is_grouped_seq` / `sequence_name`, and `export_model_aot` reuses one Dim per share_key (separate caches for SEQUENCE's axis-1 max-seq-len Dim and JAGGED_SEQUENCE's axis-0 nnz Dim). Standalone (non-grouped) sequence features keep a per-group share_key, preserving the previous behavior.

## Repro of the original failure

Running the legacy AOT export against an HSTU pipeline with multiple JAGGED_SEQUENCE feature_groups derived from the same parent `SequenceFeature` (e.g. `uih_seq` -> `uih`, `uih_action`, `uih_timestamp`, `uih_watchtime`) and a `SimpleActionEncoder` configured with `watchtime_to_action_thresholds` / `watchtime_to_action_weights` previously aborted with:

```
torch._dynamo.exc.UserError: Constraints violated (uih_watchtime__sequence__batch)!
- The values of uih_watchtime__sequence__batch and uih_action__sequence__batch must always be equal.
```

After this PR, the `[INFO] dynamic shapes=...` line shows the four UIH-derived sequence values referencing one shared Dim and the two CAND-derived ones sharing another:

```
uih__sequence:           {0: Dim('seq_uih_seq__batch', ...)}
uih_action__sequence:    {0: Dim('seq_uih_seq__batch', ...)}
uih_timestamp__sequence: {0: Dim('seq_uih_seq__batch', ...)}
uih_watchtime__sequence: {0: Dim('seq_uih_seq__batch', ...)}
candidate__sequence:           {0: Dim('seq_cand_seq__batch', ...)}
candidate_timestamp__sequence: {0: Dim('seq_cand_seq__batch', ...)}
```

and the export runs through to a complete AOTI archive.

## Why the existing DlrmHSTUTest didn't catch this

`DlrmHSTUTest::test_dlrm_hstu` already parameterizes `(graph_type=AOT_INDUCTOR, has_watchtime=True)` and exercises `split_model` + `export_model_aot`. It was silent on this bug for two reasons that this PR also fixes:

1. The encoder was built without `watchtime_to_action_thresholds` / `watchtime_to_action_weights`, so `SimpleActionEncoder.need_watchtime` returned `False` and the `bitwise_or(seq_actions, seq_watchtimes >= ...)` branch was dead at trace time. Without that op, no constraint between `uih_action__sequence` and `uih_watchtime__sequence` was ever recorded.
2. All sequence features were declared standalone (top-level `sequence_id_feature` / `sequence_raw_feature`), so `_is_grouped_seq` was always `False` and there was no `sequence_name` signal to merge separate JAGGED_SEQUENCE feature_groups under one share_key.

Both gaps are closed: features are wrapped inside `SequenceFeature(sequence_name="uih_seq" / "cand_seq", features=[...])` parents and the encoder now sets `watchtime_to_action_thresholds`/`watchtime_to_action_weights` when `has_watchtime=True`. The hypothesis sample `(AOT_INDUCTOR, has_watchtime=True)` now reproduces the failure on master and validates the fix here.

## Test plan

- [x] `pytest -x tzrec/models/dlrm_hstu_test.py::DlrmHSTUTest::test_dlrm_hstu` — passes after fix (1 passed, 141s).
- [x] Re-run the failing AOT export end-to-end — `[INFO] dynamic shapes` now logs `seq_uih_seq__batch` and `seq_cand_seq__batch` shared across the matching keys; export proceeds past the previous failure point and produces a complete `aoti_model.pt2`.
- [ ] Smoke-test the produced AOTI archive end-to-end (predict path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
