### PR TITLE
[perf] AOTI export knobs: fp32 unbacked floats, sample-input autotune, TF32 from export_config

### DIFF
--- a/docs/source/usage/export.md
+++ b/docs/source/usage/export.md
@@ -44,4 +44,5 @@ torchrun --master_addr=localhost --master_port=32555 \
 - INPUT_TILE_3_ONLINE: 配合INPUT_TILE=3使用，对User侧序列特征使用在线推理模式，序列特征在线模型服务中推理性能更好，但导出的模型无法用于离线预测
   - **INPUT_TILE_3_ONLINE=1**：启用序列特征的在线推理模式
 - ENABLE_AOT:
-  - **ENABLE_AOT=1**: 使用AOT(Ahead Of Time)编译优化导出优化的模型(experimental)
+  - **ENABLE_AOT=1**: 使用AOT(Ahead Of Time)编译优化导出优化的模型
+  - **ENABLE_AOT=2**: 使用统一 AOTI 模型编译优化 (sparse + dense 融合为单一 .pt2) [experimental]

--- a/docs/source/usage/serving.md
+++ b/docs/source/usage/serving.md
@@ -43,7 +43,7 @@ cat << EOF > tzrec_rank.json
       }
     }
   ],
-  "processor":"easyrec-torch-1.11"
+  "processor":"easyrec-torch-2.2"
 }
 EOF
 

--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -15,8 +15,11 @@ from typing import Any, Dict, Optional, Set, Union
 
 import torch
 from torch import nn
+from torch._export.passes.remove_runtime_assertions import (
+    _RemoveRuntimeAssertionsPass,
+)
 
-from tzrec.acc.utils import is_unified_aot_predict
+from tzrec.acc.utils import is_autotune_with_sample_inputs, is_unified_aot_predict
 from tzrec.models.model import (
     CombinedModelWrapper,
     CudaAutocastWrapper,
@@ -25,6 +28,38 @@ from tzrec.models.model import (
 from tzrec.ops._cuda import cutlass_hstu_attention  # noqa: F401
 from tzrec.utils.fx_util import symbolic_trace
 from tzrec.utils.logging_util import logger
+
+
+def _aoti_compile_cfg() -> Dict[str, Any]:
+    """torch._inductor.config overrides applied to AOTI compile."""
+    cfg: Dict[str, Any] = {
+        # AssertScalar codegen is incorrect; keep asserts off.
+        "scalar_asserts": False,
+        # Tolerate Triton Autotuner pre_hooks (HSTU TensorDescriptor pre_hook).
+        "unsafe_ignore_unsupported_triton_autotune_args": True,
+        # fp64 alpha forces Newton-Raphson tl.sigmoid on Ada/Ampere where
+        # there is no native ex2.f64; fp32 specialization is the right default.
+        "_use_fp64_for_unbacked_floats": False,
+    }
+    if is_autotune_with_sample_inputs():
+        cfg["triton.autotune_with_sample_inputs"] = True
+    return cfg
+
+
+def _strip_runtime_asserts_for_sample_input_autotune(
+    exported_pg: torch.export.ExportedProgram,
+) -> None:
+    """Strip runtime asserts before sample-input autotune.
+
+    Sample-input autotune walks the FX graph via ``torch.fx.Interpreter``,
+    which crashes on ``_assert_scalar`` / ``sym_constrain_*`` ops; strip
+    them when ``AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS`` is on. No-op otherwise.
+    """
+    if not is_autotune_with_sample_inputs():
+        return
+    pass_result = _RemoveRuntimeAssertionsPass()(exported_pg.graph_module)
+    if pass_result.modified:
+        exported_pg.graph_module.recompile()
 
 
 def load_model_aot(
@@ -91,7 +126,11 @@ def export_model_aot(
             it is only embedding lookups, which don't benefit from AMP and
             which would complicate torch.jit.script compilation.
     """
-    sparse_output, _ = sparse_model(data, "cuda:0")
+    # no_grad: outputs become leaf tensors so AOTI's
+    # extract_autotune_inputs() can deepcopy them when sample-input
+    # autotune is on (upstream pytorch issue: only leaves support deepcopy).
+    with torch.no_grad():
+        sparse_output, _ = sparse_model(data, "cuda:0")
     sparse_model_traced = symbolic_trace(sparse_model)
 
     with open(os.path.join(save_dir, "gm_sparse.code"), "w") as f:
@@ -147,13 +186,8 @@ def export_model_aot(
             args=(sparse_output,),
             dynamic_shapes=(dynamic_shapes,),
         )
-    # AsserScalar codegen is not correct.
-    with torch._inductor.config.patch(
-        {
-            "scalar_asserts": False,
-            "unsafe_ignore_unsupported_triton_autotune_args": True,
-        }
-    ):
+    _strip_runtime_asserts_for_sample_input_autotune(exported_pg)
+    with torch._inductor.config.patch(_aoti_compile_cfg()):
         aoti_dir = os.path.join(save_dir, "aoti")
         os.makedirs(aoti_dir, exist_ok=True)
 
@@ -419,15 +453,11 @@ def export_unified_model_aot(
             args=(data,),
             dynamic_shapes=(dynamic_shapes,),
         )
+    _strip_runtime_asserts_for_sample_input_autotune(exported_pg)
 
     # Compile with AOTI
     logger.info("compiling unified model with AOTI...")
-    with torch._inductor.config.patch(
-        {
-            "scalar_asserts": False,
-            "unsafe_ignore_unsupported_triton_autotune_args": True,
-        }
-    ):
+    with torch._inductor.config.patch(_aoti_compile_cfg()):
         aoti_dir = os.path.join(save_dir, "aoti")
         os.makedirs(aoti_dir, exist_ok=True)
 

--- a/tzrec/acc/utils.py
+++ b/tzrec/acc/utils.py
@@ -12,10 +12,11 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 import json
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import torch
 
+from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.protos.train_pb2 import TrainConfig
 from tzrec.utils.logging_util import logger
@@ -63,44 +64,56 @@ def is_input_tile_3_online() -> bool:
 
 
 def is_aot() -> bool:
-    """Judge is inductor or not."""
-    is_aot = os.environ.get("ENABLE_AOT")
-    if is_aot and is_aot[0] == "1":
+    """Judge is inductor or not.
+
+    ENABLE_AOT=1: legacy two-stage export (sparse JIT + dense AOTI).
+    ENABLE_AOT=2: unified AOTI export (fused sparse+dense single .pt2).
+    Legacy ``UNIFIED_AOT=1`` is honored as an alias of ``ENABLE_AOT=2``.
+    """
+    val = os.environ.get("ENABLE_AOT")
+    if val and val[0] in ("1", "2"):
         return True
-    else:
-        return False
+    legacy = os.environ.get("UNIFIED_AOT")
+    return bool(legacy) and legacy[0] == "1"
 
 
 def is_unified_aot() -> bool:
-    """Judge whether to use the unified AOTI export.
+    """Judge whether to use the unified AOTI export (ENABLE_AOT=2).
 
-    UNIFIED_AOT=1: fused sparse+dense AOTI model.
-    UNIFIED_AOT=0 (default): legacy two-stage export (sparse JIT + dense AOTI).
+    Legacy ``UNIFIED_AOT=1`` is honored as an alias of ``ENABLE_AOT=2``.
     """
-    unified_aot = os.environ.get("UNIFIED_AOT", "0")
-    return bool(unified_aot) and unified_aot[0] == "1"
+    val = os.environ.get("ENABLE_AOT")
+    if val and val[0] == "2":
+        return True
+    legacy = os.environ.get("UNIFIED_AOT")
+    return bool(legacy) and legacy[0] == "1"
 
 
 def is_unified_aot_predict(model_path: str) -> bool:
     """Judge whether the exported model uses unified AOTI in predict.
 
-    Prefers the explicit UNIFIED_AOT field in model_acc.json. Falls back
-    to file presence (legacy two-stage exports produce
-    scripted_sparse_model.pt; unified exports do not) when the acc.json
-    is missing or does not contain UNIFIED_AOT — this keeps unit tests
-    that bypass the full export pipeline working.
+    Reads ``ENABLE_AOT`` from model_acc.json (=2 → unified). Falls back
+    to the legacy ``UNIFIED_AOT`` key for pre-fold exports, then to
+    file presence (legacy two-stage exports produce
+    scripted_sparse_model.pt; unified exports do not) when neither
+    JSON key is present — keeps unit tests that bypass the full export
+    pipeline working.
     """
     acc_json_path = os.path.join(model_path, "model_acc.json")
     if os.path.exists(acc_json_path):
         with open(acc_json_path, "r", encoding="utf-8") as file:
             data = json.load(file)
-        unified_aot = data.get("UNIFIED_AOT")
-        if unified_aot is not None:
-            return str(unified_aot)[:1] == "1"
+        enable_aot = data.get("ENABLE_AOT")
+        if enable_aot is not None:
+            return str(enable_aot)[:1] == "2"
+        # Pre-fold compat: model_acc.json may carry UNIFIED_AOT.
+        legacy = data.get("UNIFIED_AOT")
+        if legacy is not None:
+            return str(legacy)[:1] == "1"
     sparse_model_path = os.path.join(model_path, "scripted_sparse_model.pt")
     if not os.path.exists(sparse_model_path):
         logger.warning(
-            "model_acc.json missing UNIFIED_AOT; falling back to file-presence "
+            "model_acc.json missing ENABLE_AOT; falling back to file-presence "
             "heuristic (no scripted_sparse_model.pt → unified)"
         )
         return True
@@ -108,13 +121,14 @@ def is_unified_aot_predict(model_path: str) -> bool:
 
 
 def is_aot_predict(model_path: str) -> bool:
-    """Judge is aot or not in predict."""
+    """Judge is aot or not in predict (ENABLE_AOT={1,2})."""
     with open(model_path + "/model_acc.json", "r", encoding="utf-8") as file:
         data = json.load(file)
-    is_aot = data.get("ENABLE_AOT")
-    if is_aot and is_aot[0] == "1":
+    enable_aot = data.get("ENABLE_AOT")
+    if enable_aot and str(enable_aot)[:1] in ("1", "2"):
         return True
-    return False
+    legacy = data.get("UNIFIED_AOT")
+    return bool(legacy) and str(legacy)[:1] == "1"
 
 
 def is_trt() -> bool:
@@ -138,6 +152,23 @@ def is_trt_predict(model_path: str) -> bool:
 def is_cuda_export() -> bool:
     """Judge is trt/aot or not."""
     return is_trt() or is_aot()
+
+
+def is_autotune_with_sample_inputs() -> bool:
+    """Judge whether AOTI should autotune with realized sample inputs.
+
+    AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=1: enable inductor's
+    ``triton.autotune_with_sample_inputs``. Pairs with
+    ``_RemoveRuntimeAssertionsPass`` at the AOTI compile site —
+    sample-input autotune walks the FX graph via
+    ``torch.fx.Interpreter`` which crashes on ``_assert_scalar`` /
+    ``sym_constrain_*`` ops upstream
+    ``_AddRuntimeAssertionsForInlineConstraintsPass`` inserts.
+    AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=0 (default): inductor's default —
+    autotune benches with random tensors (``rand_strided``).
+    """
+    val = os.environ.get("AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS")
+    return bool(val) and val[0] == "1"
 
 
 def is_debug_trt() -> bool:
@@ -225,17 +256,30 @@ def mixed_precision_to_dtype(mixed_precision: Optional[str]) -> Optional[torch.d
     return _MIXED_PRECISION_TO_DTYPE[mixed_precision]
 
 
-def resolve_mixed_precision(pipeline_config: EasyRecConfig) -> str:
-    """Resolve the mixed_precision mode for export/inference.
+def mixed_precision_for_export(pipeline_config: EasyRecConfig) -> str:
+    """Resolve mixed_precision for export.
 
-    Precedence: ``export_config.mixed_precision`` (when set) overrides
-    ``train_config.mixed_precision``. Empty string means no AMP.
+    Compares ``train_config.mixed_precision`` with
+    ``export_config.mixed_precision``; logs a warning when they differ.
+    Returns ``export_config.mixed_precision`` — does not fall back to
+    train_config. The export-time AMP intent must be expressed
+    explicitly on ``export_config``.
     """
-    if pipeline_config.HasField("export_config"):
-        export_mp = pipeline_config.export_config.mixed_precision
-        if export_mp:
-            return export_mp
-    return pipeline_config.train_config.mixed_precision
+    train_mp = pipeline_config.train_config.mixed_precision
+    export_mp = (
+        pipeline_config.export_config.mixed_precision
+        if pipeline_config.HasField("export_config")
+        else ""
+    )
+    if train_mp != export_mp:
+        logger.warning(
+            "export_config.mixed_precision=%r differs from "
+            "train_config.mixed_precision=%r; export uses %r",
+            export_mp,
+            train_mp,
+            export_mp,
+        )
+    return export_mp
 
 
 def write_mapping_file_for_input_tile(
@@ -291,10 +335,16 @@ def export_acc_config(
         acc_config["QUANT_EC_EMB"] = os.environ["QUANT_EC_EMB"]
     if "ENABLE_TRT" in os.environ:
         acc_config["ENABLE_TRT"] = os.environ["ENABLE_TRT"]
-    if "ENABLE_AOT" in os.environ:
-        acc_config["ENABLE_AOT"] = os.environ["ENABLE_AOT"]
-        # Record unified AOT mode (default 0) so predict can detect it.
-        acc_config["UNIFIED_AOT"] = "1" if is_unified_aot() else "0"
+    if "AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS" in os.environ:
+        acc_config["AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS"] = os.environ[
+            "AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS"
+        ]
+    if "MAX_EXPORT_BATCH_SIZE" in os.environ:
+        acc_config["MAX_EXPORT_BATCH_SIZE"] = os.environ["MAX_EXPORT_BATCH_SIZE"]
+    # Normalize ENABLE_AOT — write "2" whenever the resolved mode is unified
+    # (whether via the new env or the legacy UNIFIED_AOT=1).
+    if is_aot():
+        acc_config["ENABLE_AOT"] = "2" if is_unified_aot() else "1"
     if additional_export_config:
         acc_config.update(additional_export_config)
     return acc_config
@@ -314,10 +364,43 @@ def get_max_export_batch_size() -> int:
     return batch_size
 
 
-def allow_tf32(train_config: TrainConfig, backend: str) -> None:
-    """Set allow_tf32 flag for cudnn and cuda matmul."""
-    if backend == "nccl":
-        if train_config.HasField("cudnn_allow_tf32"):
-            torch.backends.cudnn.allow_tf32 = train_config.cudnn_allow_tf32
-        if train_config.HasField("cuda_matmul_allow_tf32"):
-            torch.backends.cuda.matmul.allow_tf32 = train_config.cuda_matmul_allow_tf32
+def allow_tf32(config: Union[TrainConfig, ExportConfig]) -> None:
+    """Apply TF32 flags from ``config`` to ``torch.backends``.
+
+    The flags are hardware-level matmul precision settings, not
+    distributed-backend-specific. Only fields that are explicitly set
+    (``HasField``) are applied; unset fields leave torch.backends as-is.
+    """
+    if config.HasField("cudnn_allow_tf32"):
+        torch.backends.cudnn.allow_tf32 = config.cudnn_allow_tf32
+    if config.HasField("cuda_matmul_allow_tf32"):
+        torch.backends.cuda.matmul.allow_tf32 = config.cuda_matmul_allow_tf32
+
+
+def allow_tf32_for_export(pipeline_config: EasyRecConfig) -> None:
+    """Apply TF32 flags for AOTI export.
+
+    Warns when ``train_config`` and ``export_config`` are both
+    explicitly set on a field and disagree, then applies train_config
+    first and export_config second so train applies for fields export
+    leaves untouched and export wins where set. Must run BEFORE
+    ``torch.export.export()`` so AOTI captures the resolved
+    ``torch.backends`` globals into Triton ``ALLOW_TF32`` constexprs.
+    """
+    train_cfg = pipeline_config.train_config
+    export_cfg = pipeline_config.export_config
+    for field in ("cudnn_allow_tf32", "cuda_matmul_allow_tf32"):
+        if (
+            train_cfg.HasField(field)
+            and export_cfg.HasField(field)
+            and getattr(train_cfg, field) != getattr(export_cfg, field)
+        ):
+            logger.warning(
+                "export_config.%s=%s overrides train_config.%s=%s",
+                field,
+                getattr(export_cfg, field),
+                field,
+                getattr(train_cfg, field),
+            )
+    allow_tf32(train_cfg)
+    allow_tf32(export_cfg)

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -588,7 +588,7 @@ def train_and_evaluate(
     device, backend = init_process_group()
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
-    acc_utils.allow_tf32(train_config, backend)
+    acc_utils.allow_tf32(train_config)
 
     data_config = pipeline_config.data_config
     # Build feature
@@ -810,7 +810,7 @@ def evaluate(
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
     train_config = pipeline_config.train_config
-    acc_utils.allow_tf32(train_config, backend)
+    acc_utils.allow_tf32(train_config)
 
     data_config = pipeline_config.data_config
     # Build feature
@@ -911,6 +911,9 @@ def export(
 
     pipeline_config = config_util.load_pipeline_config(pipeline_config_path)
     ori_pipeline_config = copy.copy(pipeline_config)
+
+    # AOTI bakes allow_tf32 into Triton constexprs at trace time.
+    acc_utils.allow_tf32_for_export(pipeline_config)
 
     if is_rank_zero:
         if os.path.exists(export_dir):
@@ -1090,8 +1093,7 @@ def predict(
     if batch_size:
         pipeline_config.data_config.batch_size = batch_size
 
-    train_config = pipeline_config.train_config
-    acc_utils.allow_tf32(train_config, backend)
+    acc_utils.allow_tf32_for_export(pipeline_config)
 
     is_trt: bool = acc_utils.is_trt_predict(scripted_model_path)
     is_aot: bool = acc_utils.is_aot_predict(scripted_model_path)
@@ -1330,7 +1332,7 @@ def predict_checkpoint(
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
     train_config = pipeline_config.train_config
-    acc_utils.allow_tf32(train_config, backend)
+    acc_utils.allow_tf32(train_config)
 
     data_config = pipeline_config.data_config
     # Build feature

--- a/tzrec/protos/export.proto
+++ b/tzrec/protos/export.proto
@@ -11,9 +11,14 @@ message ExportConfig {
     // metric value the bigger the best
     optional bool metric_larger_is_better = 3 [default = true];
     // mixed precision mode for inference/export [BF16 | FP16 | ""].
-    // If empty, falls back to train_config.mixed_precision. When set, the
-    // dense sub-graph is wrapped in torch.autocast before torch.export so
-    // that AOT Inductor captures dtype-promoting casts as a
-    // wrap_with_autocast HOP.
+    // The export-time AMP intent is taken verbatim from this field; if it
+    // disagrees with train_config.mixed_precision a warning is logged.
+    // When set, the dense sub-graph is wrapped in torch.autocast before
+    // torch.export so that AOT Inductor captures dtype-promoting casts
+    // as a wrap_with_autocast HOP.
     optional string mixed_precision = 4 [default = ''];
+    // whether to use torch.backends.cudnn.allow_tf32
+    optional bool cudnn_allow_tf32 = 5 [default = true];
+    // whether to use torch.backends.cuda.matmul.allow_tf32
+    optional bool cuda_matmul_allow_tf32 = 6 [default = false];
 }

--- a/tzrec/tests/configs/dlrm_hstu_cutlass_kuairand_1k.config
+++ b/tzrec/tests/configs/dlrm_hstu_cutlass_kuairand_1k.config
@@ -20,6 +20,9 @@ train_config {
     save_checkpoints_epochs: 1
     mixed_precision: "BF16"
 }
+export_config {
+    mixed_precision: "BF16"
+}
 data_config {
     batch_size: 8
     dataset_type: ParquetDataset

--- a/tzrec/tests/configs/dlrm_hstu_kuairand_1k.config
+++ b/tzrec/tests/configs/dlrm_hstu_kuairand_1k.config
@@ -20,6 +20,9 @@ train_config {
     save_checkpoints_epochs: 1
     mixed_precision: "BF16"
 }
+export_config {
+    mixed_precision: "BF16"
+}
 data_config {
     batch_size: 8
     dataset_type: ParquetDataset

--- a/tzrec/tests/configs/ultra_hstu_cutlass_kuairand_1k.config
+++ b/tzrec/tests/configs/ultra_hstu_cutlass_kuairand_1k.config
@@ -20,6 +20,9 @@ train_config {
     save_checkpoints_epochs: 1
     mixed_precision: "BF16"
 }
+export_config {
+    mixed_precision: "BF16"
+}
 data_config {
     batch_size: 8
     dataset_type: ParquetDataset

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -1010,13 +1010,11 @@ class RankIntegrationTest(unittest.TestCase):
         with open(model_acc_path) as f:
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg["cand_seq_pk"], "cand_seq")
-            self.assertEqual(acc_cfg["ENABLE_AOT"], "1")
 
     @mark_ci_scope("h20")
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_train_eval_export(self):
-        # Default path: UNIFIED_AOT defaults to disabled, uses legacy
-        # two-stage export (sparse JIT + dense AOTI).
+        # Default path: legacy two-stage export (sparse JIT + dense AOTI).
         self._test_rank_dlrm_hstu_train_eval_export(export_env_str="ENABLE_AOT=1")
         # Two-stage export must produce both the JIT sparse model and the
         # AOTI dense model.
@@ -1025,24 +1023,40 @@ class RankIntegrationTest(unittest.TestCase):
                 os.path.join(self.test_dir, "export/scripted_sparse_model.pt")
             )
         )
+        with open(os.path.join(self.test_dir, "export/model_acc.json")) as f:
+            self.assertEqual(json.load(f).get("ENABLE_AOT"), "1")
 
     @mark_ci_scope("h20")
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_train_eval_export_unified_aot(self):
-        # Verify the unified AOTI export path (UNIFIED_AOT=1) for DLRM-HSTU.
-        self._test_rank_dlrm_hstu_train_eval_export(
-            export_env_str="ENABLE_AOT=1 UNIFIED_AOT=1"
-        )
+        # Unified AOTI export (ENABLE_AOT=2): fused sparse+dense single .pt2.
+        self._test_rank_dlrm_hstu_train_eval_export(export_env_str="ENABLE_AOT=2")
         # Unified export must NOT produce the legacy JIT sparse model file.
         self.assertFalse(
             os.path.exists(
                 os.path.join(self.test_dir, "export/scripted_sparse_model.pt")
             )
         )
-        # model_acc.json must explicitly record UNIFIED_AOT=1.
+        # model_acc.json must explicitly record ENABLE_AOT=2.
         with open(os.path.join(self.test_dir, "export/model_acc.json")) as f:
             acc_cfg = json.load(f)
-            self.assertEqual(acc_cfg.get("UNIFIED_AOT"), "1")
+            self.assertEqual(acc_cfg.get("ENABLE_AOT"), "2")
+
+    @mark_ci_scope("h20")
+    @unittest.skipIf(*gpu_unavailable)
+    def test_rank_dlrm_hstu_train_eval_export_autotune_with_sample_inputs(self):
+        # Exercise the AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS path with a small
+        # MAX_EXPORT_BATCH_SIZE so the FX-Interpreter bench walk stays light.
+        self._test_rank_dlrm_hstu_train_eval_export(
+            export_env_str=(
+                "ENABLE_AOT=1 AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=1 "
+                "MAX_EXPORT_BATCH_SIZE=2"
+            )
+        )
+        with open(os.path.join(self.test_dir, "export/model_acc.json")) as f:
+            acc_cfg = json.load(f)
+            self.assertEqual(acc_cfg.get("AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS"), "1")
+            self.assertEqual(acc_cfg.get("MAX_EXPORT_BATCH_SIZE"), "2")
 
     @mark_ci_scope("h20")
     @unittest.skipIf(*gpu_unavailable)

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -227,7 +227,7 @@ def export_model_normal(
         model.eval()
 
         data = batch.to_dict(sparse_dtype=torch.int64)
-        mixed_precision = acc_utils.resolve_mixed_precision(pipeline_config)
+        mixed_precision = acc_utils.mixed_precision_for_export(pipeline_config)
         autocast_dtype = acc_utils.mixed_precision_to_dtype(mixed_precision)
         if acc_utils.is_trt() or acc_utils.is_aot():
             data = OrderedDict(sorted(data.items()))

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
## Summary

- Always set inductor's ``_use_fp64_for_unbacked_floats=False`` at AOTI compile so Python-``float`` scalar Triton kernel args get fp32 specialization (the fp64 default forces Newton-Raphson ``tl.sigmoid`` lowering on architectures without native ``ex2.f64``).
- Add ``AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=1`` env. When on, enable inductor's ``triton.autotune_with_sample_inputs`` and apply ``_RemoveRuntimeAssertionsPass`` to the exported program — sample-input autotune walks the FX graph via ``torch.fx.Interpreter`` which crashes on ``_assert_scalar`` / ``sym_constrain_*`` ops, so the two changes pair under one env.
- Add ``cudnn_allow_tf32`` and ``cuda_matmul_allow_tf32`` to ``ExportConfig`` (mirroring ``TrainConfig`` defaults). New ``allow_tf32_for_export(pipeline_config)`` warns when train/export disagree, then applies train then export so explicit settings combine with export winning where set. Called from ``main.export()`` before ``torch.export.export()`` so AOTI bakes the right globals into Triton ``ALLOW_TF32`` constexprs.
- ``allow_tf32(...)`` drops the dead ``backend == "nccl"`` gate and the unused ``backend`` arg.
- Rename ``resolve_mixed_precision`` → ``mixed_precision_for_export`` with compare-and-warn semantics (no train fallback — export-time AMP intent must be explicit on ``export_config``).
- Fold ``UNIFIED_AOT`` into ``ENABLE_AOT``: ``ENABLE_AOT=1`` legacy two-stage, ``ENABLE_AOT=2`` unified. Legacy ``UNIFIED_AOT=1`` env and JSON key remain honored as aliases for backwards compat.
- ``export_acc_config()`` persists ``AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS`` and ``MAX_EXPORT_BATCH_SIZE`` into ``model_acc.json``.
- Docs: drop "(experimental)" on ``ENABLE_AOT=1``; add ``ENABLE_AOT=2`` entry; bump ``processor`` reference to ``easyrec-torch-2.2``.

## Test plan

- [x] ``tzrec/acc/aot_utils.py`` and ``tzrec/acc/utils.py`` import cleanly under the standard tzrec environment.
- [x] ``_aoti_compile_cfg()`` returns the expected keys with and without ``AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS``.
- [x] ``ENABLE_AOT={1,2}`` and legacy ``UNIFIED_AOT=1`` produce the right ``is_aot`` / ``is_unified_aot`` values.
- [x] ``mixed_precision_for_export`` returns export's value, warns on disagreement.
- [x] ``allow_tf32_for_export`` applies train then export with warning on disagreement.
- [ ] (GPU host) ``test_rank_dlrm_hstu_train_eval_export``
- [ ] (GPU host) ``test_rank_dlrm_hstu_train_eval_export_unified_aot`` (now ``ENABLE_AOT=2``)
- [ ] (GPU host) ``test_rank_dlrm_hstu_train_eval_export_autotune_with_sample_inputs`` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)