### PR TITLE
[bugfix] free verify-forward activations before AOTI compile to avoid CUDA IMA

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -231,14 +231,24 @@ def export_model_normal(
         autocast_dtype = acc_utils.mixed_precision_to_dtype(mixed_precision)
         if acc_utils.is_trt() or acc_utils.is_aot():
             data = OrderedDict(sorted(data.items()))
-            with torch.amp.autocast(
-                device_type="cuda",
-                dtype=autocast_dtype,
-                enabled=autocast_dtype is not None,
+            # Verify forward runs under no_grad: we only need result shapes /
+            # dtypes for logging. Without no_grad, HSTU's many attention
+            # layers retain saved activations through `result`'s autograd
+            # graph, pinning multi-GiB on CUDA until export returns. AOTI's
+            # autotune (in unified AOT) then OOMs and surfaces as IMA.
+            with (
+                torch.no_grad(),
+                torch.amp.autocast(
+                    device_type="cuda",
+                    dtype=autocast_dtype,
+                    enabled=autocast_dtype is not None,
+                ),
             ):
                 result = model(data, "cuda:0")
             result_info = {k: (v.size(), v.dtype) for k, v in result.items()}
             logger.info(f"Model Outputs: {result_info}")
+            del result
+            torch.cuda.empty_cache()
             if acc_utils.is_trt():
                 sparse, dense, meta_info = split_model(data, model, save_dir)
                 export_model_trt(


### PR DESCRIPTION
## Summary

- Wrap the export-time verify forward in `torch.no_grad()` and free the result + empty cache before dispatching to the export branch.
- Fixes a CUDA illegal memory access during `torch._inductor.aoti_compile_and_package` when running unified AOT export on HSTU models, especially with `QUANT_EC_EMB=INT8`.

## Why

```bash
UNIFIED_AOT=1 ENABLE_AOT=1 QUANT_EC_EMB=INT8 \
torchrun --master_addr=127.0.0.1 --master_port=12345 \
  --nnodes=1 --nproc-per-node=1 --node_rank=0 \
  -m tzrec.export \
  --pipeline_config_path <pipeline.config> \
  --export_dir <export_dir>/ \
  --additional_export_config '{"cand_seq_pk": "cand_seq"}'
```

crashed with:

```
File ".../torch/_dynamo/utils.py", line 2434, in preserve_rng_state
    torch.cuda.set_rng_state(cuda_rng_state)
torch._inductor.exc.InductorError:
    AcceleratorError: CUDA error: an illegal memory access was encountered
```

The traceback's last visible frame (`set_rng_state`) is misleading; CUDA errors are async, so the IMA surfaces at the next CUDA touch *after* the real fault. Re-running under `compute-sanitizer --tool memcheck` makes the underlying error legible:

```
torch._inductor.exc.InductorError: RuntimeError:
  Failed to run autotuning code block: CUDA out of memory.
  Tried to allocate 98.00 MiB. GPU 0 has a total capacity of 22.19 GiB
  of which 57.69 MiB is free. ... 21.44 GiB is allocated by PyTorch ...
```

raised from `_inductor/codegen/wrapper.py:1942 generate_and_run_autotune_block`. So the IMA is the ungraceful manifestation of an OOM during AOTI's autotune kernel launch.

Where is the 21.44 GiB going? Reading `tzrec/utils/export_util.py:234-239`, the verify forward runs inside `torch.amp.autocast` but **not** inside `torch.no_grad()`. `model.eval()` and `model.set_is_inference(True)` don't disable autograd graph construction. So HSTU's many attention layers each save activations for backward, and those tensors stay alive through `result`'s autograd graph for the entire duration of the if/elif export-dispatch block — including the call into `export_unified_model_aot`. AOTI's autotune (which only needs ~98 MiB of headroom) then OOMs.

Two-stage AOT escapes this only because its dense graph is much smaller, so leftover budget happens to be enough. Unified AOT, with the full HSTU graph, has higher peak memory pressure and trips the OOM/IMA.

## Fix

```python
# Verify forward runs under no_grad: we only need result shapes /
# dtypes for logging. Without no_grad, HSTU's many attention
# layers retain saved activations through `result`'s autograd
# graph, pinning multi-GiB on CUDA until export returns. AOTI's
# autotune (in unified AOT) then OOMs and surfaces as IMA.
with (
    torch.no_grad(),
    torch.amp.autocast(
        device_type="cuda",
        dtype=autocast_dtype,
        enabled=autocast_dtype is not None,
    ),
):
    result = model(data, "cuda:0")
result_info = {k: (v.size(), v.dtype) for k, v in result.items()}
logger.info(f"Model Outputs: {result_info}")
del result
torch.cuda.empty_cache()
```

This is a root-cause fix, not a workaround:

- The verify forward only logs result shapes/dtypes. Backward is never called, so building an autograd graph is unconditional waste.
- Pattern parity: `tzrec/main.py`'s predict path (lines 195, 1183, 1434) already uses `torch.no_grad()` for the same kind of "forward to log outputs" call. Export was the outlier.
- Releases the activations before AOTI's autotune asks the allocator for headroom.

## Test plan

- [x] `UNIFIED_AOT=1 ENABLE_AOT=1 QUANT_EC_EMB=INT8` torchrun export succeeds end-to-end. Single-stage `aoti/aoti_model.pt2` artifact created. No `scripted_sparse_model.pt` (confirmed unified, not fallback). `model_acc.json` records `UNIFIED_AOT: "1"` and `QUANT_EC_EMB: "INT8"`.
- [x] Regression: same command without `QUANT_EC_EMB=INT8` still produces a unified single-stage artifact, no IMA/OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)