### PR TITLE
[perf] unified-AOT: stop fp64 alpha specialization on HSTU MHA

### DIFF
--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -436,6 +436,22 @@ def export_unified_model_aot(
         {
             "scalar_asserts": False,
             "unsafe_ignore_unsupported_triton_autotune_args": True,
+            # Force fp32 for Python-float scalar Triton kernel args (e.g.
+            # ``_hstu_attn_fwd``'s ``alpha``). The default open-source
+            # value is True, which infers fp64 for Python floats and
+            # triggers a register-spilling fp64 specialization that runs
+            # ~4× slower on Ampere/Ada. The two-stage path goes through
+            # a Dynamo trace that ends up classifying ``alpha`` as a
+            # tensor (taking the fp32 path of ``signature_of``); unified
+            # threads the float through ``fx.symbolic_trace`` first and
+            # lands on the SizeArg fp32/fp64 fork in ``triton_utils.py``.
+            "_use_fp64_for_unbacked_floats": False,
+            # Enable cudagraphs at AOTI compile time. The unified graph
+            # ships ~280 kernel launches per call; with cudagraphs the
+            # whole sequence collapses into one graph replay, eliminating
+            # CPU dispatch overhead and the per-launch ~3-5 µs gap.
+            "triton.cudagraphs": True,
+            "triton.cudagraph_skip_dynamic_graphs": False,
         }
     ):
         aoti_dir = os.path.join(save_dir, "aoti")


### PR DESCRIPTION
## Summary

`export_unified_model_aot` runs `fx.symbolic_trace` before `torch.export.export`, which preserves the HSTU MHA `alpha = 1/sqrt(D)` constant as a Python float (fp64). Inductor's `signature_of` (`torch/_inductor/codegen/triton_utils.py`) then specializes the downstream `_hstu_attn_fwd` Triton kernel with `alpha: fp64`. On Ampere/Ada that fp64 specialization compiles to a register-spilled cubin (REG=168/thread, STACK=3944, with the `__cuda_sm20_div_rn_f64_full` software helper linked in) and runs ~4× slower per call than the fp32 sibling produced by the two-stage export path.

The two-stage path stays on the fp32 specialization because torch.export's Dynamo tracer runs directly on a vanilla `nn.Module` (no symbolic_trace pre-pass) and ends up classifying `alpha` as a tensor — that takes the fp32 fast path in `signature_of`.

This patch surfaces the dtype choice as an Inductor config knob and pins it to fp32 inside the unified AOTI compile context. It also enables `triton.cudagraphs=True` so launch overhead can collapse into a graph replay where the runtime supports it.

## Why this matters

On a single-thread predict with batch=64, sequence_length=2048, 12 active steps on an A10:

| metric | two-stage | regression (before) | this patch |
|---|---|---|---|
| total CUDA-kernel time per 12 steps | 1217 ms | 4074 ms | **1229 ms** (1.01× two-stage) |
| `_hstu_attn_fwd` per call | 35.14 ms | 151.87 ms (4.33× slower) | **35.14 ms** (1.00× two-stage) |
| cubin `REG` / `STACK` per thread | 255 / 2968 | 168 / 3944 | **255 / 2928** |
| compiled `alpha` signature | fp32 | fp64 | **fp32** |
| iteration rate (single thread) | 2.55 it/s | 2.28 it/s | **6.16 it/s** |

The unified-AOT model now matches two-stage on the HSTU hot path and beats it end-to-end (sparse stage stays inside the AOTI graph instead of an external JIT call).

## Test plan

- [x] Re-export DLRM-HSTU rank model with `UNIFIED_AOT=1 ENABLE_AOT=1`; verify `_hstu_attn_fwd` cubin is no longer spilling (`cuobjdump --dump-resource-usage` reports REG=255, no fp64 div helper).
- [x] Kineto trace of `tzrec.predict --is_profiling`: `_hstu_attn_fwd` total time and per-call time match two-stage to within 0.1%.
- [ ] CI integration test `test_rank_dlrm_hstu_train_eval_export_unified_aot` (test data not available locally; CI will validate).