### PR TITLE
[bugfix] add CombineFeature to SINGLE_INPUT_FEATURE_CLASSES

### DIFF
--- a/tzrec/features/combine_feature_test.py
+++ b/tzrec/features/combine_feature_test.py
@@ -242,6 +242,10 @@ class CombineFeatureTest(unittest.TestCase):
         self.assertEqual(seq_feat.is_sequence, True)
         self.assertEqual(seq_feat.name, "click_50_seq__combine_feat")
         self.assertEqual(seq_feat.value_dim, 1)
+        self.assertEqual(
+            seq_feat.side_inputs, [("user", "click_50_seq__combine_input")]
+        )
+        self.assertEqual(seq_feat.inputs, ["click_50_seq__combine_input"])
 
         input_data = {
             "click_50_seq__combine_input": pa.array(["tag1\x1dtag2;tag1", "tag2", ""]),
@@ -285,6 +289,10 @@ class CombineFeatureTest(unittest.TestCase):
         self.assertEqual(seq_feat.is_sparse, False)
         self.assertEqual(seq_feat.is_sequence, True)
         self.assertEqual(seq_feat.name, "click_50_seq__combine_feat")
+        self.assertEqual(
+            seq_feat.side_inputs, [("user", "click_50_seq__combine_input")]
+        )
+        self.assertEqual(seq_feat.inputs, ["click_50_seq__combine_input"])
 
         input_data = {
             "click_50_seq__combine_input": pa.array(["tag1\x1dtag2;tag1", "tag2", ""]),

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -69,7 +69,12 @@ _meta_cls = get_register_class_meta(_FEATURE_CLASS_MAP)
 
 
 MAX_HASH_BUCKET_SIZE = 2**63 - 1
-SINGLE_INPUT_FEATURE_CLASSES = ["IdFeature", "RawFeature", "TokenizeFeature"]
+SINGLE_INPUT_FEATURE_CLASSES = [
+    "IdFeature",
+    "RawFeature",
+    "TokenizeFeature",
+    "CombineFeature",
+]
 
 
 def _parse_fg_encoded_sparse_feature_impl(


### PR DESCRIPTION
## Summary
- A `combine_feature` declared inside a grouped `sequence_feature` was producing an unprefixed `side_input` (e.g. `("user", "action_weights")` inside `uih_seq`) because `BaseFeature._need_seq_prefix` gates the `<sequence_name>__` prefix on `SINGLE_INPUT_FEATURE_CLASSES`, and `CombineFeature` was missing from that list.
- The training-data column convention and the existing `combine_feature_test` grouped-sequence cases both already use the prefixed name (e.g. `click_50_seq__combine_input`), so only the `side_inputs` API was out of sync. `CombineFeature` is structurally identical to `IdFeature` / `RawFeature` / `TokenizeFeature` (single `expression` proto field → 1 side_input), so it belongs in the list.
- Locks the new behavior in via two `side_inputs`/`inputs` assertions added to the existing grouped-sequence tests in `combine_feature_test.py`.

### Audit of which other classes belong in `SINGLE_INPUT_FEATURE_CLASSES`
Only the four single-`expression` classes (Id/Raw/Tokenize/Combine). Every other concrete feature class returns 2+ side_input tuples spanning heterogeneous sides — e.g. `LookupFeature.map` typically points at a top-level `user__kv_*` field that must NOT acquire a sequence prefix, `MatchFeature` mixes `pkey`/`skey`/`nested_map`, etc. These classes already have the explicit `sequence_fields` proto opt-in (honored at `feature.py:734-738`) for per-input prefixing when needed.

## Test plan
- [x] \`python -m unittest tzrec.features.combine_feature_test\` — 16/16 pass, including the two new \`side_inputs\`/\`inputs\` assertions in \`test_sequence_combine_feature_with_value_map_sparse\` / \`_dense\`.
- [x] \`python -m unittest discover -s tzrec/features -p '*_test.py'\` — 242/242 pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)