### PR TITLE
[feat] ULTRA-HSTU mid-stack attention truncation

### DIFF
--- a/tzrec/models/dlrm_hstu.py
+++ b/tzrec/models/dlrm_hstu.py
@@ -152,7 +152,6 @@ class DlrmHSTU(RankModel):
             scaling_seqlen=self._model_config.max_seq_len,
             **config_to_kwargs(self._model_config.hstu),
             return_full_embeddings=False,
-            listwise=False,
         )
 
         # item embeddings

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -301,8 +301,8 @@ class HSTUTransducer(BaseModule):
             seq_timestamps = apply_stu_truncation_plan(
                 seq_timestamps.unsqueeze(-1), plan, kernel=self.kernel()
             ).squeeze(-1)
+            seq_lengths = plan.new_lengths
             seq_offsets = post_stu_seq_offsets
-            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
             max_seq_len = post_stu_max_seq_len
             # Pre-truncation total_uih_len no longer matches the truncated
             # embeddings; passing None lets split_2D_jagged derive it.

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -266,14 +266,7 @@ class HSTUTransducer(BaseModule):
         plan: Optional[STUTruncationPlan],
         kernel: Kernel,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, Optional[int]]:
-        """Replay a truncation plan on the parallel jagged ``seq_timestamps``.
-
-        Refreshes dependent metadata (``seq_lengths``, ``seq_offsets``,
-        ``max_seq_len``, ``total_uih_len``) when ``plan`` is non-None;
-        passes input through untouched when ``plan`` is None.  Static so
-        tests can call it without constructing a full transducer
-        (preprocessor / postprocessor configs are heavy).
-        """
+        """Replay ``plan`` on ``seq_timestamps`` and refresh dependent metadata."""
         if plan is None:
             return (
                 seq_timestamps,

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -60,7 +60,6 @@ class HSTUTransducer(BaseModule):
             seq-length.
         is_inference (bool): whether to run in inference mode.
         return_full_embeddings (bool): return all embeddings or not.
-        listwise (bool): listwise training or not.
         attn_truncation_split_layer (int): layer index ``N1`` after which
             mid-stack attention truncation fires.  Must be in
             ``(0, attn_num_layers)`` when truncation is enabled, else 0.
@@ -86,7 +85,6 @@ class HSTUTransducer(BaseModule):
         scaling_seqlen: int = -1,
         is_inference: bool = True,
         return_full_embeddings: bool = False,
-        listwise: bool = False,
         attn_truncation_split_layer: int = 0,
         attn_truncation_tail_len: int = 0,
     ) -> None:
@@ -122,7 +120,6 @@ class HSTUTransducer(BaseModule):
             )
         self._input_dropout_ratio: float = input_dropout_ratio
         self._return_full_embeddings: bool = return_full_embeddings
-        self._listwise_training: bool = listwise and self.is_train
 
     def _preprocess(
         self, grouped_features
@@ -156,9 +153,7 @@ class HSTUTransducer(BaseModule):
                     seq_offsets=output_seq_offsets,
                     seq_timestamps=output_seq_timestamps,
                     seq_embeddings=output_seq_embeddings,
-                    num_targets=(
-                        None if self._listwise_training else output_num_targets
-                    ),
+                    num_targets=output_num_targets,
                 )
 
         output_seq_embeddings = torch.nn.functional.dropout(
@@ -192,7 +187,7 @@ class HSTUTransducer(BaseModule):
                 max_seq_len=max_seq_len,
                 x=seq_embeddings,
                 x_offsets=seq_offsets,
-                num_targets=(None if self._listwise_training else num_targets),
+                num_targets=num_targets,
             )
 
     def _postprocess(
@@ -266,7 +261,14 @@ class HSTUTransducer(BaseModule):
         plan: Optional[STUTruncationPlan],
         kernel: Kernel,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, Optional[int]]:
-        """Replay ``plan`` on ``seq_timestamps`` and refresh dependent metadata."""
+        """Replay ``plan`` on ``seq_timestamps`` and refresh dependent metadata.
+
+        When ``plan is None``, returns inputs unchanged. When ``plan is not
+        None``, returns post-truncation ``(seq_timestamps, plan.new_lengths,
+        post_stu_seq_offsets, post_stu_max_seq_len, None)`` -- the trailing
+        ``None`` replaces ``total_uih_len`` so the caller's
+        ``split_2D_jagged`` can re-derive it from the truncated offsets.
+        """
         if plan is None:
             return (
                 seq_timestamps,
@@ -278,8 +280,6 @@ class HSTUTransducer(BaseModule):
         seq_timestamps = apply_stu_truncation_plan(
             seq_timestamps.unsqueeze(-1), plan, kernel=kernel
         ).squeeze(-1)
-        # Pre-truncation total_uih_len no longer matches the truncated
-        # embeddings; passing None lets split_2D_jagged derive it.
         return (
             seq_timestamps,
             plan.new_lengths,

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -26,6 +26,7 @@ from tzrec.modules.gr.postprocessors import (
 from tzrec.modules.gr.preprocessors import InputPreprocessor, create_input_preprocessor
 from tzrec.modules.gr.stu import STULayer, STUStack
 from tzrec.modules.utils import BaseModule
+from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention_utils import (
     STUTruncationPlan,
     apply_stu_truncation_plan,
@@ -253,6 +254,47 @@ class HSTUTransducer(BaseModule):
                 candidate_embeddings,
             )
 
+    @staticmethod
+    def _replay_truncation_state(
+        seq_timestamps: torch.Tensor,
+        seq_lengths: torch.Tensor,
+        seq_offsets: torch.Tensor,
+        max_seq_len: int,
+        total_uih_len: int,
+        post_stu_seq_offsets: torch.Tensor,
+        post_stu_max_seq_len: int,
+        plan: Optional[STUTruncationPlan],
+        kernel: Kernel,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, Optional[int]]:
+        """Replay a truncation plan on the parallel jagged ``seq_timestamps``.
+
+        Refreshes dependent metadata (``seq_lengths``, ``seq_offsets``,
+        ``max_seq_len``, ``total_uih_len``) when ``plan`` is non-None;
+        passes input through untouched when ``plan`` is None.  Static so
+        tests can call it without constructing a full transducer
+        (preprocessor / postprocessor configs are heavy).
+        """
+        if plan is None:
+            return (
+                seq_timestamps,
+                seq_lengths,
+                seq_offsets,
+                max_seq_len,
+                total_uih_len,
+            )
+        seq_timestamps = apply_stu_truncation_plan(
+            seq_timestamps.unsqueeze(-1), plan, kernel=kernel
+        ).squeeze(-1)
+        # Pre-truncation total_uih_len no longer matches the truncated
+        # embeddings; passing None lets split_2D_jagged derive it.
+        return (
+            seq_timestamps,
+            plan.new_lengths,
+            post_stu_seq_offsets,
+            post_stu_max_seq_len,
+            None,
+        )
+
     def forward(
         self, grouped_features: Dict[str, torch.Tensor]
     ) -> Tuple[
@@ -296,17 +338,23 @@ class HSTUTransducer(BaseModule):
         # When STUStack truncated mid-stack, replay the same split on the
         # parallel jagged seq_timestamps so the postprocessor's UIH /
         # candidate split lines up with the truncated embeddings.
-        post_truncation_total_uih_len: Optional[int] = total_uih_len
-        if plan is not None:
-            seq_timestamps = apply_stu_truncation_plan(
-                seq_timestamps.unsqueeze(-1), plan, kernel=self.kernel()
-            ).squeeze(-1)
-            seq_lengths = plan.new_lengths
-            seq_offsets = post_stu_seq_offsets
-            max_seq_len = post_stu_max_seq_len
-            # Pre-truncation total_uih_len no longer matches the truncated
-            # embeddings; passing None lets split_2D_jagged derive it.
-            post_truncation_total_uih_len = None
+        (
+            seq_timestamps,
+            seq_lengths,
+            seq_offsets,
+            max_seq_len,
+            post_truncation_total_uih_len,
+        ) = self._replay_truncation_state(
+            seq_timestamps=seq_timestamps,
+            seq_lengths=seq_lengths,
+            seq_offsets=seq_offsets,
+            max_seq_len=max_seq_len,
+            total_uih_len=total_uih_len,
+            post_stu_seq_offsets=post_stu_seq_offsets,
+            post_stu_max_seq_len=post_stu_max_seq_len,
+            plan=plan,
+            kernel=self.kernel(),
+        )
 
         encoded_embeddings, encoded_candidate_embeddings = self._postprocess(
             max_seq_len=max_seq_len,

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -26,6 +26,10 @@ from tzrec.modules.gr.postprocessors import (
 from tzrec.modules.gr.preprocessors import InputPreprocessor, create_input_preprocessor
 from tzrec.modules.gr.stu import STULayer, STUStack
 from tzrec.modules.utils import BaseModule
+from tzrec.ops.hstu_attention_utils import (
+    STUTruncationPlan,
+    apply_stu_truncation_plan,
+)
 from tzrec.ops.jagged_tensors import split_2D_jagged
 from tzrec.utils.fx_util import fx_unwrap_optional_tensor
 
@@ -56,6 +60,13 @@ class HSTUTransducer(BaseModule):
         is_inference (bool): whether to run in inference mode.
         return_full_embeddings (bool): return all embeddings or not.
         listwise (bool): listwise training or not.
+        attn_truncation_split_layer (int): layer index ``N1`` after which
+            mid-stack attention truncation fires.  Must be in
+            ``(0, attn_num_layers)`` when truncation is enabled, else 0.
+        attn_truncation_tail_len (int): number of trailing UIH tokens kept
+            on layers ``>= N1``.  Both ``attn_truncation_split_layer`` and
+            ``attn_truncation_tail_len`` must be ``> 0`` to enable
+            truncation; setting only one is rejected at construction.
     """
 
     def __init__(
@@ -75,6 +86,8 @@ class HSTUTransducer(BaseModule):
         is_inference: bool = True,
         return_full_embeddings: bool = False,
         listwise: bool = False,
+        attn_truncation_split_layer: int = 0,
+        attn_truncation_tail_len: int = 0,
     ) -> None:
         super().__init__(is_inference=is_inference)
         self._input_preprocessor: InputPreprocessor = create_input_preprocessor(
@@ -93,6 +106,8 @@ class HSTUTransducer(BaseModule):
             stu["scaling_seqlen"] = scaling_seqlen
         self._stu_module: STUStack = STUStack(
             stu_list=[STULayer(**stu) for _ in range(attn_num_layers)],
+            truncate_split_layer=attn_truncation_split_layer,
+            truncate_tail_len=attn_truncation_tail_len,
         )
         self._output_postprocessor: OutputPostprocessor = create_output_postprocessor(
             output_postprocessor, embedding_dim=stu["embedding_dim"]
@@ -170,20 +185,19 @@ class HSTUTransducer(BaseModule):
         seq_timestamps: torch.Tensor,
         seq_embeddings: torch.Tensor,
         num_targets: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor, int, Optional[STUTruncationPlan]]:
         with record_function("hstu"):
-            seq_embeddings = self._stu_module(
+            return self._stu_module(
                 max_seq_len=max_seq_len,
                 x=seq_embeddings,
                 x_offsets=seq_offsets,
                 num_targets=(None if self._listwise_training else num_targets),
             )
-        return seq_embeddings
 
     def _postprocess(
         self,
         max_seq_len: int,
-        total_uih_len: int,
+        total_uih_len: Optional[int],
         total_targets: int,
         seq_lengths: torch.Tensor,
         seq_timestamps: torch.Tensor,
@@ -265,7 +279,12 @@ class HSTUTransducer(BaseModule):
             num_targets,
         ) = self._preprocess(grouped_features)
 
-        encoded_embeddings = self._hstu_compute(
+        (
+            encoded_embeddings,
+            post_stu_seq_offsets,
+            post_stu_max_seq_len,
+            plan,
+        ) = self._hstu_compute(
             max_seq_len=max_seq_len,
             seq_lengths=seq_lengths,
             seq_offsets=seq_offsets,
@@ -274,9 +293,26 @@ class HSTUTransducer(BaseModule):
             num_targets=num_targets,
         )
 
+        # When STUStack truncated mid-stack, replay the same split on the
+        # parallel jagged seq_timestamps so the postprocessor's UIH /
+        # candidate split lines up with the truncated embeddings.
+        # ``num_targets`` is preserved by truncation and stays valid as-is.
+        post_truncation_total_uih_len: Optional[int] = total_uih_len
+        if plan is not None:
+            seq_timestamps = apply_stu_truncation_plan(
+                seq_timestamps.unsqueeze(-1), plan
+            ).squeeze(-1)
+            seq_lengths = plan.new_lengths
+            seq_offsets = post_stu_seq_offsets
+            max_seq_len = post_stu_max_seq_len
+            # Pre-truncation total_uih_len no longer matches the truncated
+            # embeddings; let split_2D_jagged derive the correct length
+            # from the post-truncation offsets.
+            post_truncation_total_uih_len = None
+
         encoded_embeddings, encoded_candidate_embeddings = self._postprocess(
             max_seq_len=max_seq_len,
-            total_uih_len=total_uih_len,
+            total_uih_len=post_truncation_total_uih_len,
             total_targets=total_targets,
             seq_lengths=seq_lengths,
             seq_embeddings=encoded_embeddings,

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -296,18 +296,16 @@ class HSTUTransducer(BaseModule):
         # When STUStack truncated mid-stack, replay the same split on the
         # parallel jagged seq_timestamps so the postprocessor's UIH /
         # candidate split lines up with the truncated embeddings.
-        # ``num_targets`` is preserved by truncation and stays valid as-is.
         post_truncation_total_uih_len: Optional[int] = total_uih_len
         if plan is not None:
             seq_timestamps = apply_stu_truncation_plan(
-                seq_timestamps.unsqueeze(-1), plan
+                seq_timestamps.unsqueeze(-1), plan, kernel=self.kernel()
             ).squeeze(-1)
-            seq_lengths = plan.new_lengths
             seq_offsets = post_stu_seq_offsets
+            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
             max_seq_len = post_stu_max_seq_len
             # Pre-truncation total_uih_len no longer matches the truncated
-            # embeddings; let split_2D_jagged derive the correct length
-            # from the post-truncation offsets.
+            # embeddings; passing None lets split_2D_jagged derive it.
             post_truncation_total_uih_len = None
 
         encoded_embeddings, encoded_candidate_embeddings = self._postprocess(

--- a/tzrec/modules/gr/hstu_transducer_test.py
+++ b/tzrec/modules/gr/hstu_transducer_test.py
@@ -9,11 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ``HSTUTransducer._replay_truncation_state``."""
+"""Unit + integration tests for ``HSTUTransducer``."""
 
 import unittest
+from typing import Dict, List
+from unittest.mock import patch
 
 import torch
+from parameterized import parameterized
 
 from tzrec.modules.gr.hstu_transducer import HSTUTransducer
 from tzrec.ops import Kernel
@@ -21,28 +24,69 @@ from tzrec.ops.hstu_attention_utils import compute_stu_truncation_plan
 from tzrec.ops.hstu_attention_utils_test import _reference_truncation
 
 
-class ReplayTruncationStateTest(unittest.TestCase):
-    """Cover ``HSTUTransducer._replay_truncation_state`` invariants.
+class _StubInputPreprocessor(torch.nn.Module):
+    """Stub preprocessor returning a synthetic 8-tuple from recorded inputs.
 
-    - When ``plan is None``, pass through untouched.
-    - When ``plan`` fires: truncate ``seq_timestamps`` via the same plan,
-      use ``plan.new_lengths`` for ``seq_lengths`` (not, e.g.,
-      ``plan.new_x_offsets`` which would be a wrong field assignment),
-      take ``seq_offsets`` from ``post_stu_seq_offsets`` and ``max_seq_len``
-      from ``post_stu_max_seq_len``, and emit ``total_uih_len = None``.
+    Avoids the full ContentEncoder / ActionEncoder / MLP chain that the
+    real ContextualInterleavePreprocessor requires.
     """
 
-    def _setup(self):
+    def __init__(
+        self,
+        lengths: List[int],
+        targets: List[int],
+        embedding_dim: int,
+        contextual_seq_len: int,
+    ) -> None:
+        super().__init__()
+        self._lengths = lengths
+        self._targets = targets
+        self._embedding_dim = embedding_dim
+        self._contextual_seq_len = contextual_seq_len
+
+    def contextual_seq_len(self) -> int:
+        return self._contextual_seq_len
+
+    def interleave_targets(self) -> bool:
+        return False
+
+    def forward(self, grouped_features):
+        seq_lengths = torch.tensor(self._lengths, dtype=torch.int64)
+        seq_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(seq_lengths)
+        total = int(seq_offsets[-1].item())
+        num_targets = torch.tensor(self._targets, dtype=torch.int64)
+        total_targets = int(num_targets.sum().item())
+        return (
+            int(seq_lengths.max().item()),
+            total - total_targets,
+            total_targets,
+            seq_lengths,
+            seq_offsets,
+            torch.arange(total, dtype=torch.float32),
+            torch.randn(total, self._embedding_dim),
+            num_targets,
+        )
+
+
+class _StubOutputPostprocessor(torch.nn.Module):
+    def forward(
+        self, seq_embeddings: torch.Tensor, seq_timestamps: torch.Tensor
+    ) -> torch.Tensor:
+        return seq_embeddings
+
+
+class HSTUTransducerTest(unittest.TestCase):
+    # ---------- _replay_truncation_state unit tests ----------
+
+    def _replay_setup(self):
         lengths = [10, 14, 6]
         targets = [2, 3, 1]
-        ctx = 2
-        tail = 4
+        ctx, tail = 2, 4
         offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
             torch.tensor(lengths, dtype=torch.int64)
         )
         total = int(offsets[-1].item())
         seq_lengths = offsets[1:] - offsets[:-1]
-        # Identity-marked timestamps so we can verify positional alignment.
         seq_timestamps = torch.arange(total, dtype=torch.float32) * 7.0
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
@@ -65,8 +109,8 @@ class ReplayTruncationStateTest(unittest.TestCase):
             "total_targets": sum(targets),
         }
 
-    def test_pass_through_when_plan_is_none(self) -> None:
-        s = self._setup()
+    def test_replay_truncation_state_pass_through_when_plan_is_none(self) -> None:
+        s = self._replay_setup()
         out = HSTUTransducer._replay_truncation_state(
             seq_timestamps=s["seq_timestamps"],
             seq_lengths=s["seq_lengths"],
@@ -85,8 +129,10 @@ class ReplayTruncationStateTest(unittest.TestCase):
         self.assertEqual(out_max, s["max_seq_len"])
         self.assertEqual(out_total_uih, s["total_uih_len"])
 
-    def test_replays_plan_and_assigns_correct_fields(self) -> None:
-        s = self._setup()
+    def test_replay_truncation_state_replays_plan_and_assigns_correct_fields(
+        self,
+    ) -> None:
+        s = self._replay_setup()
         post_stu_seq_offsets = s["plan"].new_x_offsets
         post_stu_max_seq_len = s["plan"].new_max_seq_len
         out = HSTUTransducer._replay_truncation_state(
@@ -102,8 +148,7 @@ class ReplayTruncationStateTest(unittest.TestCase):
         )
         out_ts, out_lens, out_offsets, out_max, out_total_uih = out
 
-        # 1. Timestamps truncated against an independent reference (catches
-        #    a bug in the unsqueeze / squeeze round-trip).
+        # Timestamps truncated against an independent reference.
         ref_ts, _ = _reference_truncation(
             s["seq_timestamps"].unsqueeze(-1),
             s["offsets"],
@@ -112,21 +157,106 @@ class ReplayTruncationStateTest(unittest.TestCase):
             contextual_seq_len=s["ctx"],
         )
         torch.testing.assert_close(out_ts, ref_ts.squeeze(-1))
-
-        # 2. seq_lengths must come from plan.new_lengths, not, say,
-        #    plan.new_x_offsets.  Independent reference comparison.
+        # seq_lengths must come from plan.new_lengths (not new_x_offsets).
         torch.testing.assert_close(out_lens, s["plan"].new_lengths)
-        # Distinct from new_x_offsets (different shape; confirms the
-        # right field flowed through).
         self.assertEqual(out_lens.shape[0], len(s["lengths"]))
         self.assertEqual(s["plan"].new_x_offsets.shape[0], len(s["lengths"]) + 1)
-
-        # 3. seq_offsets / max_seq_len come from the post-STU outputs.
+        # seq_offsets / max_seq_len come from the post-STU outputs.
         self.assertIs(out_offsets, post_stu_seq_offsets)
         self.assertEqual(out_max, post_stu_max_seq_len)
-
-        # 4. total_uih_len is reset to None so split_2D_jagged derives it.
+        # total_uih_len is reset to None so split_2D_jagged derives it.
         self.assertIsNone(out_total_uih)
+
+    # ---------- forward() end-to-end integration tests ----------
+
+    def _build_transducer(
+        self,
+        attn_truncation_split_layer: int,
+        attn_truncation_tail_len: int,
+        lengths: List[int],
+        targets: List[int],
+        embedding_dim: int = 16,
+        attn_num_layers: int = 3,
+    ) -> HSTUTransducer:
+        """Construct a transducer with stubbed preprocessor / postprocessor.
+
+        The full ``ContextualInterleavePreprocessor`` requires an
+        action_encoder + content_encoder + MLP chain; for an integration
+        test focused on the truncation glue we stub those out via
+        :func:`unittest.mock.patch.object` over the factory functions.
+        """
+        stub_pre = _StubInputPreprocessor(
+            lengths=lengths,
+            targets=targets,
+            embedding_dim=embedding_dim,
+            contextual_seq_len=0,
+        )
+        stub_post = _StubOutputPostprocessor()
+        with (
+            patch(
+                "tzrec.modules.gr.hstu_transducer.create_input_preprocessor",
+                return_value=stub_pre,
+            ),
+            patch(
+                "tzrec.modules.gr.hstu_transducer.create_output_postprocessor",
+                return_value=stub_post,
+            ),
+        ):
+            transducer = HSTUTransducer(
+                uih_embedding_dim=embedding_dim,
+                target_embedding_dim=embedding_dim,
+                stu={
+                    "embedding_dim": embedding_dim,
+                    "num_heads": 2,
+                    "hidden_dim": 32,
+                    "attention_dim": 32,
+                    "output_dropout_ratio": 0.0,
+                    "causal": True,
+                    "target_aware": True,
+                },
+                attn_num_layers=attn_num_layers,
+                input_preprocessor={"contextual_preprocessor": {}},
+                output_postprocessor={"l2norm_postprocessor": {}},
+                attn_truncation_split_layer=attn_truncation_split_layer,
+                attn_truncation_tail_len=attn_truncation_tail_len,
+                is_inference=False,
+            )
+        # Set kernel on the whole transducer so split_2D_jagged calls in
+        # _postprocess (which read self.kernel()) also dispatch to PyTorch.
+        transducer.set_kernel(Kernel.PYTORCH)
+        return transducer
+
+    @parameterized.expand(
+        [
+            # attn_truncation_split_layer, attn_truncation_tail_len
+            [0, 0],  # disabled baseline
+            [1, 4],  # truncation enabled; tail=4 bites for samples with U>4
+        ]
+    )
+    def test_forward_end_to_end(self, split: int, tail: int) -> None:
+        """Full ``forward`` runs cleanly with truncation on/off.
+
+        Catches: wrong field assignment in ``_replay_truncation_state``,
+        num_targets / seq_lengths mismatch in ``_postprocess`` after
+        truncation, kernel not threading through, or shape mismatch on
+        the seq_timestamps unsqueeze/squeeze round-trip.  Any of these
+        would raise or produce non-finite output here.
+        """
+        lengths = [12, 20, 5, 30]
+        targets = [2, 3, 1, 2]
+        transducer = self._build_transducer(
+            attn_truncation_split_layer=split,
+            attn_truncation_tail_len=tail,
+            lengths=lengths,
+            targets=targets,
+        )
+        # grouped_features is consumed by the stubbed preprocessor only.
+        grouped_features: Dict[str, torch.Tensor] = {}
+        encoded_candidate_embeddings, encoded_embeddings = transducer(grouped_features)
+        self.assertTrue(torch.isfinite(encoded_candidate_embeddings).all())
+        self.assertEqual(encoded_candidate_embeddings.size(0), sum(targets))
+        # return_full_embeddings=False (default), so encoded_embeddings is None.
+        self.assertIsNone(encoded_embeddings)
 
 
 if __name__ == "__main__":

--- a/tzrec/modules/gr/hstu_transducer_test.py
+++ b/tzrec/modules/gr/hstu_transducer_test.py
@@ -9,12 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Focused unit tests for ``HSTUTransducer`` plan-replay glue.
-
-The full ``forward`` requires a configured input preprocessor + output
-postprocessor; tests here exercise the post-stack truncation block in
-isolation via the static ``_replay_truncation_state`` helper.
-"""
+"""Unit tests for ``HSTUTransducer._replay_truncation_state``."""
 
 import unittest
 

--- a/tzrec/modules/gr/hstu_transducer_test.py
+++ b/tzrec/modules/gr/hstu_transducer_test.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2025, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused unit tests for ``HSTUTransducer`` plan-replay glue.
+
+The full ``forward`` requires a configured input preprocessor + output
+postprocessor; tests here exercise the post-stack truncation block in
+isolation via the static ``_replay_truncation_state`` helper.
+"""
+
+import unittest
+
+import torch
+
+from tzrec.modules.gr.hstu_transducer import HSTUTransducer
+from tzrec.ops import Kernel
+from tzrec.ops.hstu_attention_utils import compute_stu_truncation_plan
+from tzrec.ops.hstu_attention_utils_test import _reference_truncation
+
+
+class ReplayTruncationStateTest(unittest.TestCase):
+    """Cover ``HSTUTransducer._replay_truncation_state`` invariants.
+
+    - When ``plan is None``, pass through untouched.
+    - When ``plan`` fires: truncate ``seq_timestamps`` via the same plan,
+      use ``plan.new_lengths`` for ``seq_lengths`` (not, e.g.,
+      ``plan.new_x_offsets`` which would be a wrong field assignment),
+      take ``seq_offsets`` from ``post_stu_seq_offsets`` and ``max_seq_len``
+      from ``post_stu_max_seq_len``, and emit ``total_uih_len = None``.
+    """
+
+    def _setup(self):
+        lengths = [10, 14, 6]
+        targets = [2, 3, 1]
+        ctx = 2
+        tail = 4
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor(lengths, dtype=torch.int64)
+        )
+        total = int(offsets[-1].item())
+        seq_lengths = offsets[1:] - offsets[:-1]
+        # Identity-marked timestamps so we can verify positional alignment.
+        seq_timestamps = torch.arange(total, dtype=torch.float32) * 7.0
+        plan = compute_stu_truncation_plan(
+            x_offsets=offsets,
+            num_targets=torch.tensor(targets, dtype=torch.int64),
+            max_seq_len=int(seq_lengths.max().item()),
+            truncate_tail_len=tail,
+            contextual_seq_len=ctx,
+        )
+        return {
+            "lengths": lengths,
+            "targets": targets,
+            "ctx": ctx,
+            "tail": tail,
+            "offsets": offsets,
+            "seq_lengths": seq_lengths,
+            "seq_timestamps": seq_timestamps,
+            "plan": plan,
+            "max_seq_len": int(seq_lengths.max().item()),
+            "total_uih_len": int(seq_lengths.sum().item()) - sum(targets),
+            "total_targets": sum(targets),
+        }
+
+    def test_pass_through_when_plan_is_none(self) -> None:
+        s = self._setup()
+        out = HSTUTransducer._replay_truncation_state(
+            seq_timestamps=s["seq_timestamps"],
+            seq_lengths=s["seq_lengths"],
+            seq_offsets=s["offsets"],
+            max_seq_len=s["max_seq_len"],
+            total_uih_len=s["total_uih_len"],
+            post_stu_seq_offsets=s["offsets"],
+            post_stu_max_seq_len=s["max_seq_len"],
+            plan=None,
+            kernel=Kernel.PYTORCH,
+        )
+        out_ts, out_lens, out_offsets, out_max, out_total_uih = out
+        self.assertIs(out_ts, s["seq_timestamps"])
+        self.assertIs(out_lens, s["seq_lengths"])
+        self.assertIs(out_offsets, s["offsets"])
+        self.assertEqual(out_max, s["max_seq_len"])
+        self.assertEqual(out_total_uih, s["total_uih_len"])
+
+    def test_replays_plan_and_assigns_correct_fields(self) -> None:
+        s = self._setup()
+        post_stu_seq_offsets = s["plan"].new_x_offsets
+        post_stu_max_seq_len = s["plan"].new_max_seq_len
+        out = HSTUTransducer._replay_truncation_state(
+            seq_timestamps=s["seq_timestamps"],
+            seq_lengths=s["seq_lengths"],
+            seq_offsets=s["offsets"],
+            max_seq_len=s["max_seq_len"],
+            total_uih_len=s["total_uih_len"],
+            post_stu_seq_offsets=post_stu_seq_offsets,
+            post_stu_max_seq_len=post_stu_max_seq_len,
+            plan=s["plan"],
+            kernel=Kernel.PYTORCH,
+        )
+        out_ts, out_lens, out_offsets, out_max, out_total_uih = out
+
+        # 1. Timestamps truncated against an independent reference (catches
+        #    a bug in the unsqueeze / squeeze round-trip).
+        ref_ts, _ = _reference_truncation(
+            s["seq_timestamps"].unsqueeze(-1),
+            s["offsets"],
+            s["targets"],
+            truncate_tail_len=s["tail"],
+            contextual_seq_len=s["ctx"],
+        )
+        torch.testing.assert_close(out_ts, ref_ts.squeeze(-1))
+
+        # 2. seq_lengths must come from plan.new_lengths, not, say,
+        #    plan.new_x_offsets.  Independent reference comparison.
+        torch.testing.assert_close(out_lens, s["plan"].new_lengths)
+        # Distinct from new_x_offsets (different shape; confirms the
+        # right field flowed through).
+        self.assertEqual(out_lens.shape[0], len(s["lengths"]))
+        self.assertEqual(s["plan"].new_x_offsets.shape[0], len(s["lengths"]) + 1)
+
+        # 3. seq_offsets / max_seq_len come from the post-STU outputs.
+        self.assertIs(out_offsets, post_stu_seq_offsets)
+        self.assertEqual(out_max, post_stu_max_seq_len)
+
+        # 4. total_uih_len is reset to None so split_2D_jagged derives it.
+        self.assertIsNone(out_total_uih)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/modules/gr/hstu_transducer_test.py
+++ b/tzrec/modules/gr/hstu_transducer_test.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 from tzrec.modules.gr.hstu_transducer import HSTUTransducer
 from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention_utils import compute_stu_truncation_plan
-from tzrec.ops.hstu_attention_utils_test import _reference_truncation
+from tzrec.utils.test_util import reference_stu_truncation
 
 
 class _StubInputPreprocessor(torch.nn.Module):
@@ -37,18 +37,20 @@ class _StubInputPreprocessor(torch.nn.Module):
         targets: List[int],
         embedding_dim: int,
         contextual_seq_len: int,
+        interleave_targets: bool = False,
     ) -> None:
         super().__init__()
         self._lengths = lengths
         self._targets = targets
         self._embedding_dim = embedding_dim
         self._contextual_seq_len = contextual_seq_len
+        self._interleave_targets = interleave_targets
 
     def contextual_seq_len(self) -> int:
         return self._contextual_seq_len
 
     def interleave_targets(self) -> bool:
-        return False
+        return self._interleave_targets
 
     def forward(self, grouped_features):
         seq_lengths = torch.tensor(self._lengths, dtype=torch.int64)
@@ -149,7 +151,7 @@ class HSTUTransducerTest(unittest.TestCase):
         out_ts, out_lens, out_offsets, out_max, out_total_uih = out
 
         # Timestamps truncated against an independent reference.
-        ref_ts, _ = _reference_truncation(
+        ref_ts, _ = reference_stu_truncation(
             s["seq_timestamps"].unsqueeze(-1),
             s["offsets"],
             s["targets"],
@@ -175,6 +177,8 @@ class HSTUTransducerTest(unittest.TestCase):
         attn_truncation_tail_len: int,
         lengths: List[int],
         targets: List[int],
+        contextual_seq_len: int = 0,
+        interleave_targets: bool = False,
         embedding_dim: int = 16,
         attn_num_layers: int = 3,
     ) -> HSTUTransducer:
@@ -189,7 +193,8 @@ class HSTUTransducerTest(unittest.TestCase):
             lengths=lengths,
             targets=targets,
             embedding_dim=embedding_dim,
-            contextual_seq_len=0,
+            contextual_seq_len=contextual_seq_len,
+            interleave_targets=interleave_targets,
         )
         stub_post = _StubOutputPostprocessor()
         with (
@@ -228,33 +233,47 @@ class HSTUTransducerTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # attn_truncation_split_layer, attn_truncation_tail_len
-            [0, 0],  # disabled baseline
-            [1, 4],  # truncation enabled; tail=4 bites for samples with U>4
+            # split, tail, interleave, ctx, lengths,         targets
+            [0, 0, False, 0, [12, 20, 5, 30], [2, 3, 1, 2]],  # disabled baseline
+            [1, 4, False, 0, [12, 20, 5, 30], [2, 3, 1, 2]],  # truncation, plain
+            [1, 4, True, 0, [12, 20, 5, 30], [2, 4, 2, 2]],  # interleave (T=10, even)
+            [1, 4, False, 3, [15, 22, 8, 30], [2, 3, 1, 2]],  # contextual prefix
+            [1, 4, True, 3, [15, 22, 8, 30], [2, 4, 2, 2]],  # interleave + ctx
         ]
     )
-    def test_forward_end_to_end(self, split: int, tail: int) -> None:
-        """Full ``forward`` runs cleanly with truncation on/off.
+    def test_forward_end_to_end(
+        self,
+        split: int,
+        tail: int,
+        interleave: bool,
+        ctx: int,
+        lengths: List[int],
+        targets: List[int],
+    ) -> None:
+        """Full ``forward`` runs cleanly across the (interleave, ctx) matrix.
 
         Catches: wrong field assignment in ``_replay_truncation_state``,
         num_targets / seq_lengths mismatch in ``_postprocess`` after
-        truncation, kernel not threading through, or shape mismatch on
-        the seq_timestamps unsqueeze/squeeze round-trip.  Any of these
-        would raise or produce non-finite output here.
+        truncation, kernel not threading through, shape mismatch on the
+        seq_timestamps unsqueeze/squeeze round-trip, the
+        ``view(-1, 2)`` candidate reshape under interleave, and the
+        3-op contextual-prefix path through ``apply_stu_truncation_plan``.
         """
-        lengths = [12, 20, 5, 30]
-        targets = [2, 3, 1, 2]
         transducer = self._build_transducer(
             attn_truncation_split_layer=split,
             attn_truncation_tail_len=tail,
             lengths=lengths,
             targets=targets,
+            contextual_seq_len=ctx,
+            interleave_targets=interleave,
         )
         # grouped_features is consumed by the stubbed preprocessor only.
         grouped_features: Dict[str, torch.Tensor] = {}
         encoded_candidate_embeddings, encoded_embeddings = transducer(grouped_features)
         self.assertTrue(torch.isfinite(encoded_candidate_embeddings).all())
-        self.assertEqual(encoded_candidate_embeddings.size(0), sum(targets))
+        # Under interleave, candidates are reshaped (T, D) -> (T // 2, D).
+        expected_rows = sum(targets) // (2 if interleave else 1)
+        self.assertEqual(encoded_candidate_embeddings.size(0), expected_rows)
         # return_full_embeddings=False (default), so encoded_embeddings is None.
         self.assertIsNone(encoded_embeddings)
 

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -649,23 +649,14 @@ class STULayer(STU):
 class STUStack(BaseModule):
     """Stack of ``STU`` layers with optional mid-stack attention truncation.
 
-    Threads SLA mask reuse between layers.  When truncation is enabled
-    (``truncate_split_layer > 0`` and ``truncate_tail_len > 0``), after
-    ``truncate_split_layer`` full-sequence layers the stack drops UIH
-    prefix tokens so each sample keeps at most ``truncate_tail_len`` UIH
-    tokens; contextual prefix and targets always survive.  Crossing the
-    truncation boundary invalidates the per-layer SLA cache so the next
-    layer rebuilds the func tensor against the new offsets.
-
     Args:
         stu_list (List[STU]): list of STU layers.
-        truncate_split_layer (int): layer index ``N1`` after which
-            mid-stack truncation fires.  Must be in ``(0, len(stu_list))``
-            when truncation is enabled, else ``0``.
-        truncate_tail_len (int): number of trailing UIH tokens kept on
-            layers ``>= N1``.  Both ``truncate_split_layer`` and
-            ``truncate_tail_len`` must be ``> 0`` to enable truncation;
-            setting only one is rejected at construction.
+        truncate_split_layer (int): layer index after which UIH tokens
+            are truncated.  Must be in ``(0, len(stu_list))`` when
+            ``truncate_tail_len > 0``, else ``0``.
+        truncate_tail_len (int): max UIH tokens kept on layers
+            ``>= truncate_split_layer``.  Both fields must be ``> 0``
+            to enable truncation.
         is_inference (bool): whether to run in inference mode.
     """
 

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -61,6 +61,7 @@ class STU(BaseModule, abc.ABC):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def truncate_input(
         self,
         x: torch.Tensor,
@@ -72,9 +73,10 @@ class STU(BaseModule, abc.ABC):
     ) -> Tuple[torch.Tensor, torch.Tensor, int, STUTruncationPlan]:
         """Truncate the UIH tail of the jagged batch before this layer.
 
-        Default impl raises -- subclasses that participate in mid-stack
-        truncation must override using their own ``contextual_seq_len``
-        and ``kernel()``.
+        Subclasses that don't participate in mid-stack truncation should
+        override and ``raise NotImplementedError(...)`` from their
+        override -- the abstract decorator forces a deliberate choice
+        at subclass instantiation rather than at the truncating call site.
 
         Args:
             x: jagged values ``(total, D)``.
@@ -86,11 +88,7 @@ class STU(BaseModule, abc.ABC):
         Returns:
             ``(x, x_offsets, max_seq_len, plan)`` post-truncation.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__}.truncate_input not implemented; "
-            f"this STU subclass cannot participate in STUStack mid-stack "
-            f"truncation."
-        )
+        ...
 
     @abc.abstractmethod
     def forward(
@@ -673,6 +671,12 @@ class STUStack(BaseModule):
     ) -> None:
         super().__init__(is_inference=is_inference)
         self._stu_layers: torch.nn.ModuleList = torch.nn.ModuleList(modules=stu_list)
+        if truncate_split_layer < 0 or truncate_tail_len < 0:
+            raise ValueError(
+                f"truncate_split_layer and truncate_tail_len must be "
+                f"non-negative; got truncate_split_layer={truncate_split_layer}, "
+                f"truncate_tail_len={truncate_tail_len}."
+            )
         if (truncate_split_layer > 0) != (truncate_tail_len > 0):
             raise ValueError(
                 f"truncate_split_layer and truncate_tail_len must both be "

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -61,6 +61,37 @@ class STU(BaseModule, abc.ABC):
         """
         raise NotImplementedError
 
+    def truncate_input(
+        self,
+        x: torch.Tensor,
+        x_offsets: torch.Tensor,
+        max_seq_len: int,
+        num_targets: Optional[torch.Tensor],
+        *,
+        truncate_tail_len: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, int, STUTruncationPlan]:
+        """Truncate the UIH tail of the jagged batch before this layer.
+
+        Default impl raises -- subclasses that participate in mid-stack
+        truncation must override using their own ``contextual_seq_len``
+        and ``kernel()``.
+
+        Args:
+            x: jagged values ``(total, D)``.
+            x_offsets: cumulative offsets ``(B + 1,)``.
+            max_seq_len: padded max length.
+            num_targets: per-sample target counts ``(B,)`` or ``None``.
+            truncate_tail_len: max UIH tokens kept per sample.
+
+        Returns:
+            ``(x, x_offsets, max_seq_len, plan)`` post-truncation.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.truncate_input not implemented; "
+            f"this STU subclass cannot participate in STUStack mid-stack "
+            f"truncation."
+        )
+
     @abc.abstractmethod
     def forward(
         self,
@@ -391,6 +422,26 @@ class STULayer(STU):
             kv_caching_offsets=self.kv_caching_offsets,
         )
 
+    def truncate_input(
+        self,
+        x: torch.Tensor,
+        x_offsets: torch.Tensor,
+        max_seq_len: int,
+        num_targets: Optional[torch.Tensor],
+        *,
+        truncate_tail_len: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, int, STUTruncationPlan]:
+        """Truncate the UIH tail of the jagged batch before this layer."""
+        plan = compute_stu_truncation_plan(
+            x_offsets=x_offsets,
+            num_targets=num_targets,
+            max_seq_len=max_seq_len,
+            truncate_tail_len=truncate_tail_len,
+            contextual_seq_len=self._contextual_seq_len,
+        )
+        x = apply_stu_truncation_plan(x, plan, kernel=self.kernel())
+        return x, plan.new_x_offsets, plan.new_max_seq_len, plan
+
     def forward(
         self,
         x: torch.Tensor,
@@ -680,16 +731,13 @@ class STUStack(BaseModule):
         prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None
         for i, layer in enumerate(self._stu_layers):
             if self._truncate_tail_len > 0 and i == self._truncate_split_layer:
-                plan = compute_stu_truncation_plan(
-                    x_offsets=x_offsets,
-                    num_targets=num_targets,
-                    max_seq_len=max_seq_len,
+                x, x_offsets, max_seq_len, plan = layer.truncate_input(
+                    x,
+                    x_offsets,
+                    max_seq_len,
+                    num_targets,
                     truncate_tail_len=self._truncate_tail_len,
-                    contextual_seq_len=self._stu_layers[0]._contextual_seq_len,
                 )
-                x = apply_stu_truncation_plan(x, plan, kernel=self.kernel())
-                x_offsets = plan.new_x_offsets
-                max_seq_len = plan.new_max_seq_len
                 # SLA cache keyed on offsets / total_q; both changed.
                 prev_attn_func = None
                 prev_attn_func_sig = None

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -627,8 +627,6 @@ class STUStack(BaseModule):
     ) -> None:
         super().__init__(is_inference=is_inference)
         self._stu_layers: torch.nn.ModuleList = torch.nn.ModuleList(modules=stu_list)
-        # Symmetric validation: setting one of the two without the other
-        # used to silently no-op at forward time; surface it at __init__.
         if (truncate_split_layer > 0) != (truncate_tail_len > 0):
             raise ValueError(
                 f"truncate_split_layer and truncate_tail_len must both be "
@@ -647,13 +645,6 @@ class STUStack(BaseModule):
             )
         self._truncate_split_layer: int = truncate_split_layer
         self._truncate_tail_len: int = truncate_tail_len
-        # Capture contextual_seq_len from the first layer at __init__:
-        # all layers in a stack share the same value, and it's immutable
-        # post-construction.  Snapshotting here avoids reaching into the
-        # layer's private state during forward.
-        self._contextual_seq_len: int = (
-            stu_list[0]._contextual_seq_len if stu_list else 0
-        )
 
     def forward(
         self,
@@ -689,23 +680,17 @@ class STUStack(BaseModule):
         prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None
         for i, layer in enumerate(self._stu_layers):
             if self._truncate_tail_len > 0 and i == self._truncate_split_layer:
-                seq_lengths = x_offsets[1:] - x_offsets[:-1]
                 plan = compute_stu_truncation_plan(
                     x_offsets=x_offsets,
-                    seq_lengths=seq_lengths,
                     num_targets=num_targets,
                     max_seq_len=max_seq_len,
                     truncate_tail_len=self._truncate_tail_len,
-                    contextual_seq_len=self._contextual_seq_len,
-                    kernel=self.kernel(),
+                    contextual_seq_len=self._stu_layers[0]._contextual_seq_len,
                 )
-                x = apply_stu_truncation_plan(x, plan)
+                x = apply_stu_truncation_plan(x, plan, kernel=self.kernel())
                 x_offsets = plan.new_x_offsets
                 max_seq_len = plan.new_max_seq_len
-                # Invalidate the SLA cache: offsets / total_q have
-                # changed, so the previous func tensor is stale.  The
-                # next layer's cache-miss path will rebuild against the
-                # truncated layout.
+                # SLA cache keyed on offsets / total_q; both changed.
                 prev_attn_func = None
                 prev_attn_func_sig = None
             x, prev_attn_func, prev_attn_func_sig = layer(
@@ -739,11 +724,9 @@ class STUStack(BaseModule):
             torch.Tensor: output sequence embedding tensor.
         """
         if self._truncate_tail_len > 0 and self._truncate_split_layer > 0:
-            # The cached / delta path operates per-layer on a rolling KV
-            # cache; mid-stack truncation would drop UIH prefix tokens that
-            # post-truncation layers still reference via the cache, causing
-            # train/serve skew.  Refuse the config rather than silently
-            # diverge -- proper support is a follow-up.
+            # Cached / delta path keeps a rolling KV cache; mid-stack
+            # truncation would drop UIH prefix tokens that post-truncation
+            # layers still reference via the cache (train/serve skew).
             raise NotImplementedError(
                 "STUStack attention truncation is not supported in "
                 "cached_forward (serving path). Either disable truncation "

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -22,7 +22,12 @@ from torch.autograd.profiler import record_function
 from tzrec.modules.utils import BaseModule
 from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention import delta_hstu_mha
-from tzrec.ops.hstu_attention_utils import build_sla_func_tensor
+from tzrec.ops.hstu_attention_utils import (
+    STUTruncationPlan,
+    apply_stu_truncation_plan,
+    build_sla_func_tensor,
+    compute_stu_truncation_plan,
+)
 from tzrec.ops.hstu_compute import (
     hstu_compute_output,
     hstu_compute_uqvk,
@@ -591,20 +596,64 @@ class STULayer(STU):
 
 
 class STUStack(BaseModule):
-    """Stack of ``STU`` layers.  Threads SLA mask reuse between layers.
+    """Stack of ``STU`` layers with optional mid-stack attention truncation.
+
+    Threads SLA mask reuse between layers.  When truncation is enabled
+    (``truncate_split_layer > 0`` and ``truncate_tail_len > 0``), after
+    ``truncate_split_layer`` full-sequence layers the stack drops UIH
+    prefix tokens so each sample keeps at most ``truncate_tail_len`` UIH
+    tokens; contextual prefix and targets always survive.  Crossing the
+    truncation boundary invalidates the per-layer SLA cache so the next
+    layer rebuilds the func tensor against the new offsets.
 
     Args:
         stu_list (List[STU]): list of STU layers.
+        truncate_split_layer (int): layer index ``N1`` after which
+            mid-stack truncation fires.  Must be in ``(0, len(stu_list))``
+            when truncation is enabled, else ``0``.
+        truncate_tail_len (int): number of trailing UIH tokens kept on
+            layers ``>= N1``.  Both ``truncate_split_layer`` and
+            ``truncate_tail_len`` must be ``> 0`` to enable truncation;
+            setting only one is rejected at construction.
         is_inference (bool): whether to run in inference mode.
     """
 
     def __init__(
         self,
         stu_list: List[STU],
+        truncate_split_layer: int = 0,
+        truncate_tail_len: int = 0,
         is_inference: bool = False,
     ) -> None:
         super().__init__(is_inference=is_inference)
         self._stu_layers: torch.nn.ModuleList = torch.nn.ModuleList(modules=stu_list)
+        # Symmetric validation: setting one of the two without the other
+        # used to silently no-op at forward time; surface it at __init__.
+        if (truncate_split_layer > 0) != (truncate_tail_len > 0):
+            raise ValueError(
+                f"truncate_split_layer and truncate_tail_len must both be "
+                f"> 0 to enable truncation, or both 0 to disable; got "
+                f"truncate_split_layer={truncate_split_layer}, "
+                f"truncate_tail_len={truncate_tail_len}."
+            )
+        if truncate_tail_len > 0 and not (
+            0 < truncate_split_layer < len(self._stu_layers)
+        ):
+            raise ValueError(
+                f"truncate_split_layer must be in (0, {len(self._stu_layers)}) "
+                f"when truncate_tail_len > 0; got "
+                f"truncate_split_layer={truncate_split_layer}, "
+                f"truncate_tail_len={truncate_tail_len}."
+            )
+        self._truncate_split_layer: int = truncate_split_layer
+        self._truncate_tail_len: int = truncate_tail_len
+        # Capture contextual_seq_len from the first layer at __init__:
+        # all layers in a stack share the same value, and it's immutable
+        # post-construction.  Snapshotting here avoids reaching into the
+        # layer's private state during forward.
+        self._contextual_seq_len: int = (
+            stu_list[0]._contextual_seq_len if stu_list else 0
+        )
 
     def forward(
         self,
@@ -614,7 +663,7 @@ class STUStack(BaseModule):
         num_targets: torch.Tensor,
         max_kv_caching_len: int = 0,
         kv_caching_lengths: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor, int, Optional[STUTruncationPlan]]:
         """Forward stack of stu layer.
 
         Args:
@@ -626,11 +675,39 @@ class STUStack(BaseModule):
             kv_caching_lengths (Optional[torch.Tensor]): key-value caching lengths.
 
         Returns:
-            torch.Tensor: output sequence embedding tensor from the last layer.
+            ``(x, x_offsets, max_seq_len, plan)``.  ``plan`` is the
+            :class:`STUTruncationPlan` produced when mid-stack truncation
+            fired, else ``None``.  When ``plan`` is not ``None``,
+            ``x_offsets`` and ``max_seq_len`` reflect the post-truncation
+            state; ``num_targets`` is preserved intact across truncation,
+            so the caller's input tensor is still valid.  Callers that
+            hold parallel jagged tensors (e.g. ``seq_timestamps``) replay
+            the same split via :func:`apply_stu_truncation_plan`.
         """
+        plan: Optional[STUTruncationPlan] = None
         prev_attn_func: Optional[torch.Tensor] = None
         prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None
-        for layer in self._stu_layers:
+        for i, layer in enumerate(self._stu_layers):
+            if self._truncate_tail_len > 0 and i == self._truncate_split_layer:
+                seq_lengths = x_offsets[1:] - x_offsets[:-1]
+                plan = compute_stu_truncation_plan(
+                    x_offsets=x_offsets,
+                    seq_lengths=seq_lengths,
+                    num_targets=num_targets,
+                    max_seq_len=max_seq_len,
+                    truncate_tail_len=self._truncate_tail_len,
+                    contextual_seq_len=self._contextual_seq_len,
+                    kernel=self.kernel(),
+                )
+                x = apply_stu_truncation_plan(x, plan)
+                x_offsets = plan.new_x_offsets
+                max_seq_len = plan.new_max_seq_len
+                # Invalidate the SLA cache: offsets / total_q have
+                # changed, so the previous func tensor is stale.  The
+                # next layer's cache-miss path will rebuild against the
+                # truncated layout.
+                prev_attn_func = None
+                prev_attn_func_sig = None
             x, prev_attn_func, prev_attn_func_sig = layer(
                 x=x,
                 x_offsets=x_offsets,
@@ -641,7 +718,7 @@ class STUStack(BaseModule):
                 prev_attn_func=prev_attn_func,
                 prev_attn_func_sig=prev_attn_func_sig,
             )
-        return x
+        return x, x_offsets, max_seq_len, plan
 
     def cached_forward(
         self,
@@ -661,6 +738,17 @@ class STUStack(BaseModule):
         Returns:
             torch.Tensor: output sequence embedding tensor.
         """
+        if self._truncate_tail_len > 0 and self._truncate_split_layer > 0:
+            # The cached / delta path operates per-layer on a rolling KV
+            # cache; mid-stack truncation would drop UIH prefix tokens that
+            # post-truncation layers still reference via the cache, causing
+            # train/serve skew.  Refuse the config rather than silently
+            # diverge -- proper support is a follow-up.
+            raise NotImplementedError(
+                "STUStack attention truncation is not supported in "
+                "cached_forward (serving path). Either disable truncation "
+                "or use the non-cached forward path."
+            )
         for layer in self._stu_layers:
             delta_x = layer.cached_forward(
                 delta_x=delta_x,

--- a/tzrec/modules/gr/stu.py
+++ b/tzrec/modules/gr/stu.py
@@ -102,11 +102,11 @@ class STU(BaseModule, abc.ABC):
         max_kv_caching_len: int = 0,
         kv_caching_lengths: Optional[torch.Tensor] = None,
         prev_attn_func: Optional[torch.Tensor] = None,
-        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None,
+        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool, int]] = None,
     ) -> Tuple[
         torch.Tensor,
         Optional[torch.Tensor],
-        Optional[Tuple[int, int, int, int, bool]],
+        Optional[Tuple[int, int, int, int, bool, int]],
     ]:
         """Forward the layer.
 
@@ -120,16 +120,16 @@ class STU(BaseModule, abc.ABC):
             prev_attn_func (Optional[torch.Tensor]): SLA NFUNC mask tensor
                 produced by the previous layer in the stack, available for
                 reuse when the current layer's signature matches.
-            prev_attn_func_sig (Optional[Tuple[int,int,int,int,bool]]):
+            prev_attn_func_sig (Optional[Tuple[int,int,int,int,bool,int]]):
                 signature ``(sla_k1, sla_k2, contextual_seq_len, num_heads,
-                target_aware)`` describing the SLA config that produced
-                ``prev_attn_func``.
+                target_aware, total_q)`` describing the SLA config and
+                jagged token count that produced ``prev_attn_func``.
+                Including ``total_q`` ensures the cache invalidates
+                automatically when offsets / token count change mid-stack
+                (e.g. after attention truncation).
 
         Returns:
-            Tuple of ``(output, attn_func, attn_func_sig)``.  The sig
-            does not encode offsets / num_targets identity; reuse
-            assumes all layers in one stack forward see the same
-            offsets.
+            Tuple of ``(output, attn_func, attn_func_sig)``.
         """
         pass
 
@@ -451,11 +451,11 @@ class STULayer(STU):
         max_kv_caching_len: int = 0,
         kv_caching_lengths: Optional[torch.Tensor] = None,
         prev_attn_func: Optional[torch.Tensor] = None,
-        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None,
+        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool, int]] = None,
     ) -> Tuple[
         torch.Tensor,
         Optional[torch.Tensor],
-        Optional[Tuple[int, int, int, int, bool]],
+        Optional[Tuple[int, int, int, int, bool, int]],
     ]:
         """Forward the layer.
 
@@ -468,15 +468,18 @@ class STULayer(STU):
             kv_caching_lengths (Optional[torch.Tensor]): key-value caching lengths.
             prev_attn_func (Optional[torch.Tensor]): SLA NFUNC mask
                 from the previous layer; reused if sig matches.
-            prev_attn_func_sig (Optional[Tuple[int,int,int,int,bool]]):
+            prev_attn_func_sig (Optional[Tuple[int,int,int,int,bool,int]]):
                 ``(sla_k1, sla_k2, contextual_seq_len, num_heads,
-                target_aware)`` of ``prev_attn_func``.
+                target_aware, total_q)`` of ``prev_attn_func``.  The
+                trailing ``total_q`` makes the cache automatically
+                invalidate when ``x.size(0)`` changes mid-stack
+                (e.g. across an attention-truncation boundary).
 
         Returns:
             ``(output, attn_func, attn_func_sig)``.
         """
         attn_func: Optional[torch.Tensor] = None
-        attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None
+        attn_func_sig: Optional[Tuple[int, int, int, int, bool, int]] = None
         uses_sla = self._sla_k1 > 0 or self._sla_k2 > 0
         if uses_sla:
             if self.kernel() == Kernel.TRITON:
@@ -484,12 +487,13 @@ class STULayer(STU):
                     "SLA (sla_k1 / sla_k2 > 0) requires Kernel.CUTLASS or "
                     "Kernel.PYTORCH; Kernel.TRITON has no NFUNC mask path."
                 )
-            my_sig: Tuple[int, int, int, int, bool] = (
+            my_sig: Tuple[int, int, int, int, bool, int] = (
                 self._sla_k1,
                 self._sla_k2,
                 self._contextual_seq_len,
                 self._num_heads,
                 self._target_aware,
+                x.size(0),
             )
             if my_sig == prev_attn_func_sig and prev_attn_func is not None:
                 attn_func = prev_attn_func
@@ -719,7 +723,7 @@ class STUStack(BaseModule):
         """
         plan: Optional[STUTruncationPlan] = None
         prev_attn_func: Optional[torch.Tensor] = None
-        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool]] = None
+        prev_attn_func_sig: Optional[Tuple[int, int, int, int, bool, int]] = None
         for i, layer in enumerate(self._stu_layers):
             if self._truncate_tail_len > 0 and i == self._truncate_split_layer:
                 x, x_offsets, max_seq_len, plan = layer.truncate_input(
@@ -729,9 +733,9 @@ class STUStack(BaseModule):
                     num_targets,
                     truncate_tail_len=self._truncate_tail_len,
                 )
-                # SLA cache keyed on offsets / total_q; both changed.
-                prev_attn_func = None
-                prev_attn_func_sig = None
+                # No manual cache reset: total_q in the sig changes after
+                # truncation, so the next layer's sig comparison naturally
+                # misses and rebuilds the func tensor.
             x, prev_attn_func, prev_attn_func_sig = layer(
                 x=x,
                 x_offsets=x_offsets,

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -384,7 +384,7 @@ class StuTest(unittest.TestCase):
         ).requires_grad_(True)
 
         # default forward().
-        ref_y = stu(
+        ref_y, _, _, _ = stu(
             x=x,
             x_offsets=x_offsets,
             max_seq_len=max_seq_len,

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -11,7 +11,7 @@
 
 import copy
 import unittest
-from typing import List, Optional
+from typing import List
 
 import torch
 from hypothesis import Verbosity, given, settings
@@ -19,26 +19,7 @@ from hypothesis import strategies as st
 from parameterized import parameterized
 
 from tzrec.ops import Kernel
-from tzrec.utils.test_util import gpu_unavailable
-
-
-def _expected_truncation_lengths(
-    lengths: List[int],
-    targets: Optional[List[int]],
-    truncate_tail_len: int,
-    contextual_seq_len: int = 0,
-    enabled: bool = True,
-) -> List[int]:
-    """Reference computation of post-truncation per-sample lengths."""
-    if not enabled:
-        return list(lengths)
-    out: List[int] = []
-    for i, length in enumerate(lengths):
-        t = targets[i] if targets is not None else 0
-        u = length - contextual_seq_len - t
-        new_uih = max(0, min(u, truncate_tail_len))
-        out.append(contextual_seq_len + new_uih + t)
-    return out
+from tzrec.utils.test_util import gpu_unavailable, reference_stu_truncation
 
 
 def _inplace_swap(
@@ -626,6 +607,20 @@ class STUStackTruncationTest(unittest.TestCase):
                 truncate_split_layer=0,
                 truncate_tail_len=4,
             )
+        # Negative pair: would XOR-equal to False and silently disable.
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=-1,
+                truncate_tail_len=-1,
+            )
+        # Single negative: rejected before the XOR check.
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=-1,
+                truncate_tail_len=4,
+            )
         # Valid: enabled.
         STUStack(stu_list=stu_list, truncate_split_layer=1, truncate_tail_len=4)
         # Valid: disabled (defaults).
@@ -678,9 +673,16 @@ class STUStackTruncationTest(unittest.TestCase):
         out, new_offsets, new_max, plan = self._forward(
             stack, D, x_lengths, num_targets
         )
-        expected_lens = _expected_truncation_lengths(
-            lengths, targets, tail, enabled=(split > 0 and tail > 0)
-        )
+        if split > 0 and tail > 0:
+            offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(x_lengths)
+            _, expected_lens = reference_stu_truncation(
+                torch.zeros(int(offsets[-1].item()), 1),
+                offsets,
+                targets,
+                truncate_tail_len=tail,
+            )
+        else:
+            expected_lens = list(lengths)
         self.assertEqual(plan is not None, expects_plan)
         self.assertEqual((new_offsets[1:] - new_offsets[:-1]).tolist(), expected_lens)
         self.assertEqual(out.size(0), sum(expected_lens))

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -133,13 +133,13 @@ class StuTest(unittest.TestCase):
             dtype=dtype,
         ).requires_grad_(True)
         x_triton = x.clone().detach().requires_grad_()
-        stu_output = stu(
+        stu_output, _, _, _ = stu(
             x=x,
             x_offsets=x_offsets,
             max_seq_len=max_seq_len,
             num_targets=num_targets,
         )
-        stu_triton_output = stu_triton(
+        stu_triton_output, _, _, _ = stu_triton(
             x=x_triton,
             x_offsets=x_offsets,
             max_seq_len=max_seq_len,
@@ -230,7 +230,7 @@ class StuTest(unittest.TestCase):
             device=device,
             dtype=dtype,
         ).requires_grad_(True)
-        stu_output = stu(
+        stu_output, _, _, _ = stu(
             x=x,
             x_offsets=x_offsets,
             max_seq_len=max_seq_len,
@@ -254,7 +254,7 @@ class StuTest(unittest.TestCase):
             swapped_dense_x,
             [x_offsets],
         )[0].requires_grad_(True)
-        swapped_stu_output = stu(
+        swapped_stu_output, _, _, _ = stu(
             x=swapped_x,
             x_offsets=x_offsets,
             max_seq_len=max_seq_len,
@@ -518,6 +518,219 @@ class StuTest(unittest.TestCase):
                 max_seq_len=max_seq_len,
                 num_targets=num_targets,
             )
+
+
+class STUStackTruncationTest(unittest.TestCase):
+    """Cover the mid-stack truncation block in ``STUStack.forward``.
+
+    The truncation branch rewrites ``x`` / ``x_offsets`` / ``max_seq_len``
+    and has no coverage from ``StuTest`` (which leaves ``truncate_*`` at
+    their defaults).
+    """
+
+    _LAYER_KWARGS = dict(
+        embedding_dim=16,
+        num_heads=2,
+        hidden_dim=32,
+        attention_dim=32,
+        output_dropout_ratio=0.0,
+        causal=True,
+        target_aware=True,
+        max_attn_len=None,
+        attn_alpha=None,
+        use_group_norm=False,
+        recompute_normed_x=False,
+        recompute_uvqk=False,
+        recompute_y=False,
+        sort_by_length=False,
+        contextual_seq_len=0,
+        is_inference=False,
+    )
+
+    def _make_stack(
+        self,
+        num_layers: int,
+        truncate_split_layer: int,
+        truncate_tail_len: int,
+        contextual_seq_len: int = 0,
+        sla_k1: int = 0,
+        sla_k2: int = 0,
+    ):
+        from tzrec.modules.gr.stu import STU, STULayer, STUStack
+
+        kwargs = dict(self._LAYER_KWARGS)
+        kwargs["contextual_seq_len"] = contextual_seq_len
+        kwargs["sla_k1"] = sla_k1
+        kwargs["sla_k2"] = sla_k2
+        embedding_dim = kwargs["embedding_dim"]
+        layers: List[STU] = [STULayer(**kwargs) for _ in range(num_layers)]
+        stack = STUStack(
+            stu_list=layers,
+            truncate_split_layer=truncate_split_layer,
+            truncate_tail_len=truncate_tail_len,
+            is_inference=False,
+        )
+        stack.set_kernel(Kernel.PYTORCH)
+        return stack, embedding_dim
+
+    def test_init_validates_split_layer_bounds(self) -> None:
+        """Both bounds + symmetric (only-one-positive rejected)."""
+        from tzrec.modules.gr.stu import STU, STULayer, STUStack
+
+        stu_list: List[STU] = [STULayer(**self._LAYER_KWARGS) for _ in range(3)]
+        # split_layer must be > 0 when tail_len > 0.
+        with self.assertRaises(ValueError):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=0,
+                truncate_tail_len=4,
+            )
+        # split_layer must be < len(stu_list).
+        with self.assertRaises(ValueError):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=3,
+                truncate_tail_len=4,
+            )
+        # Asymmetric: setting split_layer without tail_len.
+        with self.assertRaises(ValueError):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=1,
+                truncate_tail_len=0,
+            )
+        # Asymmetric: setting tail_len without split_layer.
+        with self.assertRaises(ValueError):
+            STUStack(
+                stu_list=stu_list,
+                truncate_split_layer=0,
+                truncate_tail_len=4,
+            )
+        # Valid: enabled.
+        STUStack(stu_list=stu_list, truncate_split_layer=1, truncate_tail_len=4)
+        # Valid: disabled (defaults).
+        STUStack(stu_list=stu_list)
+
+    def _forward(
+        self,
+        stack,
+        embedding_dim: int,
+        x_lengths: torch.Tensor,
+        num_targets,
+    ):
+        x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(x_lengths)
+        total = int(x_offsets[-1].item())
+        x = torch.randn(total, embedding_dim)
+        max_seq_len = int(x_lengths.max().item())
+        return stack(
+            x=x,
+            x_offsets=x_offsets,
+            max_seq_len=max_seq_len,
+            num_targets=num_targets,
+        )
+
+    def test_truncation_applied_when_uih_longer_than_tail(self) -> None:
+        """UIH > tail_len is truncated; targets survive."""
+        stack, D = self._make_stack(
+            num_layers=3, truncate_split_layer=1, truncate_tail_len=8
+        )
+        x_lengths = torch.tensor([12, 20, 5, 30], dtype=torch.int64)
+        num_targets = torch.full((x_lengths.size(0),), 2, dtype=torch.int64)
+        out, new_offsets, new_max_seq_len, plan = self._forward(
+            stack, D, x_lengths, num_targets
+        )
+        # contextual_seq_len == 0; per-sample U_b = L_b - T_b; new_uih =
+        # min(U_b, tail_len); new_len = new_uih + T_b.
+        uih = x_lengths - 2
+        new_uih = torch.clamp(uih, max=8)
+        expected = new_uih + 2
+        new_lengths = new_offsets[1:] - new_offsets[:-1]
+        torch.testing.assert_close(new_lengths, expected)
+        self.assertEqual(out.size(0), int(expected.sum().item()))
+        self.assertEqual(new_max_seq_len, int(expected.max().item()))
+        self.assertIsNotNone(plan)
+
+    def test_truncation_no_op_when_uih_fits(self) -> None:
+        """UIH <= tail_len for every sample: no row dropped."""
+        stack, D = self._make_stack(
+            num_layers=3, truncate_split_layer=1, truncate_tail_len=16
+        )
+        x_lengths = torch.tensor([3, 5, 2], dtype=torch.int64)
+        num_targets = torch.tensor([1, 1, 1], dtype=torch.int64)
+        out, _, new_max_seq_len, plan = self._forward(stack, D, x_lengths, num_targets)
+        self.assertEqual(out.size(0), int(x_lengths.sum().item()))
+        self.assertEqual(new_max_seq_len, int(x_lengths.max().item()))
+        # Plan still returned; just describes a no-op truncation.
+        self.assertIsNotNone(plan)
+
+    def test_return_signature_when_disabled_is_four_tuple(self) -> None:
+        """Truncation disabled → ``(x, x_offsets, max, None)``."""
+        stack, D = self._make_stack(
+            num_layers=2, truncate_split_layer=0, truncate_tail_len=0
+        )
+        x_lengths = torch.tensor([4, 6], dtype=torch.int64)
+        x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(x_lengths)
+        x = torch.randn(int(x_offsets[-1].item()), D)
+        out = stack(
+            x=x,
+            x_offsets=x_offsets,
+            max_seq_len=6,
+            num_targets=torch.tensor([1, 2], dtype=torch.int64),
+        )
+        self.assertEqual(len(out), 4)
+        ret_x, ret_offsets, ret_max, ret_plan = out
+        torch.testing.assert_close(ret_offsets, x_offsets)
+        self.assertEqual(ret_max, 6)
+        self.assertEqual(ret_x.size(0), x.size(0))
+        self.assertIsNone(ret_plan)
+
+    def test_cached_forward_raises_on_truncation(self) -> None:
+        """Train/serve firewall: ``cached_forward`` refuses truncation."""
+        stack, D = self._make_stack(
+            num_layers=3, truncate_split_layer=1, truncate_tail_len=4
+        )
+        delta_x = torch.randn(8, D)
+        num_targets = torch.tensor([2, 2], dtype=torch.int64)
+        with self.assertRaisesRegex(NotImplementedError, "truncation"):
+            stack.cached_forward(
+                delta_x=delta_x,
+                num_targets=num_targets,
+            )
+
+    def test_truncation_with_num_targets_none(self) -> None:
+        """Listwise mode: ``num_targets=None`` + truncation works."""
+        stack, D = self._make_stack(
+            num_layers=3, truncate_split_layer=1, truncate_tail_len=8
+        )
+        x_lengths = torch.tensor([12, 20, 5, 30], dtype=torch.int64)
+        out, new_offsets, _, plan = self._forward(stack, D, x_lengths, None)
+        # Listwise: entire sequence is "UIH" (no targets to preserve).
+        expected = torch.clamp(x_lengths, max=8)
+        new_lengths = new_offsets[1:] - new_offsets[:-1]
+        torch.testing.assert_close(new_lengths, expected)
+        self.assertEqual(out.size(0), int(expected.sum().item()))
+        self.assertIsNotNone(plan)
+
+    def test_truncation_with_sla_runs(self) -> None:
+        """SLA-enabled stack with truncation produces a finite output.
+
+        Ensures that resetting ``prev_attn_func`` across the truncation
+        boundary lets the next layer's cache-miss path rebuild the SLA
+        func tensor against the truncated offsets without crashing.
+        """
+        stack, D = self._make_stack(
+            num_layers=3,
+            truncate_split_layer=1,
+            truncate_tail_len=6,
+            sla_k1=4,
+            sla_k2=2,
+        )
+        x_lengths = torch.tensor([16, 20, 8], dtype=torch.int64)
+        num_targets = torch.tensor([2, 2, 2], dtype=torch.int64)
+        out, new_offsets, _, plan = self._forward(stack, D, x_lengths, num_targets)
+        self.assertIsNotNone(plan)
+        self.assertTrue(torch.isfinite(out).all())
+        self.assertEqual(out.size(0), int(new_offsets[-1].item()))
 
 
 if __name__ == "__main__":

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -16,6 +16,7 @@ from typing import List
 import torch
 from hypothesis import Verbosity, given, settings
 from hypothesis import strategies as st
+from parameterized import parameterized
 
 from tzrec.ops import Kernel
 from tzrec.utils.test_util import gpu_unavailable
@@ -629,60 +630,39 @@ class STUStackTruncationTest(unittest.TestCase):
             num_targets=num_targets,
         )
 
-    def test_truncation_applied_when_uih_longer_than_tail(self) -> None:
-        """UIH > tail_len is truncated; targets survive."""
+    @parameterized.expand(
+        [
+            # split, tail, num_targets, lengths, expects_plan
+            [0, 0, [1, 2], [4, 6], False],  # disabled
+            [1, 8, [2, 2, 2, 2], [12, 20, 5, 30], True],  # truncated
+            [1, 16, [1, 1, 1], [3, 5, 2], True],  # no-op (plan still returned)
+            [1, 8, None, [12, 20, 5, 30], True],  # listwise (num_targets=None)
+        ]
+    )
+    def test_forward_threads_truncation_metadata(
+        self, split, tail, targets, lengths, expects_plan
+    ) -> None:
+        """Stack returns ``(x, offsets, max, plan)`` and threads num_targets.
+
+        Helper-level tests verify the offset arithmetic; this confirms the
+        stack invokes truncation at split_layer and returns plan iff enabled.
+        """
         stack, D = self._make_stack(
-            num_layers=3, truncate_split_layer=1, truncate_tail_len=8
+            num_layers=3, truncate_split_layer=split, truncate_tail_len=tail
         )
-        x_lengths = torch.tensor([12, 20, 5, 30], dtype=torch.int64)
-        num_targets = torch.full((x_lengths.size(0),), 2, dtype=torch.int64)
-        out, new_offsets, new_max_seq_len, plan = self._forward(
+        x_lengths = torch.tensor(lengths, dtype=torch.int64)
+        num_targets = (
+            torch.tensor(targets, dtype=torch.int64) if targets is not None else None
+        )
+        out, new_offsets, new_max, plan = self._forward(
             stack, D, x_lengths, num_targets
         )
-        # contextual_seq_len == 0; per-sample U_b = L_b - T_b; new_uih =
-        # min(U_b, tail_len); new_len = new_uih + T_b.
-        uih = x_lengths - 2
-        new_uih = torch.clamp(uih, max=8)
-        expected = new_uih + 2
-        new_lengths = new_offsets[1:] - new_offsets[:-1]
-        torch.testing.assert_close(new_lengths, expected)
-        self.assertEqual(out.size(0), int(expected.sum().item()))
-        self.assertEqual(new_max_seq_len, int(expected.max().item()))
-        self.assertIsNotNone(plan)
-
-    def test_truncation_no_op_when_uih_fits(self) -> None:
-        """UIH <= tail_len for every sample: no row dropped."""
-        stack, D = self._make_stack(
-            num_layers=3, truncate_split_layer=1, truncate_tail_len=16
+        self.assertEqual(plan is not None, expects_plan)
+        self.assertEqual(out.size(0), int(new_offsets[-1].item()))
+        self.assertEqual(
+            new_max,
+            int((new_offsets[1:] - new_offsets[:-1]).max().item()),
         )
-        x_lengths = torch.tensor([3, 5, 2], dtype=torch.int64)
-        num_targets = torch.tensor([1, 1, 1], dtype=torch.int64)
-        out, _, new_max_seq_len, plan = self._forward(stack, D, x_lengths, num_targets)
-        self.assertEqual(out.size(0), int(x_lengths.sum().item()))
-        self.assertEqual(new_max_seq_len, int(x_lengths.max().item()))
-        # Plan still returned; just describes a no-op truncation.
-        self.assertIsNotNone(plan)
-
-    def test_return_signature_when_disabled_is_four_tuple(self) -> None:
-        """Truncation disabled → ``(x, x_offsets, max, None)``."""
-        stack, D = self._make_stack(
-            num_layers=2, truncate_split_layer=0, truncate_tail_len=0
-        )
-        x_lengths = torch.tensor([4, 6], dtype=torch.int64)
-        x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(x_lengths)
-        x = torch.randn(int(x_offsets[-1].item()), D)
-        out = stack(
-            x=x,
-            x_offsets=x_offsets,
-            max_seq_len=6,
-            num_targets=torch.tensor([1, 2], dtype=torch.int64),
-        )
-        self.assertEqual(len(out), 4)
-        ret_x, ret_offsets, ret_max, ret_plan = out
-        torch.testing.assert_close(ret_offsets, x_offsets)
-        self.assertEqual(ret_max, 6)
-        self.assertEqual(ret_x.size(0), x.size(0))
-        self.assertIsNone(ret_plan)
 
     def test_cached_forward_raises_on_truncation(self) -> None:
         """Train/serve firewall: ``cached_forward`` refuses truncation."""
@@ -696,20 +676,6 @@ class STUStackTruncationTest(unittest.TestCase):
                 delta_x=delta_x,
                 num_targets=num_targets,
             )
-
-    def test_truncation_with_num_targets_none(self) -> None:
-        """Listwise mode: ``num_targets=None`` + truncation works."""
-        stack, D = self._make_stack(
-            num_layers=3, truncate_split_layer=1, truncate_tail_len=8
-        )
-        x_lengths = torch.tensor([12, 20, 5, 30], dtype=torch.int64)
-        out, new_offsets, _, plan = self._forward(stack, D, x_lengths, None)
-        # Listwise: entire sequence is "UIH" (no targets to preserve).
-        expected = torch.clamp(x_lengths, max=8)
-        new_lengths = new_offsets[1:] - new_offsets[:-1]
-        torch.testing.assert_close(new_lengths, expected)
-        self.assertEqual(out.size(0), int(expected.sum().item()))
-        self.assertIsNotNone(plan)
 
     def test_truncation_with_sla_runs(self) -> None:
         """SLA-enabled stack with truncation produces a finite output.

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -11,7 +11,7 @@
 
 import copy
 import unittest
-from typing import List
+from typing import List, Optional
 
 import torch
 from hypothesis import Verbosity, given, settings
@@ -20,6 +20,25 @@ from parameterized import parameterized
 
 from tzrec.ops import Kernel
 from tzrec.utils.test_util import gpu_unavailable
+
+
+def _expected_truncation_lengths(
+    lengths: List[int],
+    targets: Optional[List[int]],
+    truncate_tail_len: int,
+    contextual_seq_len: int = 0,
+    enabled: bool = True,
+) -> List[int]:
+    """Reference computation of post-truncation per-sample lengths."""
+    if not enabled:
+        return list(lengths)
+    out: List[int] = []
+    for i, length in enumerate(lengths):
+        t = targets[i] if targets is not None else 0
+        u = length - contextual_seq_len - t
+        new_uih = max(0, min(u, truncate_tail_len))
+        out.append(contextual_seq_len + new_uih + t)
+    return out
 
 
 def _inplace_swap(
@@ -644,8 +663,10 @@ class STUStackTruncationTest(unittest.TestCase):
     ) -> None:
         """Stack returns ``(x, offsets, max, plan)`` and threads num_targets.
 
-        Helper-level tests verify the offset arithmetic; this confirms the
-        stack invokes truncation at split_layer and returns plan iff enabled.
+        Asserts post-truncation lengths against an independent Python
+        reference, so a regression that silently corrupts ``x``'s row
+        count fails (the trivial ``out.size(0) == new_offsets[-1]``
+        identity would otherwise pass).
         """
         stack, D = self._make_stack(
             num_layers=3, truncate_split_layer=split, truncate_tail_len=tail
@@ -657,12 +678,13 @@ class STUStackTruncationTest(unittest.TestCase):
         out, new_offsets, new_max, plan = self._forward(
             stack, D, x_lengths, num_targets
         )
-        self.assertEqual(plan is not None, expects_plan)
-        self.assertEqual(out.size(0), int(new_offsets[-1].item()))
-        self.assertEqual(
-            new_max,
-            int((new_offsets[1:] - new_offsets[:-1]).max().item()),
+        expected_lens = _expected_truncation_lengths(
+            lengths, targets, tail, enabled=(split > 0 and tail > 0)
         )
+        self.assertEqual(plan is not None, expects_plan)
+        self.assertEqual((new_offsets[1:] - new_offsets[:-1]).tolist(), expected_lens)
+        self.assertEqual(out.size(0), sum(expected_lens))
+        self.assertEqual(new_max, max(expected_lens))
 
     def test_cached_forward_raises_on_truncation(self) -> None:
         """Train/serve firewall: ``cached_forward`` refuses truncation."""

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -231,7 +231,9 @@ def compute_stu_truncation_plan(
             * contextual_seq_len
         )
         offsets_rest = x_offsets - offsets_prefix
-        new_x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(new_lengths)
+        # ``new_lengths_b = C + rest_tail_lengths_b`` so cumsum(new_lengths)
+        # equals offsets_prefix + offsets_tail; saves one cumsum kernel.
+        new_x_offsets = offsets_prefix + offsets_tail
     else:
         offsets_prefix = None
         offsets_rest = None
@@ -252,7 +254,7 @@ def compute_stu_truncation_plan(
 def apply_stu_truncation_plan(
     x: torch.Tensor,
     plan: STUTruncationPlan,
-    kernel: Kernel = Kernel.PYTORCH,
+    kernel: Kernel,
 ) -> torch.Tensor:
     """Apply a precomputed truncation plan to a jagged tensor.
 
@@ -315,7 +317,7 @@ def apply_stu_truncation(
     *,
     truncate_tail_len: int,
     contextual_seq_len: int = 0,
-    kernel: Kernel = Kernel.PYTORCH,
+    kernel: Kernel,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
     """Truncate the UIH portion of each jagged sample to ``truncate_tail_len``.
 

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -139,9 +139,8 @@ class STUTruncationPlan:
     redoing the offset arithmetic or paying a second D->H sync.
 
     Fields:
+        new_lengths: per-sample lengths after truncation, shape ``(B,)``.
         new_x_offsets: cumulative offsets after truncation, shape ``(B+1,)``.
-            Per-sample new lengths recoverable as ``new_x_offsets[1:] -
-            new_x_offsets[:-1]``.
         new_max_seq_len: tight post-truncation ``max(new_lengths)``.  This
             is the only D->H sync on the truncation path.
         pre_max_seq_len: input ``max_seq_len`` before truncation; needed
@@ -158,6 +157,7 @@ class STUTruncationPlan:
             shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
     """
 
+    new_lengths: torch.Tensor
     new_x_offsets: torch.Tensor
     new_max_seq_len: int
     pre_max_seq_len: int
@@ -237,6 +237,7 @@ def compute_stu_truncation_plan(
         offsets_rest = None
         new_x_offsets = offsets_tail
     return STUTruncationPlan(
+        new_lengths=new_lengths,
         new_x_offsets=new_x_offsets,
         new_max_seq_len=int(new_lengths.max().item()),
         pre_max_seq_len=max_seq_len,
@@ -351,5 +352,4 @@ def apply_stu_truncation(
         contextual_seq_len=contextual_seq_len,
     )
     x = apply_stu_truncation_plan(x, plan, kernel=kernel)
-    new_lengths = plan.new_x_offsets[1:] - plan.new_x_offsets[:-1]
-    return x, plan.new_x_offsets, new_lengths, plan.new_max_seq_len
+    return x, plan.new_x_offsets, plan.new_lengths, plan.new_max_seq_len

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -9,17 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backend-agnostic helpers for HSTU attention.
-
-Contains mask / func-tensor builders that feed the ``attn_func`` input of
-``hstu_mha`` / ``cutlass_hstu_mha`` / ``pytorch_hstu_mha``, plus the
-mid-stack attention-truncation helpers (``STUTruncationPlan``,
-``compute_stu_truncation_plan``, ``apply_stu_truncation_plan``,
-``apply_stu_truncation``).  The helpers themselves have no
-kernel-specific dependencies: the ``attn_func`` NFUNC=3 layout is shared
-between the CUTLASS production path and the PyTorch reference path, and
-the truncation helpers wrap the existing jagged split / concat ops.
-"""
+"""Backend-agnostic helpers for HSTU attention: SLA mask builder + truncation."""
 
 from dataclasses import dataclass
 from typing import Optional, Tuple
@@ -130,31 +120,23 @@ def build_sla_func_tensor(
 
 @dataclass(frozen=True)
 class STUTruncationPlan:
-    """Precomputed offsets describing a UIH-only truncation of a jagged batch.
-
-    Produced by :func:`compute_stu_truncation_plan` and consumed by
-    :func:`apply_stu_truncation_plan`, so the same split can be replayed
-    on multiple jagged tensors that share the same ``(B, seq_lengths)``
-    layout (e.g. token embeddings + their parallel timestamps) without
-    redoing the offset arithmetic or paying a second D->H sync.
+    """Precomputed offsets for a UIH-only truncation, replayable across tensors.
 
     Fields:
         new_lengths: per-sample lengths after truncation, shape ``(B,)``.
         new_x_offsets: cumulative offsets after truncation, shape ``(B+1,)``.
-        new_max_seq_len: tight post-truncation ``max(new_lengths)``.  This
-            is the only D->H sync on the truncation path.
-        pre_max_seq_len: input ``max_seq_len`` before truncation; needed
-            by ``split_2D_jagged`` calls in :func:`apply_stu_truncation_plan`.
-        contextual_seq_len: number of leading contextual tokens preserved
-            uniformly across the batch.
+        new_max_seq_len: tight post-truncation ``max(new_lengths)``;
+            only D->H sync on the truncation path.
+        pre_max_seq_len: input ``max_seq_len`` before truncation.
+        contextual_seq_len: leading contextual tokens preserved uniformly.
         offsets_head: cumulative drop counts, shape ``(B+1,)``.
-        offsets_tail: post-truncation offsets into the
-            contextual-stripped subsequence, shape ``(B+1,)``.  Equals
-            ``new_x_offsets`` when ``contextual_seq_len == 0``.
-        offsets_prefix: cumulative offsets of the contextual prefix,
-            shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
-        offsets_rest: cumulative offsets of the post-prefix subsequence,
-            shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
+        offsets_tail: post-truncation offsets into the contextual-stripped
+            subsequence; equals ``new_x_offsets`` when
+            ``contextual_seq_len == 0``.
+        offsets_prefix: contextual-prefix cumulative offsets ``(B+1,)``;
+            only set when ``contextual_seq_len > 0``.
+        offsets_rest: post-prefix cumulative offsets ``(B+1,)``;
+            only set when ``contextual_seq_len > 0``.
     """
 
     new_lengths: torch.Tensor

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -12,7 +12,7 @@
 """Backend-agnostic helpers for HSTU attention: SLA mask builder + truncation."""
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -289,51 +289,3 @@ def apply_stu_truncation_plan(
         kernel=kernel,
     )
     return x_kept
-
-
-def apply_stu_truncation(
-    x: torch.Tensor,
-    x_offsets: torch.Tensor,
-    num_targets: Optional[torch.Tensor],
-    max_seq_len: int,
-    *,
-    truncate_tail_len: int,
-    contextual_seq_len: int = 0,
-    kernel: Kernel,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
-    """Truncate the UIH portion of each jagged sample to ``truncate_tail_len``.
-
-    Sample layout is ``[contextual(C) | UIH(U_b) | targets(T_b)]`` with
-    ``L_b = C + U_b + T_b``.  ``truncate_tail_len`` caps the UIH portion
-    only; contextual prefix and all targets are preserved.
-
-    Thin wrapper around :func:`compute_stu_truncation_plan` +
-    :func:`apply_stu_truncation_plan`; callers that need to apply the
-    same truncation to multiple jagged tensors (e.g. ``x`` and a parallel
-    timestamp tensor) should call those two directly to avoid recomputing
-    the plan.
-
-    Args:
-        x: jagged values of shape ``(total, D)``.
-        x_offsets: cumulative offsets ``(B + 1,)``.
-        num_targets: per-sample target counts ``(B,)`` or ``None``.
-        max_seq_len: padded max length of the input batch.
-        truncate_tail_len: maximum UIH tokens kept per sample.  Must be
-            non-negative; ``0`` drops all UIH.
-        contextual_seq_len: number of leading contextual tokens to
-            preserve (uniform across the batch).
-        kernel: backend for the underlying jagged ops.
-
-    Returns:
-        ``(x, new_x_offsets, new_lengths, new_max_seq_len)`` with
-        post-truncation values.
-    """
-    plan = compute_stu_truncation_plan(
-        x_offsets=x_offsets,
-        num_targets=num_targets,
-        max_seq_len=max_seq_len,
-        truncate_tail_len=truncate_tail_len,
-        contextual_seq_len=contextual_seq_len,
-    )
-    x = apply_stu_truncation_plan(x, plan, kernel=kernel)
-    return x, plan.new_x_offsets, plan.new_lengths, plan.new_max_seq_len

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -12,15 +12,22 @@
 """Backend-agnostic helpers for HSTU attention.
 
 Contains mask / func-tensor builders that feed the ``attn_func`` input of
-``hstu_mha`` / ``cutlass_hstu_mha`` / ``pytorch_hstu_mha``.  The helpers
-themselves have no kernel-specific dependencies: the ``attn_func`` NFUNC=3
-layout is shared between the CUTLASS production path and the PyTorch
-reference path.
+``hstu_mha`` / ``cutlass_hstu_mha`` / ``pytorch_hstu_mha``, plus the
+mid-stack attention-truncation helpers (``STUTruncationPlan``,
+``compute_stu_truncation_plan``, ``apply_stu_truncation_plan``,
+``apply_stu_truncation``).  The helpers themselves have no
+kernel-specific dependencies: the ``attn_func`` NFUNC=3 layout is shared
+between the CUTLASS production path and the PyTorch reference path, and
+the truncation helpers wrap the existing jagged split / concat ops.
 """
 
-from typing import Optional
+from dataclasses import dataclass
+from typing import Optional, Tuple
 
 import torch
+
+from tzrec.ops import Kernel
+from tzrec.ops.jagged_tensors import concat_2D_jagged, split_2D_jagged
 
 
 def build_sla_func_tensor(
@@ -119,3 +126,253 @@ def build_sla_func_tensor(
 
     func_2d = torch.stack([col_max0, col_min0, col_max1], dim=0)  # (3, total_q)
     return func_2d.unsqueeze(0).expand(nheads, 3, total_q)
+
+
+@dataclass(frozen=True)
+class STUTruncationPlan:
+    """Precomputed offsets describing a UIH-only truncation of a jagged batch.
+
+    Produced by :func:`compute_stu_truncation_plan` and consumed by
+    :func:`apply_stu_truncation_plan`, so the same split can be replayed
+    on multiple jagged tensors that share the same ``(B, seq_lengths)``
+    layout (e.g. token embeddings + their parallel timestamps) without
+    redoing the offset arithmetic or paying a second D->H sync.
+
+    Fields:
+        new_lengths: per-sample lengths after truncation, shape ``(B,)``.
+        new_x_offsets: cumulative offsets after truncation, shape ``(B+1,)``.
+        new_max_seq_len: tight post-truncation ``max(new_lengths)``.  This
+            is the only D->H sync on the truncation path.
+        pre_max_seq_len: input ``max_seq_len`` before truncation; needed
+            by ``split_2D_jagged`` calls in :func:`apply_stu_truncation_plan`.
+        contextual_seq_len: number of leading contextual tokens preserved
+            uniformly across the batch.
+        kernel: backend used for the underlying jagged ops.
+        offsets_head: cumulative drop counts, shape ``(B+1,)``.  When
+            ``contextual_seq_len == 0`` this is fed directly to
+            ``split_2D_jagged`` as ``offsets_left``; otherwise it indexes
+            into the contextual-stripped subsequence.
+        offsets_tail: post-truncation offsets into ``x`` (when no
+            contextual prefix) or into the contextual-stripped subsequence
+            (otherwise).  Equals ``new_x_offsets`` when
+            ``contextual_seq_len == 0``.
+        offsets_prefix: cumulative offsets of the contextual prefix,
+            shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
+        offsets_rest: cumulative offsets of the post-prefix subsequence,
+            shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
+    """
+
+    new_lengths: torch.Tensor
+    new_x_offsets: torch.Tensor
+    new_max_seq_len: int
+    pre_max_seq_len: int
+    contextual_seq_len: int
+    kernel: Kernel
+    offsets_head: torch.Tensor
+    offsets_tail: torch.Tensor
+    offsets_prefix: Optional[torch.Tensor] = None
+    offsets_rest: Optional[torch.Tensor] = None
+
+
+def compute_stu_truncation_plan(
+    x_offsets: torch.Tensor,
+    seq_lengths: torch.Tensor,
+    num_targets: Optional[torch.Tensor],
+    max_seq_len: int,
+    *,
+    truncate_tail_len: int,
+    contextual_seq_len: int = 0,
+    kernel: Kernel = Kernel.PYTORCH,
+) -> STUTruncationPlan:
+    """Compute the offset / length math for a UIH-only truncation.
+
+    No jagged-value moves happen here -- the returned plan can be applied
+    to any number of jagged tensors that share the same ``(B,
+    seq_lengths)`` layout via :func:`apply_stu_truncation_plan`.
+
+    Sample layout is ``[contextual(C) | UIH(U_b) | targets(T_b)]`` with
+    ``L_b = C + U_b + T_b``.  ``truncate_tail_len`` caps the UIH portion
+    only; the contextual prefix and all targets are preserved as full
+    structural elements.
+
+    Args:
+        x_offsets: cumulative offsets ``(B + 1,)`` (used for the prefix
+            split when ``contextual_seq_len > 0``).
+        seq_lengths: per-sample lengths ``(B,)``.
+        num_targets: per-sample target counts ``(B,)`` or ``None``
+            (listwise mode -- the entire sample counts as UIH).
+        max_seq_len: padded max length of the input batch.
+        truncate_tail_len: maximum UIH tokens kept per sample.  Must be
+            non-negative; ``0`` drops all UIH (only contextual + targets
+            survive).
+        contextual_seq_len: number of leading contextual tokens preserved
+            uniformly across the batch.
+        kernel: backend used by ``apply_stu_truncation_plan`` for the
+            split / concat operations.
+
+    Returns:
+        A :class:`STUTruncationPlan`.  Contains one D->H sync to compute
+        the tight ``new_max_seq_len``.
+    """
+    if truncate_tail_len < 0:
+        raise ValueError(
+            f"truncate_tail_len must be non-negative; got {truncate_tail_len}"
+        )
+    if contextual_seq_len < 0:
+        raise ValueError(
+            f"contextual_seq_len must be non-negative; got {contextual_seq_len}"
+        )
+    if num_targets is not None:
+        uih_lengths = seq_lengths - contextual_seq_len - num_targets
+    else:
+        uih_lengths = seq_lengths - contextual_seq_len
+    new_uih_lengths = torch.clamp(uih_lengths, max=truncate_tail_len)
+    drop_count = uih_lengths - new_uih_lengths
+    new_lengths = seq_lengths - drop_count
+
+    if contextual_seq_len > 0:
+        B = seq_lengths.size(0)
+        offsets_prefix = (
+            torch.arange(B + 1, device=seq_lengths.device, dtype=x_offsets.dtype)
+            * contextual_seq_len
+        )
+        offsets_rest = x_offsets - offsets_prefix
+        rest_tail_lengths = new_lengths - contextual_seq_len
+        offsets_head = torch.ops.fbgemm.asynchronous_complete_cumsum(drop_count)
+        offsets_tail = torch.ops.fbgemm.asynchronous_complete_cumsum(rest_tail_lengths)
+        new_x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(new_lengths)
+    else:
+        offsets_prefix = None
+        offsets_rest = None
+        offsets_head = torch.ops.fbgemm.asynchronous_complete_cumsum(drop_count)
+        offsets_tail = torch.ops.fbgemm.asynchronous_complete_cumsum(new_lengths)
+        new_x_offsets = offsets_tail
+    new_max_seq_len = int(new_lengths.max().item())
+    return STUTruncationPlan(
+        new_lengths=new_lengths,
+        new_x_offsets=new_x_offsets,
+        new_max_seq_len=new_max_seq_len,
+        pre_max_seq_len=max_seq_len,
+        contextual_seq_len=contextual_seq_len,
+        kernel=kernel,
+        offsets_head=offsets_head,
+        offsets_tail=offsets_tail,
+        offsets_prefix=offsets_prefix,
+        offsets_rest=offsets_rest,
+    )
+
+
+def apply_stu_truncation_plan(
+    x: torch.Tensor,
+    plan: STUTruncationPlan,
+) -> torch.Tensor:
+    """Apply a precomputed truncation plan to a jagged tensor.
+
+    The plan must come from a call to :func:`compute_stu_truncation_plan`
+    on offsets / lengths that match ``x``'s layout.  Performs no D->H syncs.
+
+    Args:
+        x: jagged values of shape ``(total, D)``.
+        plan: precomputed truncation plan.
+
+    Returns:
+        Post-truncation jagged values of shape
+        ``(plan.new_x_offsets[-1], D)``.
+    """
+    contextual_seq_len = plan.contextual_seq_len
+    pre_max = plan.pre_max_seq_len
+    if contextual_seq_len > 0:
+        offsets_prefix = plan.offsets_prefix
+        offsets_rest = plan.offsets_rest
+        assert offsets_prefix is not None and offsets_rest is not None
+        x_prefix, x_rest = split_2D_jagged(
+            values=x,
+            max_seq_len=pre_max,
+            offsets_left=offsets_prefix,
+            offsets_right=offsets_rest,
+            kernel=plan.kernel,
+        )
+        _, x_rest_kept = split_2D_jagged(
+            values=x_rest,
+            max_seq_len=pre_max - contextual_seq_len,
+            offsets_left=plan.offsets_head,
+            offsets_right=plan.offsets_tail,
+            kernel=plan.kernel,
+        )
+        return concat_2D_jagged(
+            values_left=x_prefix,
+            values_right=x_rest_kept,
+            max_len_left=contextual_seq_len,
+            max_len_right=pre_max - contextual_seq_len,
+            offsets_left=offsets_prefix,
+            offsets_right=plan.offsets_tail,
+            kernel=plan.kernel,
+        )
+    _, x_kept = split_2D_jagged(
+        values=x,
+        max_seq_len=pre_max,
+        offsets_left=plan.offsets_head,
+        offsets_right=plan.offsets_tail,
+        kernel=plan.kernel,
+    )
+    return x_kept
+
+
+def apply_stu_truncation(
+    x: torch.Tensor,
+    x_offsets: torch.Tensor,
+    seq_lengths: torch.Tensor,
+    num_targets: Optional[torch.Tensor],
+    max_seq_len: int,
+    *,
+    truncate_tail_len: int,
+    contextual_seq_len: int = 0,
+    kernel: Kernel = Kernel.PYTORCH,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Truncate the UIH portion of each jagged sample to ``truncate_tail_len``.
+
+    Sample layout is ``[contextual(C) | UIH(U_b) | targets(T_b)]`` with
+    ``L_b = C + U_b + T_b``.  ``truncate_tail_len`` caps the UIH portion
+    only; the contextual prefix and all targets are preserved.
+
+    Per sample:
+      ``new_uih_b = min(U_b, truncate_tail_len)``
+      ``drop_b    = U_b - new_uih_b``
+      ``new_L_b   = C + new_uih_b + T_b  =  L_b - drop_b``
+
+    The kept layout is
+    ``[contextual | last new_uih_b tokens of UIH | targets]``.
+
+    This is a thin wrapper around :func:`compute_stu_truncation_plan` +
+    :func:`apply_stu_truncation_plan`; callers that need to apply the
+    same truncation to multiple jagged tensors (e.g. ``x`` and a parallel
+    timestamp tensor) should call those two directly to avoid recomputing
+    the plan.
+
+    Args:
+        x: jagged values of shape ``(total, D)``.
+        x_offsets: cumulative offsets ``(B + 1,)``.
+        seq_lengths: per-sample lengths ``(B,)``.
+        num_targets: per-sample target counts ``(B,)`` or ``None``.
+        max_seq_len: padded max length of the input batch.
+        truncate_tail_len: maximum UIH tokens kept per sample.  Must be
+            non-negative; ``0`` drops all UIH.
+        contextual_seq_len: number of leading contextual tokens to
+            preserve (uniform across the batch).
+        kernel: backend for the underlying jagged ops.
+
+    Returns:
+        ``(x, new_x_offsets, new_lengths, new_max_seq_len)`` with
+        post-truncation values.
+    """
+    plan = compute_stu_truncation_plan(
+        x_offsets=x_offsets,
+        seq_lengths=seq_lengths,
+        num_targets=num_targets,
+        max_seq_len=max_seq_len,
+        truncate_tail_len=truncate_tail_len,
+        contextual_seq_len=contextual_seq_len,
+        kernel=kernel,
+    )
+    x = apply_stu_truncation_plan(x, plan)
+    return x, plan.new_x_offsets, plan.new_lengths, plan.new_max_seq_len

--- a/tzrec/ops/hstu_attention_utils.py
+++ b/tzrec/ops/hstu_attention_utils.py
@@ -139,35 +139,29 @@ class STUTruncationPlan:
     redoing the offset arithmetic or paying a second D->H sync.
 
     Fields:
-        new_lengths: per-sample lengths after truncation, shape ``(B,)``.
         new_x_offsets: cumulative offsets after truncation, shape ``(B+1,)``.
+            Per-sample new lengths recoverable as ``new_x_offsets[1:] -
+            new_x_offsets[:-1]``.
         new_max_seq_len: tight post-truncation ``max(new_lengths)``.  This
             is the only D->H sync on the truncation path.
         pre_max_seq_len: input ``max_seq_len`` before truncation; needed
             by ``split_2D_jagged`` calls in :func:`apply_stu_truncation_plan`.
         contextual_seq_len: number of leading contextual tokens preserved
             uniformly across the batch.
-        kernel: backend used for the underlying jagged ops.
-        offsets_head: cumulative drop counts, shape ``(B+1,)``.  When
-            ``contextual_seq_len == 0`` this is fed directly to
-            ``split_2D_jagged`` as ``offsets_left``; otherwise it indexes
-            into the contextual-stripped subsequence.
-        offsets_tail: post-truncation offsets into ``x`` (when no
-            contextual prefix) or into the contextual-stripped subsequence
-            (otherwise).  Equals ``new_x_offsets`` when
-            ``contextual_seq_len == 0``.
+        offsets_head: cumulative drop counts, shape ``(B+1,)``.
+        offsets_tail: post-truncation offsets into the
+            contextual-stripped subsequence, shape ``(B+1,)``.  Equals
+            ``new_x_offsets`` when ``contextual_seq_len == 0``.
         offsets_prefix: cumulative offsets of the contextual prefix,
             shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
         offsets_rest: cumulative offsets of the post-prefix subsequence,
             shape ``(B+1,)``; only set when ``contextual_seq_len > 0``.
     """
 
-    new_lengths: torch.Tensor
     new_x_offsets: torch.Tensor
     new_max_seq_len: int
     pre_max_seq_len: int
     contextual_seq_len: int
-    kernel: Kernel
     offsets_head: torch.Tensor
     offsets_tail: torch.Tensor
     offsets_prefix: Optional[torch.Tensor] = None
@@ -176,13 +170,11 @@ class STUTruncationPlan:
 
 def compute_stu_truncation_plan(
     x_offsets: torch.Tensor,
-    seq_lengths: torch.Tensor,
     num_targets: Optional[torch.Tensor],
     max_seq_len: int,
     *,
     truncate_tail_len: int,
     contextual_seq_len: int = 0,
-    kernel: Kernel = Kernel.PYTORCH,
 ) -> STUTruncationPlan:
     """Compute the offset / length math for a UIH-only truncation.
 
@@ -196,9 +188,8 @@ def compute_stu_truncation_plan(
     structural elements.
 
     Args:
-        x_offsets: cumulative offsets ``(B + 1,)`` (used for the prefix
-            split when ``contextual_seq_len > 0``).
-        seq_lengths: per-sample lengths ``(B,)``.
+        x_offsets: cumulative offsets ``(B + 1,)``; per-sample lengths
+            are derived as ``x_offsets[1:] - x_offsets[:-1]``.
         num_targets: per-sample target counts ``(B,)`` or ``None``
             (listwise mode -- the entire sample counts as UIH).
         max_seq_len: padded max length of the input batch.
@@ -207,8 +198,6 @@ def compute_stu_truncation_plan(
             survive).
         contextual_seq_len: number of leading contextual tokens preserved
             uniformly across the batch.
-        kernel: backend used by ``apply_stu_truncation_plan`` for the
-            split / concat operations.
 
     Returns:
         A :class:`STUTruncationPlan`.  Contains one D->H sync to compute
@@ -222,6 +211,7 @@ def compute_stu_truncation_plan(
         raise ValueError(
             f"contextual_seq_len must be non-negative; got {contextual_seq_len}"
         )
+    seq_lengths = x_offsets[1:] - x_offsets[:-1]
     if num_targets is not None:
         uih_lengths = seq_lengths - contextual_seq_len - num_targets
     else:
@@ -229,7 +219,11 @@ def compute_stu_truncation_plan(
     new_uih_lengths = torch.clamp(uih_lengths, max=truncate_tail_len)
     drop_count = uih_lengths - new_uih_lengths
     new_lengths = seq_lengths - drop_count
-
+    # ``rest_tail_lengths`` collapses to ``new_lengths`` when C == 0, so
+    # both branches share the same offsets math.
+    rest_tail_lengths = new_lengths - contextual_seq_len
+    offsets_head = torch.ops.fbgemm.asynchronous_complete_cumsum(drop_count)
+    offsets_tail = torch.ops.fbgemm.asynchronous_complete_cumsum(rest_tail_lengths)
     if contextual_seq_len > 0:
         B = seq_lengths.size(0)
         offsets_prefix = (
@@ -237,24 +231,16 @@ def compute_stu_truncation_plan(
             * contextual_seq_len
         )
         offsets_rest = x_offsets - offsets_prefix
-        rest_tail_lengths = new_lengths - contextual_seq_len
-        offsets_head = torch.ops.fbgemm.asynchronous_complete_cumsum(drop_count)
-        offsets_tail = torch.ops.fbgemm.asynchronous_complete_cumsum(rest_tail_lengths)
         new_x_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(new_lengths)
     else:
         offsets_prefix = None
         offsets_rest = None
-        offsets_head = torch.ops.fbgemm.asynchronous_complete_cumsum(drop_count)
-        offsets_tail = torch.ops.fbgemm.asynchronous_complete_cumsum(new_lengths)
         new_x_offsets = offsets_tail
-    new_max_seq_len = int(new_lengths.max().item())
     return STUTruncationPlan(
-        new_lengths=new_lengths,
         new_x_offsets=new_x_offsets,
-        new_max_seq_len=new_max_seq_len,
+        new_max_seq_len=int(new_lengths.max().item()),
         pre_max_seq_len=max_seq_len,
         contextual_seq_len=contextual_seq_len,
-        kernel=kernel,
         offsets_head=offsets_head,
         offsets_tail=offsets_tail,
         offsets_prefix=offsets_prefix,
@@ -265,6 +251,7 @@ def compute_stu_truncation_plan(
 def apply_stu_truncation_plan(
     x: torch.Tensor,
     plan: STUTruncationPlan,
+    kernel: Kernel = Kernel.PYTORCH,
 ) -> torch.Tensor:
     """Apply a precomputed truncation plan to a jagged tensor.
 
@@ -274,6 +261,7 @@ def apply_stu_truncation_plan(
     Args:
         x: jagged values of shape ``(total, D)``.
         plan: precomputed truncation plan.
+        kernel: backend for the underlying jagged ops.
 
     Returns:
         Post-truncation jagged values of shape
@@ -290,14 +278,14 @@ def apply_stu_truncation_plan(
             max_seq_len=pre_max,
             offsets_left=offsets_prefix,
             offsets_right=offsets_rest,
-            kernel=plan.kernel,
+            kernel=kernel,
         )
         _, x_rest_kept = split_2D_jagged(
             values=x_rest,
             max_seq_len=pre_max - contextual_seq_len,
             offsets_left=plan.offsets_head,
             offsets_right=plan.offsets_tail,
-            kernel=plan.kernel,
+            kernel=kernel,
         )
         return concat_2D_jagged(
             values_left=x_prefix,
@@ -306,14 +294,14 @@ def apply_stu_truncation_plan(
             max_len_right=pre_max - contextual_seq_len,
             offsets_left=offsets_prefix,
             offsets_right=plan.offsets_tail,
-            kernel=plan.kernel,
+            kernel=kernel,
         )
     _, x_kept = split_2D_jagged(
         values=x,
         max_seq_len=pre_max,
         offsets_left=plan.offsets_head,
         offsets_right=plan.offsets_tail,
-        kernel=plan.kernel,
+        kernel=kernel,
     )
     return x_kept
 
@@ -321,7 +309,6 @@ def apply_stu_truncation_plan(
 def apply_stu_truncation(
     x: torch.Tensor,
     x_offsets: torch.Tensor,
-    seq_lengths: torch.Tensor,
     num_targets: Optional[torch.Tensor],
     max_seq_len: int,
     *,
@@ -333,17 +320,9 @@ def apply_stu_truncation(
 
     Sample layout is ``[contextual(C) | UIH(U_b) | targets(T_b)]`` with
     ``L_b = C + U_b + T_b``.  ``truncate_tail_len`` caps the UIH portion
-    only; the contextual prefix and all targets are preserved.
+    only; contextual prefix and all targets are preserved.
 
-    Per sample:
-      ``new_uih_b = min(U_b, truncate_tail_len)``
-      ``drop_b    = U_b - new_uih_b``
-      ``new_L_b   = C + new_uih_b + T_b  =  L_b - drop_b``
-
-    The kept layout is
-    ``[contextual | last new_uih_b tokens of UIH | targets]``.
-
-    This is a thin wrapper around :func:`compute_stu_truncation_plan` +
+    Thin wrapper around :func:`compute_stu_truncation_plan` +
     :func:`apply_stu_truncation_plan`; callers that need to apply the
     same truncation to multiple jagged tensors (e.g. ``x`` and a parallel
     timestamp tensor) should call those two directly to avoid recomputing
@@ -352,7 +331,6 @@ def apply_stu_truncation(
     Args:
         x: jagged values of shape ``(total, D)``.
         x_offsets: cumulative offsets ``(B + 1,)``.
-        seq_lengths: per-sample lengths ``(B,)``.
         num_targets: per-sample target counts ``(B,)`` or ``None``.
         max_seq_len: padded max length of the input batch.
         truncate_tail_len: maximum UIH tokens kept per sample.  Must be
@@ -367,12 +345,11 @@ def apply_stu_truncation(
     """
     plan = compute_stu_truncation_plan(
         x_offsets=x_offsets,
-        seq_lengths=seq_lengths,
         num_targets=num_targets,
         max_seq_len=max_seq_len,
         truncate_tail_len=truncate_tail_len,
         contextual_seq_len=contextual_seq_len,
-        kernel=kernel,
     )
-    x = apply_stu_truncation_plan(x, plan)
-    return x, plan.new_x_offsets, plan.new_lengths, plan.new_max_seq_len
+    x = apply_stu_truncation_plan(x, plan, kernel=kernel)
+    new_lengths = plan.new_x_offsets[1:] - plan.new_x_offsets[:-1]
+    return x, plan.new_x_offsets, new_lengths, plan.new_max_seq_len

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -16,17 +16,45 @@ every CI lane has direct coverage of the NFUNC mask construction without
 depending on the GPU attention kernels.
 """
 
+import itertools
 import unittest
+from typing import List, Optional, Tuple
 
 import torch
+from parameterized import parameterized
 
-from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention_utils import (
     apply_stu_truncation,
     apply_stu_truncation_plan,
     build_sla_func_tensor,
     compute_stu_truncation_plan,
 )
+
+
+def _reference_truncation(
+    x: torch.Tensor,
+    x_offsets: torch.Tensor,
+    num_targets: Optional[List[int]],
+    truncate_tail_len: int,
+    contextual_seq_len: int = 0,
+) -> Tuple[torch.Tensor, List[int]]:
+    """Plain-Python UIH-only truncation: ``[ctx | last min(U, tail) UIH | targets]``."""
+    chunks: List[torch.Tensor] = []
+    new_lens: List[int] = []
+    for b in range(x_offsets.numel() - 1):
+        s, e = int(x_offsets[b].item()), int(x_offsets[b + 1].item())
+        L = e - s
+        T = int(num_targets[b]) if num_targets is not None else 0
+        U = L - contextual_seq_len - T
+        new_uih = max(0, min(U, truncate_tail_len))
+        prefix = x[s : s + contextual_seq_len]
+        uih_kept = x[
+            s + contextual_seq_len + (U - new_uih) : s + contextual_seq_len + U
+        ]
+        targets = x[e - T : e]
+        chunks.append(torch.cat([prefix, uih_kept, targets], dim=0))
+        new_lens.append(contextual_seq_len + new_uih + T)
+    return torch.cat(chunks, dim=0), new_lens
 
 
 class BuildSlaFuncTensorTest(unittest.TestCase):
@@ -147,175 +175,48 @@ class BuildSlaFuncTensorTest(unittest.TestCase):
 
 
 class ApplyStuTruncationTest(unittest.TestCase):
-    """Direct content-level coverage of ``apply_stu_truncation``.
+    """Spec-vs-impl: ``apply_stu_truncation`` matches the Python reference."""
 
-    ``truncate_tail_len`` caps UIH only; contextual prefix and all
-    targets always survive intact.
-    """
-
-    def _id_marked_input(self, lengths):
-        """Build (x, offsets) where row ``i`` carries value ``float(i)``."""
+    @parameterized.expand(
+        [
+            # lengths, targets, contextual_seq_len, truncate_tail_len
+            [[3, 5, 2], None, 0, 16],  # no-op (tail >> U)
+            [[4, 10, 7], None, 0, 5],  # head drop, no ctx, no targets
+            [[8, 12], [3, 5], 0, 2],  # targets-aware, no ctx
+            [[6, 12, 20], [1, 2, 4], 3, 4],  # ctx + targets + UIH cap
+            [[6, 8], [1, 2], 2, 0],  # tail=0 drops all UIH
+        ]
+    )
+    def test_matches_reference(self, lengths, targets, ctx, tail) -> None:
         offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
             torch.tensor(lengths, dtype=torch.int64)
         )
-        total = int(offsets[-1].item())
-        x = torch.arange(total, dtype=torch.float32).view(total, 1).repeat(1, 4)
-        return x, offsets
-
-    def test_no_op_when_uih_fits(self) -> None:
-        """All ``U_b <= tail_len`` and no contextual / targets: unchanged."""
-        lengths = [3, 5, 2]
-        x, offsets = self._id_marked_input(lengths)
-        out_x, out_offsets, _, out_max = apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=None,
-            max_seq_len=int(max(lengths)),
-            truncate_tail_len=16,
+        x = torch.randn(int(offsets[-1].item()), 4)
+        num_targets = (
+            torch.tensor(targets, dtype=torch.int64) if targets is not None else None
         )
-        torch.testing.assert_close(out_x, x)
-        torch.testing.assert_close(out_offsets, offsets)
-        self.assertEqual(out_max, max(lengths))
-
-    def test_simple_head_drop_no_contextual_no_targets(self) -> None:
-        """C=0, no targets: keep last ``tail`` rows per sample."""
-        lengths = [4, 10, 7]
-        tail = 5
-        x, offsets = self._id_marked_input(lengths)
-        out_x, out_offsets, _, out_max = apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=None,
-            max_seq_len=int(max(lengths)),
-            truncate_tail_len=tail,
-        )
-        expected_lens = [min(L, tail) for L in lengths]
-        self.assertEqual(out_max, max(expected_lens))
-        for b in range(len(lengths)):
-            new_len = expected_lens[b]
-            keep_start_global = int(offsets[b + 1].item()) - new_len
-            sample_start = int(out_offsets[b].item())
-            for k in range(new_len):
-                self.assertEqual(
-                    out_x[sample_start + k, 0].item(),
-                    float(keep_start_global + k),
-                )
-
-    def test_targets_always_preserved(self) -> None:
-        """Target rows survive intact regardless of ``tail_len``."""
-        lengths = [8, 12]
-        targets = [3, 5]
-        tail = 2  # UIH cap so small that targets would be lost under naive clamp
-        x, offsets = self._id_marked_input(lengths)
-        num_targets = torch.tensor(targets, dtype=torch.int64)
-        out_x, out_offsets, _, out_max = apply_stu_truncation(
+        ref_x, ref_lens = _reference_truncation(x, offsets, targets, tail, ctx)
+        out_x, out_off, out_lens, out_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
             num_targets=num_targets,
             max_seq_len=int(max(lengths)),
-            truncate_tail_len=tail,
-        )
-        expected_lens = [min(L - T, tail) + T for L, T in zip(lengths, targets)]
-        actual_lens = (out_offsets[1:] - out_offsets[:-1]).tolist()
-        self.assertEqual(actual_lens, expected_lens)
-        self.assertEqual(out_max, max(expected_lens))
-        # Last T_b rows must be the original last T_b rows (targets intact).
-        for b, T in enumerate(targets):
-            new_len = expected_lens[b]
-            sample_start = int(out_offsets[b].item())
-            orig_end = int(offsets[b + 1].item())
-            for k in range(T):
-                tgt_slot = sample_start + new_len - T + k
-                self.assertEqual(
-                    out_x[tgt_slot, 0].item(),
-                    float(orig_end - T + k),
-                )
-
-    def test_preserves_contextual_prefix(self) -> None:
-        """C > 0 + targets: prefix, UIH tail, targets all survive."""
-        lengths = [6, 12, 20]
-        targets = [1, 2, 4]
-        ctx = 3
-        tail = 4
-        x, offsets = self._id_marked_input(lengths)
-        seq_lengths = offsets[1:] - offsets[:-1]
-        num_targets = torch.tensor(targets, dtype=torch.int64)
-        out_x, out_offsets, _, out_max = apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=num_targets,
-            max_seq_len=int(seq_lengths.max().item()),
             truncate_tail_len=tail,
             contextual_seq_len=ctx,
         )
-        for b, (L, T) in enumerate(zip(lengths, targets)):
-            U = L - ctx - T
-            new_uih = min(U, tail)
-            new_len = ctx + new_uih + T
-            sample_start = int(out_offsets[b].item())
-            orig_start = int(offsets[b].item())
-            orig_end = int(offsets[b + 1].item())
-            # Contextual prefix: first C rows.
-            for j in range(ctx):
-                self.assertEqual(
-                    out_x[sample_start + j, 0].item(), float(orig_start + j)
-                )
-            # Kept UIH: positions [C, C+new_uih).
-            uih_keep_start = orig_start + ctx + (U - new_uih)
-            for k in range(new_uih):
-                self.assertEqual(
-                    out_x[sample_start + ctx + k, 0].item(),
-                    float(uih_keep_start + k),
-                )
-            # Targets: last T rows.
-            for t in range(T):
-                self.assertEqual(
-                    out_x[sample_start + new_len - T + t, 0].item(),
-                    float(orig_end - T + t),
-                )
+        torch.testing.assert_close(out_x, ref_x)
+        self.assertEqual(out_lens.tolist(), ref_lens)
+        self.assertEqual(out_max, max(ref_lens))
         self.assertEqual(
-            out_max,
-            max(
-                lengths[i] - max(0, (lengths[i] - ctx - targets[i]) - tail)
-                for i in range(len(lengths))
-            ),
+            out_off.tolist(),
+            list(itertools.accumulate([0] + ref_lens)),
         )
-
-    def test_truncate_tail_len_zero_drops_all_uih(self) -> None:
-        """``truncate_tail_len == 0`` drops every UIH token."""
-        lengths = [6, 8]
-        targets = [1, 2]
-        ctx = 2
-        x, offsets = self._id_marked_input(lengths)
-        num_targets = torch.tensor(targets, dtype=torch.int64)
-        out_x, out_offsets, _, _ = apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=num_targets,
-            max_seq_len=int(max(lengths)),
-            truncate_tail_len=0,
-            contextual_seq_len=ctx,
-        )
-        expected_lens = [ctx + T for T in targets]
-        actual_lens = (out_offsets[1:] - out_offsets[:-1]).tolist()
-        self.assertEqual(actual_lens, expected_lens)
-        # And the kept rows are exactly C-prefix + targets-suffix.
-        for b, T in enumerate(targets):
-            sample_start = int(out_offsets[b].item())
-            orig_start = int(offsets[b].item())
-            orig_end = int(offsets[b + 1].item())
-            for j in range(ctx):
-                self.assertEqual(
-                    out_x[sample_start + j, 0].item(), float(orig_start + j)
-                )
-            for t in range(T):
-                self.assertEqual(
-                    out_x[sample_start + ctx + t, 0].item(),
-                    float(orig_end - T + t),
-                )
 
     def test_validation_raises_on_negative_params(self) -> None:
-        x, offsets = self._id_marked_input([6])
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor([6], dtype=torch.int64)
+        )
+        x = torch.randn(int(offsets[-1].item()), 4)
         with self.assertRaisesRegex(ValueError, "truncate_tail_len"):
             apply_stu_truncation(
                 x=x,
@@ -334,57 +235,32 @@ class ApplyStuTruncationTest(unittest.TestCase):
                 contextual_seq_len=-1,
             )
 
-    def test_kernel_param_threaded_through(self) -> None:
-        """Smoke: kernel kwarg routes through both jagged ops."""
-        x, offsets = self._id_marked_input([4, 6])
-        apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=None,
-            max_seq_len=6,
-            truncate_tail_len=3,
-            kernel=Kernel.PYTORCH,
-        )
-
 
 class StuTruncationPlanTest(unittest.TestCase):
-    """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``.
-
-    Same offsets, replayable on parallel jagged tensors.
-    """
-
-    def _make(self, lengths):
-        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
-            torch.tensor(lengths, dtype=torch.int64)
-        )
-        total = int(offsets[-1].item())
-        x = torch.arange(total, dtype=torch.float32).view(total, 1).repeat(1, 4)
-        return x, offsets
+    """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``."""
 
     def test_plan_apply_matches_apply_stu_truncation(self) -> None:
         """Two-step plan + apply matches the wrapper bit-for-bit."""
-        lengths = [10, 14, 6]
-        targets = [2, 3, 1]
-        ctx = 2
-        tail = 4
-        x, offsets = self._make(lengths)
-        seq_lengths = offsets[1:] - offsets[:-1]
-        num_targets = torch.tensor(targets, dtype=torch.int64)
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor([10, 14, 6], dtype=torch.int64)
+        )
+        x = torch.randn(int(offsets[-1].item()), 4)
+        num_targets = torch.tensor([2, 3, 1], dtype=torch.int64)
 
         wrapped_x, wrapped_off, wrapped_lens, wrapped_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
             num_targets=num_targets,
-            max_seq_len=int(seq_lengths.max().item()),
-            truncate_tail_len=tail,
-            contextual_seq_len=ctx,
+            max_seq_len=14,
+            truncate_tail_len=4,
+            contextual_seq_len=2,
         )
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
             num_targets=num_targets,
-            max_seq_len=int(seq_lengths.max().item()),
-            truncate_tail_len=tail,
-            contextual_seq_len=ctx,
+            max_seq_len=14,
+            truncate_tail_len=4,
+            contextual_seq_len=2,
         )
         out_x = apply_stu_truncation_plan(x, plan)
         torch.testing.assert_close(out_x, wrapped_x)
@@ -395,35 +271,32 @@ class StuTruncationPlanTest(unittest.TestCase):
     def test_replay_on_parallel_jagged(self) -> None:
         """A single plan can be applied to multiple parallel jagged tensors.
 
-        Use case: after STUStack truncates the embedding tensor, reuse
-        the plan to truncate the timestamp tensor with the same offsets.
+        Use case: ``HSTUTransducer.forward`` reuses the plan from
+        ``STUStack.forward`` to truncate ``seq_timestamps`` with the
+        same offsets used on the embeddings.
         """
-        lengths = [8, 12]
-        targets = [2, 3]
-        tail = 3
-        x, offsets = self._make(lengths)
-        seq_lengths = offsets[1:] - offsets[:-1]
-        num_targets = torch.tensor(targets, dtype=torch.int64)
-
-        # Parallel tensor: timestamps, same jagged layout but D=1 column.
-        ts = (
-            torch.arange(int(offsets[-1].item()), dtype=torch.float32)
-            .mul(7.0)
-            .unsqueeze(-1)
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor([8, 12], dtype=torch.int64)
         )
+        total = int(offsets[-1].item())
+        x = torch.randn(total, 4)
+        # Parallel tensor (D=1): row i holds 7.0 * i, so positional alignment
+        # after truncation is checkable with a simple scalar multiply.
+        ts = torch.arange(total, dtype=torch.float32).mul(7.0).unsqueeze(-1)
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
-            num_targets=num_targets,
-            max_seq_len=int(seq_lengths.max().item()),
-            truncate_tail_len=tail,
+            num_targets=torch.tensor([2, 3], dtype=torch.int64),
+            max_seq_len=12,
+            truncate_tail_len=3,
         )
+        # Build parallel reference: every kept row in `x` corresponds to
+        # the same original index in `ts` (= row * 7.0).
+        ref_x, _ = _reference_truncation(x, offsets, [2, 3], truncate_tail_len=3)
+        ref_ts, _ = _reference_truncation(ts, offsets, [2, 3], truncate_tail_len=3)
         out_x = apply_stu_truncation_plan(x, plan)
         out_ts = apply_stu_truncation_plan(ts, plan)
-        # Sanity: same number of kept rows.
-        self.assertEqual(out_x.size(0), out_ts.size(0))
-        # And the rows kept are positionally aligned: same original index
-        # across the two tensors.
-        torch.testing.assert_close(out_x[:, 0:1] * 7.0, out_ts)
+        torch.testing.assert_close(out_x, ref_x)
+        torch.testing.assert_close(out_ts, ref_ts)
 
 
 if __name__ == "__main__":

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -20,7 +20,13 @@ import unittest
 
 import torch
 
-from tzrec.ops.hstu_attention_utils import build_sla_func_tensor
+from tzrec.ops import Kernel
+from tzrec.ops.hstu_attention_utils import (
+    apply_stu_truncation,
+    apply_stu_truncation_plan,
+    build_sla_func_tensor,
+    compute_stu_truncation_plan,
+)
 
 
 class BuildSlaFuncTensorTest(unittest.TestCase):
@@ -138,6 +144,298 @@ class BuildSlaFuncTensorTest(unittest.TestCase):
         # Local pos 2 in each sample → col_max1 == 3.
         self.assertEqual(func[0, 2, 2].item(), 3)
         self.assertEqual(func[0, 2, 5].item(), 3)
+
+
+class ApplyStuTruncationTest(unittest.TestCase):
+    """Direct content-level coverage of ``apply_stu_truncation``.
+
+    ``truncate_tail_len`` caps UIH only; contextual prefix and all
+    targets always survive intact.
+    """
+
+    def _id_marked_input(self, lengths):
+        """Build (x, offsets) where row ``i`` carries value ``float(i)``."""
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor(lengths, dtype=torch.int64)
+        )
+        total = int(offsets[-1].item())
+        x = torch.arange(total, dtype=torch.float32).view(total, 1).repeat(1, 4)
+        return x, offsets
+
+    def test_no_op_when_uih_fits(self) -> None:
+        """All ``U_b <= tail_len`` and no contextual / targets: unchanged."""
+        lengths = [3, 5, 2]
+        x, offsets = self._id_marked_input(lengths)
+        out_x, out_offsets, _, out_max = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=offsets[1:] - offsets[:-1],
+            num_targets=None,
+            max_seq_len=int(max(lengths)),
+            truncate_tail_len=16,
+        )
+        torch.testing.assert_close(out_x, x)
+        torch.testing.assert_close(out_offsets, offsets)
+        self.assertEqual(out_max, max(lengths))
+
+    def test_simple_head_drop_no_contextual_no_targets(self) -> None:
+        """C=0, no targets: keep last ``tail`` rows per sample."""
+        lengths = [4, 10, 7]
+        tail = 5
+        x, offsets = self._id_marked_input(lengths)
+        out_x, out_offsets, _, out_max = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=offsets[1:] - offsets[:-1],
+            num_targets=None,
+            max_seq_len=int(max(lengths)),
+            truncate_tail_len=tail,
+        )
+        expected_lens = [min(L, tail) for L in lengths]
+        self.assertEqual(out_max, max(expected_lens))
+        for b in range(len(lengths)):
+            new_len = expected_lens[b]
+            keep_start_global = int(offsets[b + 1].item()) - new_len
+            sample_start = int(out_offsets[b].item())
+            for k in range(new_len):
+                self.assertEqual(
+                    out_x[sample_start + k, 0].item(),
+                    float(keep_start_global + k),
+                )
+
+    def test_targets_always_preserved(self) -> None:
+        """Target rows survive intact regardless of ``tail_len``."""
+        lengths = [8, 12]
+        targets = [3, 5]
+        tail = 2  # UIH cap so small that targets would be lost under naive clamp
+        x, offsets = self._id_marked_input(lengths)
+        num_targets = torch.tensor(targets, dtype=torch.int64)
+        out_x, out_offsets, _, out_max = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=offsets[1:] - offsets[:-1],
+            num_targets=num_targets,
+            max_seq_len=int(max(lengths)),
+            truncate_tail_len=tail,
+        )
+        expected_lens = [min(L - T, tail) + T for L, T in zip(lengths, targets)]
+        actual_lens = (out_offsets[1:] - out_offsets[:-1]).tolist()
+        self.assertEqual(actual_lens, expected_lens)
+        self.assertEqual(out_max, max(expected_lens))
+        # Last T_b rows must be the original last T_b rows (targets intact).
+        for b, T in enumerate(targets):
+            new_len = expected_lens[b]
+            sample_start = int(out_offsets[b].item())
+            orig_end = int(offsets[b + 1].item())
+            for k in range(T):
+                tgt_slot = sample_start + new_len - T + k
+                self.assertEqual(
+                    out_x[tgt_slot, 0].item(),
+                    float(orig_end - T + k),
+                )
+
+    def test_preserves_contextual_prefix(self) -> None:
+        """C > 0 + targets: prefix, UIH tail, targets all survive."""
+        lengths = [6, 12, 20]
+        targets = [1, 2, 4]
+        ctx = 3
+        tail = 4
+        x, offsets = self._id_marked_input(lengths)
+        seq_lengths = offsets[1:] - offsets[:-1]
+        num_targets = torch.tensor(targets, dtype=torch.int64)
+        out_x, out_offsets, _, out_max = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=seq_lengths,
+            num_targets=num_targets,
+            max_seq_len=int(seq_lengths.max().item()),
+            truncate_tail_len=tail,
+            contextual_seq_len=ctx,
+        )
+        for b, (L, T) in enumerate(zip(lengths, targets)):
+            U = L - ctx - T
+            new_uih = min(U, tail)
+            new_len = ctx + new_uih + T
+            sample_start = int(out_offsets[b].item())
+            orig_start = int(offsets[b].item())
+            orig_end = int(offsets[b + 1].item())
+            # Contextual prefix: first C rows.
+            for j in range(ctx):
+                self.assertEqual(
+                    out_x[sample_start + j, 0].item(), float(orig_start + j)
+                )
+            # Kept UIH: positions [C, C+new_uih).
+            uih_keep_start = orig_start + ctx + (U - new_uih)
+            for k in range(new_uih):
+                self.assertEqual(
+                    out_x[sample_start + ctx + k, 0].item(),
+                    float(uih_keep_start + k),
+                )
+            # Targets: last T rows.
+            for t in range(T):
+                self.assertEqual(
+                    out_x[sample_start + new_len - T + t, 0].item(),
+                    float(orig_end - T + t),
+                )
+        self.assertEqual(
+            out_max,
+            max(
+                lengths[i] - max(0, (lengths[i] - ctx - targets[i]) - tail)
+                for i in range(len(lengths))
+            ),
+        )
+
+    def test_truncate_tail_len_zero_drops_all_uih(self) -> None:
+        """``truncate_tail_len == 0`` drops every UIH token."""
+        lengths = [6, 8]
+        targets = [1, 2]
+        ctx = 2
+        x, offsets = self._id_marked_input(lengths)
+        num_targets = torch.tensor(targets, dtype=torch.int64)
+        out_x, out_offsets, _, _ = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=offsets[1:] - offsets[:-1],
+            num_targets=num_targets,
+            max_seq_len=int(max(lengths)),
+            truncate_tail_len=0,
+            contextual_seq_len=ctx,
+        )
+        expected_lens = [ctx + T for T in targets]
+        actual_lens = (out_offsets[1:] - out_offsets[:-1]).tolist()
+        self.assertEqual(actual_lens, expected_lens)
+        # And the kept rows are exactly C-prefix + targets-suffix.
+        for b, T in enumerate(targets):
+            sample_start = int(out_offsets[b].item())
+            orig_start = int(offsets[b].item())
+            orig_end = int(offsets[b + 1].item())
+            for j in range(ctx):
+                self.assertEqual(
+                    out_x[sample_start + j, 0].item(), float(orig_start + j)
+                )
+            for t in range(T):
+                self.assertEqual(
+                    out_x[sample_start + ctx + t, 0].item(),
+                    float(orig_end - T + t),
+                )
+
+    def test_validation_raises_on_negative_params(self) -> None:
+        x, offsets = self._id_marked_input([6])
+        seq_lengths = offsets[1:] - offsets[:-1]
+        with self.assertRaisesRegex(ValueError, "truncate_tail_len"):
+            apply_stu_truncation(
+                x=x,
+                x_offsets=offsets,
+                seq_lengths=seq_lengths,
+                num_targets=None,
+                max_seq_len=6,
+                truncate_tail_len=-1,
+            )
+        with self.assertRaisesRegex(ValueError, "contextual_seq_len"):
+            apply_stu_truncation(
+                x=x,
+                x_offsets=offsets,
+                seq_lengths=seq_lengths,
+                num_targets=None,
+                max_seq_len=6,
+                truncate_tail_len=4,
+                contextual_seq_len=-1,
+            )
+
+    def test_kernel_param_threaded_through(self) -> None:
+        """Smoke: kernel kwarg routes through both jagged ops."""
+        x, offsets = self._id_marked_input([4, 6])
+        apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=offsets[1:] - offsets[:-1],
+            num_targets=None,
+            max_seq_len=6,
+            truncate_tail_len=3,
+            kernel=Kernel.PYTORCH,
+        )
+
+
+class StuTruncationPlanTest(unittest.TestCase):
+    """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``.
+
+    Same offsets, replayable on parallel jagged tensors.
+    """
+
+    def _make(self, lengths):
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor(lengths, dtype=torch.int64)
+        )
+        total = int(offsets[-1].item())
+        x = torch.arange(total, dtype=torch.float32).view(total, 1).repeat(1, 4)
+        return x, offsets
+
+    def test_plan_apply_matches_apply_stu_truncation(self) -> None:
+        """Two-step plan + apply matches the wrapper bit-for-bit."""
+        lengths = [10, 14, 6]
+        targets = [2, 3, 1]
+        ctx = 2
+        tail = 4
+        x, offsets = self._make(lengths)
+        seq_lengths = offsets[1:] - offsets[:-1]
+        num_targets = torch.tensor(targets, dtype=torch.int64)
+
+        wrapped_x, wrapped_off, wrapped_lens, wrapped_max = apply_stu_truncation(
+            x=x,
+            x_offsets=offsets,
+            seq_lengths=seq_lengths,
+            num_targets=num_targets,
+            max_seq_len=int(seq_lengths.max().item()),
+            truncate_tail_len=tail,
+            contextual_seq_len=ctx,
+        )
+        plan = compute_stu_truncation_plan(
+            x_offsets=offsets,
+            seq_lengths=seq_lengths,
+            num_targets=num_targets,
+            max_seq_len=int(seq_lengths.max().item()),
+            truncate_tail_len=tail,
+            contextual_seq_len=ctx,
+        )
+        out_x = apply_stu_truncation_plan(x, plan)
+        torch.testing.assert_close(out_x, wrapped_x)
+        torch.testing.assert_close(plan.new_x_offsets, wrapped_off)
+        torch.testing.assert_close(plan.new_lengths, wrapped_lens)
+        self.assertEqual(plan.new_max_seq_len, wrapped_max)
+
+    def test_replay_on_parallel_jagged(self) -> None:
+        """A single plan can be applied to multiple parallel jagged tensors.
+
+        Use case: after STUStack truncates the embedding tensor, reuse
+        the plan to truncate the timestamp tensor with the same offsets.
+        """
+        lengths = [8, 12]
+        targets = [2, 3]
+        tail = 3
+        x, offsets = self._make(lengths)
+        seq_lengths = offsets[1:] - offsets[:-1]
+        num_targets = torch.tensor(targets, dtype=torch.int64)
+
+        # Parallel tensor: timestamps, same jagged layout but D=1 column.
+        ts = (
+            torch.arange(int(offsets[-1].item()), dtype=torch.float32)
+            .mul(7.0)
+            .unsqueeze(-1)
+        )
+        plan = compute_stu_truncation_plan(
+            x_offsets=offsets,
+            seq_lengths=seq_lengths,
+            num_targets=num_targets,
+            max_seq_len=int(seq_lengths.max().item()),
+            truncate_tail_len=tail,
+        )
+        out_x = apply_stu_truncation_plan(x, plan)
+        out_ts = apply_stu_truncation_plan(ts, plan)
+        # Sanity: same number of kept rows.
+        self.assertEqual(out_x.size(0), out_ts.size(0))
+        # And the rows kept are positionally aligned: same original index
+        # across the two tensors.
+        torch.testing.assert_close(out_x[:, 0:1] * 7.0, out_ts)
 
 
 if __name__ == "__main__":

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -389,8 +389,7 @@ class StuTruncationPlanTest(unittest.TestCase):
         out_x = apply_stu_truncation_plan(x, plan)
         torch.testing.assert_close(out_x, wrapped_x)
         torch.testing.assert_close(plan.new_x_offsets, wrapped_off)
-        plan_lens = plan.new_x_offsets[1:] - plan.new_x_offsets[:-1]
-        torch.testing.assert_close(plan_lens, wrapped_lens)
+        torch.testing.assert_close(plan.new_lengths, wrapped_lens)
         self.assertEqual(plan.new_max_seq_len, wrapped_max)
 
     def test_replay_on_parallel_jagged(self) -> None:

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -25,7 +25,6 @@ from parameterized import parameterized
 
 from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention_utils import (
-    apply_stu_truncation,
     apply_stu_truncation_plan,
     build_sla_func_tensor,
     compute_stu_truncation_plan,
@@ -175,8 +174,8 @@ class BuildSlaFuncTensorTest(unittest.TestCase):
         self.assertEqual(func[0, 2, 5].item(), 3)
 
 
-class ApplyStuTruncationTest(unittest.TestCase):
-    """Spec-vs-impl: ``apply_stu_truncation`` matches the Python reference."""
+class StuTruncationTest(unittest.TestCase):
+    """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``."""
 
     @parameterized.expand(
         [
@@ -197,20 +196,19 @@ class ApplyStuTruncationTest(unittest.TestCase):
             torch.tensor(targets, dtype=torch.int64) if targets is not None else None
         )
         ref_x, ref_lens = _reference_truncation(x, offsets, targets, tail, ctx)
-        out_x, out_off, out_lens, out_max = apply_stu_truncation(
-            x=x,
+        plan = compute_stu_truncation_plan(
             x_offsets=offsets,
             num_targets=num_targets,
             max_seq_len=int(max(lengths)),
             truncate_tail_len=tail,
             contextual_seq_len=ctx,
-            kernel=Kernel.PYTORCH,
         )
+        out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)
         torch.testing.assert_close(out_x, ref_x)
-        self.assertEqual(out_lens.tolist(), ref_lens)
-        self.assertEqual(out_max, max(ref_lens))
+        self.assertEqual(plan.new_lengths.tolist(), ref_lens)
+        self.assertEqual(plan.new_max_seq_len, max(ref_lens))
         self.assertEqual(
-            out_off.tolist(),
+            plan.new_x_offsets.tolist(),
             list(itertools.accumulate([0] + ref_lens)),
         )
 
@@ -218,60 +216,21 @@ class ApplyStuTruncationTest(unittest.TestCase):
         offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
             torch.tensor([6], dtype=torch.int64)
         )
-        x = torch.randn(int(offsets[-1].item()), 4)
         with self.assertRaisesRegex(ValueError, "truncate_tail_len"):
-            apply_stu_truncation(
-                x=x,
+            compute_stu_truncation_plan(
                 x_offsets=offsets,
                 num_targets=None,
                 max_seq_len=6,
                 truncate_tail_len=-1,
-                kernel=Kernel.PYTORCH,
             )
         with self.assertRaisesRegex(ValueError, "contextual_seq_len"):
-            apply_stu_truncation(
-                x=x,
+            compute_stu_truncation_plan(
                 x_offsets=offsets,
                 num_targets=None,
                 max_seq_len=6,
                 truncate_tail_len=4,
                 contextual_seq_len=-1,
-                kernel=Kernel.PYTORCH,
             )
-
-
-class StuTruncationPlanTest(unittest.TestCase):
-    """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``."""
-
-    def test_plan_apply_matches_apply_stu_truncation(self) -> None:
-        """Two-step plan + apply matches the wrapper bit-for-bit."""
-        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
-            torch.tensor([10, 14, 6], dtype=torch.int64)
-        )
-        x = torch.randn(int(offsets[-1].item()), 4)
-        num_targets = torch.tensor([2, 3, 1], dtype=torch.int64)
-
-        wrapped_x, wrapped_off, wrapped_lens, wrapped_max = apply_stu_truncation(
-            x=x,
-            x_offsets=offsets,
-            num_targets=num_targets,
-            max_seq_len=14,
-            truncate_tail_len=4,
-            contextual_seq_len=2,
-            kernel=Kernel.PYTORCH,
-        )
-        plan = compute_stu_truncation_plan(
-            x_offsets=offsets,
-            num_targets=num_targets,
-            max_seq_len=14,
-            truncate_tail_len=4,
-            contextual_seq_len=2,
-        )
-        out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)
-        torch.testing.assert_close(out_x, wrapped_x)
-        torch.testing.assert_close(plan.new_x_offsets, wrapped_off)
-        torch.testing.assert_close(plan.new_lengths, wrapped_lens)
-        self.assertEqual(plan.new_max_seq_len, wrapped_max)
 
     def test_replay_on_parallel_jagged(self) -> None:
         """A single plan can be applied to multiple parallel jagged tensors.
@@ -294,8 +253,6 @@ class StuTruncationPlanTest(unittest.TestCase):
             max_seq_len=12,
             truncate_tail_len=3,
         )
-        # Build parallel reference: every kept row in `x` corresponds to
-        # the same original index in `ts` (= row * 7.0).
         ref_x, _ = _reference_truncation(x, offsets, [2, 3], truncate_tail_len=3)
         ref_ts, _ = _reference_truncation(ts, offsets, [2, 3], truncate_tail_len=3)
         out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -169,7 +169,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         out_x, out_offsets, _, out_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=offsets[1:] - offsets[:-1],
             num_targets=None,
             max_seq_len=int(max(lengths)),
             truncate_tail_len=16,
@@ -186,7 +185,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         out_x, out_offsets, _, out_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=offsets[1:] - offsets[:-1],
             num_targets=None,
             max_seq_len=int(max(lengths)),
             truncate_tail_len=tail,
@@ -213,7 +211,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         out_x, out_offsets, _, out_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=offsets[1:] - offsets[:-1],
             num_targets=num_targets,
             max_seq_len=int(max(lengths)),
             truncate_tail_len=tail,
@@ -246,7 +243,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         out_x, out_offsets, _, out_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=seq_lengths,
             num_targets=num_targets,
             max_seq_len=int(seq_lengths.max().item()),
             truncate_tail_len=tail,
@@ -295,7 +291,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         out_x, out_offsets, _, _ = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=offsets[1:] - offsets[:-1],
             num_targets=num_targets,
             max_seq_len=int(max(lengths)),
             truncate_tail_len=0,
@@ -321,12 +316,10 @@ class ApplyStuTruncationTest(unittest.TestCase):
 
     def test_validation_raises_on_negative_params(self) -> None:
         x, offsets = self._id_marked_input([6])
-        seq_lengths = offsets[1:] - offsets[:-1]
         with self.assertRaisesRegex(ValueError, "truncate_tail_len"):
             apply_stu_truncation(
                 x=x,
                 x_offsets=offsets,
-                seq_lengths=seq_lengths,
                 num_targets=None,
                 max_seq_len=6,
                 truncate_tail_len=-1,
@@ -335,7 +328,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
             apply_stu_truncation(
                 x=x,
                 x_offsets=offsets,
-                seq_lengths=seq_lengths,
                 num_targets=None,
                 max_seq_len=6,
                 truncate_tail_len=4,
@@ -348,7 +340,6 @@ class ApplyStuTruncationTest(unittest.TestCase):
         apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=offsets[1:] - offsets[:-1],
             num_targets=None,
             max_seq_len=6,
             truncate_tail_len=3,
@@ -383,7 +374,6 @@ class StuTruncationPlanTest(unittest.TestCase):
         wrapped_x, wrapped_off, wrapped_lens, wrapped_max = apply_stu_truncation(
             x=x,
             x_offsets=offsets,
-            seq_lengths=seq_lengths,
             num_targets=num_targets,
             max_seq_len=int(seq_lengths.max().item()),
             truncate_tail_len=tail,
@@ -391,7 +381,6 @@ class StuTruncationPlanTest(unittest.TestCase):
         )
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
-            seq_lengths=seq_lengths,
             num_targets=num_targets,
             max_seq_len=int(seq_lengths.max().item()),
             truncate_tail_len=tail,
@@ -400,7 +389,8 @@ class StuTruncationPlanTest(unittest.TestCase):
         out_x = apply_stu_truncation_plan(x, plan)
         torch.testing.assert_close(out_x, wrapped_x)
         torch.testing.assert_close(plan.new_x_offsets, wrapped_off)
-        torch.testing.assert_close(plan.new_lengths, wrapped_lens)
+        plan_lens = plan.new_x_offsets[1:] - plan.new_x_offsets[:-1]
+        torch.testing.assert_close(plan_lens, wrapped_lens)
         self.assertEqual(plan.new_max_seq_len, wrapped_max)
 
     def test_replay_on_parallel_jagged(self) -> None:
@@ -424,7 +414,6 @@ class StuTruncationPlanTest(unittest.TestCase):
         )
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
-            seq_lengths=seq_lengths,
             num_targets=num_targets,
             max_seq_len=int(seq_lengths.max().item()),
             truncate_tail_len=tail,

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -18,7 +18,6 @@ depending on the GPU attention kernels.
 
 import itertools
 import unittest
-from typing import List, Optional, Tuple
 
 import torch
 from parameterized import parameterized
@@ -29,32 +28,7 @@ from tzrec.ops.hstu_attention_utils import (
     build_sla_func_tensor,
     compute_stu_truncation_plan,
 )
-
-
-def _reference_truncation(
-    x: torch.Tensor,
-    x_offsets: torch.Tensor,
-    num_targets: Optional[List[int]],
-    truncate_tail_len: int,
-    contextual_seq_len: int = 0,
-) -> Tuple[torch.Tensor, List[int]]:
-    """Plain-Python UIH-only truncation: ``[ctx | last min(U, tail) UIH | targets]``."""
-    chunks: List[torch.Tensor] = []
-    new_lens: List[int] = []
-    for b in range(x_offsets.numel() - 1):
-        s, e = int(x_offsets[b].item()), int(x_offsets[b + 1].item())
-        L = e - s
-        T = int(num_targets[b]) if num_targets is not None else 0
-        U = L - contextual_seq_len - T
-        new_uih = max(0, min(U, truncate_tail_len))
-        prefix = x[s : s + contextual_seq_len]
-        uih_kept = x[
-            s + contextual_seq_len + (U - new_uih) : s + contextual_seq_len + U
-        ]
-        targets = x[e - T : e]
-        chunks.append(torch.cat([prefix, uih_kept, targets], dim=0))
-        new_lens.append(contextual_seq_len + new_uih + T)
-    return torch.cat(chunks, dim=0), new_lens
+from tzrec.utils.test_util import reference_stu_truncation
 
 
 class BuildSlaFuncTensorTest(unittest.TestCase):
@@ -195,7 +169,7 @@ class StuTruncationTest(unittest.TestCase):
         num_targets = (
             torch.tensor(targets, dtype=torch.int64) if targets is not None else None
         )
-        ref_x, ref_lens = _reference_truncation(x, offsets, targets, tail, ctx)
+        ref_x, ref_lens = reference_stu_truncation(x, offsets, targets, tail, ctx)
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
             num_targets=num_targets,
@@ -253,8 +227,8 @@ class StuTruncationTest(unittest.TestCase):
             max_seq_len=12,
             truncate_tail_len=3,
         )
-        ref_x, _ = _reference_truncation(x, offsets, [2, 3], truncate_tail_len=3)
-        ref_ts, _ = _reference_truncation(ts, offsets, [2, 3], truncate_tail_len=3)
+        ref_x, _ = reference_stu_truncation(x, offsets, [2, 3], truncate_tail_len=3)
+        ref_ts, _ = reference_stu_truncation(ts, offsets, [2, 3], truncate_tail_len=3)
         out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)
         out_ts = apply_stu_truncation_plan(ts, plan, kernel=Kernel.PYTORCH)
         torch.testing.assert_close(out_x, ref_x)

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple
 import torch
 from parameterized import parameterized
 
+from tzrec.ops import Kernel
 from tzrec.ops.hstu_attention_utils import (
     apply_stu_truncation,
     apply_stu_truncation_plan,
@@ -203,6 +204,7 @@ class ApplyStuTruncationTest(unittest.TestCase):
             max_seq_len=int(max(lengths)),
             truncate_tail_len=tail,
             contextual_seq_len=ctx,
+            kernel=Kernel.PYTORCH,
         )
         torch.testing.assert_close(out_x, ref_x)
         self.assertEqual(out_lens.tolist(), ref_lens)
@@ -224,6 +226,7 @@ class ApplyStuTruncationTest(unittest.TestCase):
                 num_targets=None,
                 max_seq_len=6,
                 truncate_tail_len=-1,
+                kernel=Kernel.PYTORCH,
             )
         with self.assertRaisesRegex(ValueError, "contextual_seq_len"):
             apply_stu_truncation(
@@ -233,6 +236,7 @@ class ApplyStuTruncationTest(unittest.TestCase):
                 max_seq_len=6,
                 truncate_tail_len=4,
                 contextual_seq_len=-1,
+                kernel=Kernel.PYTORCH,
             )
 
 
@@ -254,6 +258,7 @@ class StuTruncationPlanTest(unittest.TestCase):
             max_seq_len=14,
             truncate_tail_len=4,
             contextual_seq_len=2,
+            kernel=Kernel.PYTORCH,
         )
         plan = compute_stu_truncation_plan(
             x_offsets=offsets,
@@ -262,7 +267,7 @@ class StuTruncationPlanTest(unittest.TestCase):
             truncate_tail_len=4,
             contextual_seq_len=2,
         )
-        out_x = apply_stu_truncation_plan(x, plan)
+        out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)
         torch.testing.assert_close(out_x, wrapped_x)
         torch.testing.assert_close(plan.new_x_offsets, wrapped_off)
         torch.testing.assert_close(plan.new_lengths, wrapped_lens)
@@ -293,8 +298,8 @@ class StuTruncationPlanTest(unittest.TestCase):
         # the same original index in `ts` (= row * 7.0).
         ref_x, _ = _reference_truncation(x, offsets, [2, 3], truncate_tail_len=3)
         ref_ts, _ = _reference_truncation(ts, offsets, [2, 3], truncate_tail_len=3)
-        out_x = apply_stu_truncation_plan(x, plan)
-        out_ts = apply_stu_truncation_plan(ts, plan)
+        out_x = apply_stu_truncation_plan(x, plan, kernel=Kernel.PYTORCH)
+        out_ts = apply_stu_truncation_plan(ts, plan, kernel=Kernel.PYTORCH)
         torch.testing.assert_close(out_x, ref_x)
         torch.testing.assert_close(out_ts, ref_ts)
 

--- a/tzrec/protos/module.proto
+++ b/tzrec/protos/module.proto
@@ -287,17 +287,11 @@ message HSTU {
     required GRInputPreprocessor input_preprocessor = 5;
     // output postprocessor
     required GROutputPostprocessor output_postprocessor = 6;
-    // Attention truncation: run the first attn_truncation_split_layer
-    // layers on the full sequence, then on layers >= split_layer keep only
-    // the last attn_truncation_tail_len UIH tokens per sample.  Contextual
-    // prefix and targets always survive.
-    //
-    // attn_truncation_split_layer must be in (0, attn_num_layers) when
-    // truncation is enabled.
-    // attn_truncation_tail_len is the trailing UIH cap on layers >= split.
-    //
-    // Both must be > 0 to enable truncation; setting only one is rejected
-    // at construction.
+    // Attention truncation: after this many full-sequence layers, drop UIH
+    // prefix tokens to keep only the last attn_truncation_tail_len per
+    // sample.  Contextual prefix and targets survive.  Must be in
+    // (0, attn_num_layers); 0 disables.
     optional uint32 attn_truncation_split_layer = 7;
+    // Trailing UIH cap; both fields must be > 0 to enable truncation.
     optional uint32 attn_truncation_tail_len = 8;
 }

--- a/tzrec/protos/module.proto
+++ b/tzrec/protos/module.proto
@@ -287,4 +287,17 @@ message HSTU {
     required GRInputPreprocessor input_preprocessor = 5;
     // output postprocessor
     required GROutputPostprocessor output_postprocessor = 6;
+    // Attention truncation: run the first attn_truncation_split_layer
+    // layers on the full sequence, then on layers >= split_layer keep only
+    // the last attn_truncation_tail_len UIH tokens per sample.  Contextual
+    // prefix and targets always survive.
+    //
+    // attn_truncation_split_layer must be in (0, attn_num_layers) when
+    // truncation is enabled.
+    // attn_truncation_tail_len is the trailing UIH cap on layers >= split.
+    //
+    // Both must be > 0 to enable truncation; setting only one is rejected
+    // at construction.
+    optional uint32 attn_truncation_split_layer = 7;
+    optional uint32 attn_truncation_tail_len = 8;
 }

--- a/tzrec/tests/configs/dlrm_ultra_hstu_cutlass_kuairand_1k.config
+++ b/tzrec/tests/configs/dlrm_ultra_hstu_cutlass_kuairand_1k.config
@@ -194,6 +194,8 @@ model_config {
             }
             input_dropout_ratio: 0.2
             attn_num_layers: 4
+            attn_truncation_split_layer: 2
+            attn_truncation_tail_len: 512
             positional_encoder {
                 num_position_buckets: 8192
                 num_time_buckets: 2048

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -214,3 +214,29 @@ def get_test_enable_tma() -> List[bool]:
             if version.parse(triton.__version__) >= version.parse("3.5.0"):
                 results.append(True)
     return results
+
+
+def reference_stu_truncation(
+    x: torch.Tensor,
+    x_offsets: torch.Tensor,
+    num_targets: Optional[List[int]],
+    truncate_tail_len: int,
+    contextual_seq_len: int = 0,
+) -> Tuple[torch.Tensor, List[int]]:
+    """Plain-Python UIH-only truncation: ``[ctx | last min(U, tail) UIH | targets]``."""
+    chunks: List[torch.Tensor] = []
+    new_lens: List[int] = []
+    for b in range(x_offsets.numel() - 1):
+        s, e = int(x_offsets[b].item()), int(x_offsets[b + 1].item())
+        L = e - s
+        T = int(num_targets[b]) if num_targets is not None else 0
+        U = L - contextual_seq_len - T
+        new_uih = max(0, min(U, truncate_tail_len))
+        prefix = x[s : s + contextual_seq_len]
+        uih_kept = x[
+            s + contextual_seq_len + (U - new_uih) : s + contextual_seq_len + U
+        ]
+        targets = x[e - T : e]
+        chunks.append(torch.cat([prefix, uih_kept, targets], dim=0))
+        new_lens.append(contextual_seq_len + new_uih + T)
+    return torch.cat(chunks, dim=0), new_lens

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"


### PR DESCRIPTION
## Summary

Extracts the **attention truncation** piece from PR #476 (ULTRA-HSTU). SLA + selective rematerialization already landed in #486; this PR ships only the mid-stack truncation work, refined against PR #476's review feedback.

After ``attn_truncation_split_layer`` (N1) full-sequence layers, the stack drops UIH prefix tokens so each sample keeps at most ``attn_truncation_tail_len`` (L') trailing UIH tokens; contextual prefix and targets always survive. Crossing the truncation boundary invalidates the per-layer SLA cache so the next layer rebuilds the func tensor against the truncated offsets.

### Highlights

- **Plan / apply split.** `STUTruncationPlan` + `compute_stu_truncation_plan` + `apply_stu_truncation_plan` separate the offset arithmetic from the jagged-value moves, so the same split can be replayed on parallel jagged tensors (e.g. embeddings + timestamps) without redoing the math or paying a second D->H sync.
- **Symmetric ctor validation.** Both `truncate_split_layer` and `truncate_tail_len` must be `> 0` (or both `0`); setting only one used to silently no-op and now raises `ValueError`. `split_layer` must be in `(0, len(stu_list))` when enabled.
- **`cached_forward` train/serve firewall.** Mid-stack truncation drops UIH prefix tokens that the cached / delta path's KV cache still references; `STUStack.cached_forward` raises `NotImplementedError` when truncation is configured rather than silently diverging.
- **Plan-based plumbing in `HSTUTransducer`.** `_hstu_compute` returns `(x, x_offsets, max_seq_len, plan)`; `forward` consumes the plan to truncate `seq_timestamps` and refresh `seq_lengths` / `seq_offsets` / `max_seq_len`. `total_uih_len=None` is passed into `_postprocess` so `split_2D_jagged` derives the correct length from the truncated offsets.
- **Integrates with #486's SLA cache.** Truncation resets `prev_attn_func` / `prev_attn_func_sig` to `None` across the boundary so the existing layer-level cache miss naturally rebuilds the SLA func tensor against the new offsets -- no stack-scope SLA cache reintroduced.

### Files

- `tzrec/protos/module.proto` -- HSTU.attn_truncation_split_layer (7), HSTU.attn_truncation_tail_len (8).
- `tzrec/ops/hstu_attention_utils.py` -- `STUTruncationPlan`, `compute_stu_truncation_plan`, `apply_stu_truncation_plan`, `apply_stu_truncation`.
- `tzrec/modules/gr/stu.py` -- `STUStack` truncation ctor args, mid-stack apply in `forward`, `cached_forward` `NotImplementedError`.
- `tzrec/modules/gr/hstu_transducer.py` -- `attn_truncation_*` kwargs, plan consumption in `forward`.
- `tzrec/ops/hstu_attention_utils_test.py` -- `ApplyStuTruncationTest` (no-op, head-drop, target preservation, contextual prefix, `tail_len=0`, validation, kernel kwarg) + `StuTruncationPlanTest` (plan-then-apply parity, parallel-jagged replay).
- `tzrec/modules/gr/stu_test.py` -- `STUStackTruncationTest` (init bounds + symmetric, truncation, no-op, return signature, `cached_forward` raise, `num_targets=None`, SLA + truncation runs).
- `tzrec/tests/configs/dlrm_ultra_hstu_cutlass_kuairand_1k.config` -- enable truncation end-to-end (split=2, tail=512).
- `tzrec/version.py` -- 1.1.15 -> 1.1.16.

### Out of scope

- `STUStack.cached_forward` truncation support (currently raises).
- FP8 / Mixture of Transducers (deferred ULTRA-HSTU branches).
- User-facing docs (`docs/source/models/dlrm_hstu.md`) intentionally not edited; a consolidated `ultra_hstu.md` will follow once the remaining ULTRA-HSTU pieces land.

## Test plan

- [x] `python -m unittest tzrec.ops.hstu_attention_utils_test` -- 16/16 pass.
- [x] `python -m unittest tzrec.modules.gr.stu_test.STUStackTruncationTest` -- 7/7 pass.
- [x] `pre-commit run` on all changed files -- clean.
- [ ] GPU smoke: `python -m tzrec.models.dlrm_hstu_test` and ~50 train steps on `dlrm_ultra_hstu_cutlass_kuairand_1k.config` to verify finite loss + comparable step time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)