### PR TITLE
[feat] stu.scaling_seqlen + drop autotune assert strip

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -305,3 +305,38 @@ torch.AcceleratorError: CUDA error: an illegal memory access was encountered
 ```bash
 pip install --force-reinstall --no-deps "https://tzrec.oss-cn-beijing.aliyuncs.com/third_party/triton/triton-3.6.0%2B565c08520-cp311-cp311-linux_x86_64.whl"
 ```
+
+______________________________________________________________________
+
+**Q16: DlrmHSTU/UltraHSTU AOTI sample-input autotune导出报错 `_assert_scalar(u? <= K)`**
+
+**报错信息：**
+
+```
+torch._inductor.exc.InductorError: RuntimeError: Runtime assertion failed for expression u0 <= 2002 on node 'le_5'
+While executing %_assert_scalar_1 = call_function[target=torch.ops.aten._assert_scalar.default](args = (%le, "Runtime assertion failed for expression u0 <= 2002 on node 'le_5'"), kwargs = {})
+```
+
+**原因：** 开启`AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=1`后，AOTI在`extract_autotune_inputs`中通过`torch.fx.Interpreter`走一次sample-input图，会触达由torch.export插入的`_assert_scalar(u_i <= K)`节点。这里：
+
+- `u0/u2` 是 `max(uih_seq_lengths).item() / max(num_targets).item()`等data-dependent unbacked SymInt（见`tzrec/modules/gr/preprocessors.py:375-381`）；
+- `tzrec/ops/utils.py:74` 的 `torch._check(max_len >= runtime_max_seq_len)` 在 `runtime_max_seq_len = max_uih_len + max_targets + max_contextual_seq_len`（见`preprocessors.py:283 + :325`）替换之后，给出 sum 上界 `u0 + u2 ≤ max_seq_len − max_contextual_seq_len`；sympy 进一步用 `u2 ≥ 1` 推出 per-symbol 上界 `u0 ≤ max_seq_len − max_contextual_seq_len − 1`；
+- PyTorch对unbacked SymInt的`node.hint`在创建时一次性赋值（约等于`max_seq_len`），后续`torch._check`只更新value-range而不回填hint；当hint大于 per-symbol 上界时 sample-input 走graph会触发 assert。
+
+**解决方法：** 调大`model_config.max_seq_len`使派生上界跳过hint，同时通过新增的`stu.scaling_seqlen`把attention scaling分母固定为原`max_seq_len`，保持推理跟训练时计算完全一致。例：原`max_seq_len: 2048`、`max_contextual_seq_len = 45`，per-symbol 上界 `2048 − 45 − 1 = 2002` 被 hint=2048 打破；改为：
+
+```protobuf
+model_config {
+  dlrm_hstu {
+    hstu {
+      stu {
+        # ...其余字段不变...
+        scaling_seqlen: 2048   # 与训练时相同；保持attention scaling
+      }
+    }
+    max_seq_len: 2112          # 原2048 + 余量；新 per-symbol 上界 2112−45−1 = 2066 > hint
+  }
+}
+```
+
+具体余量需大于`max_contextual_seq_len + 1`（`max_contextual_seq_len` = contextual feature group的特征数）。

--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -15,9 +15,6 @@ from typing import Any, Dict, Optional, Set, Union
 
 import torch
 from torch import nn
-from torch._export.passes.remove_runtime_assertions import (
-    _RemoveRuntimeAssertionsPass,
-)
 
 from tzrec.acc.utils import is_autotune_with_sample_inputs, is_unified_aot_predict
 from tzrec.models.model import (
@@ -44,22 +41,6 @@ def _aoti_compile_cfg() -> Dict[str, Any]:
     if is_autotune_with_sample_inputs():
         cfg["triton.autotune_with_sample_inputs"] = True
     return cfg
-
-
-def _strip_runtime_asserts_for_sample_input_autotune(
-    exported_pg: torch.export.ExportedProgram,
-) -> None:
-    """Strip runtime asserts before sample-input autotune.
-
-    Sample-input autotune walks the FX graph via ``torch.fx.Interpreter``,
-    which crashes on ``_assert_scalar`` / ``sym_constrain_*`` ops; strip
-    them when ``AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS`` is on. No-op otherwise.
-    """
-    if not is_autotune_with_sample_inputs():
-        return
-    pass_result = _RemoveRuntimeAssertionsPass()(exported_pg.graph_module)
-    if pass_result.modified:
-        exported_pg.graph_module.recompile()
 
 
 def load_model_aot(
@@ -186,7 +167,6 @@ def export_model_aot(
             args=(sparse_output,),
             dynamic_shapes=(dynamic_shapes,),
         )
-    _strip_runtime_asserts_for_sample_input_autotune(exported_pg)
     with torch._inductor.config.patch(_aoti_compile_cfg()):
         aoti_dir = os.path.join(save_dir, "aoti")
         os.makedirs(aoti_dir, exist_ok=True)
@@ -453,7 +433,6 @@ def export_unified_model_aot(
             args=(data,),
             dynamic_shapes=(dynamic_shapes,),
         )
-    _strip_runtime_asserts_for_sample_input_autotune(exported_pg)
 
     # Compile with AOTI
     logger.info("compiling unified model with AOTI...")

--- a/tzrec/acc/utils.py
+++ b/tzrec/acc/utils.py
@@ -158,14 +158,17 @@ def is_autotune_with_sample_inputs() -> bool:
     """Judge whether AOTI should autotune with realized sample inputs.
 
     AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=1: enable inductor's
-    ``triton.autotune_with_sample_inputs``. Pairs with
-    ``_RemoveRuntimeAssertionsPass`` at the AOTI compile site —
-    sample-input autotune walks the FX graph via
-    ``torch.fx.Interpreter`` which crashes on ``_assert_scalar`` /
-    ``sym_constrain_*`` ops upstream
-    ``_AddRuntimeAssertionsForInlineConstraintsPass`` inserts.
-    AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=0 (default): inductor's default —
-    autotune benches with random tensors (``rand_strided``).
+    ``triton.autotune_with_sample_inputs``. Sample-input autotune walks
+    the FX graph via ``torch.fx.Interpreter``, dispatching
+    ``_assert_scalar`` / ``sym_constrain_*`` nodes that
+    ``_AddRuntimeAssertionsForInlineConstraintsPass`` inserts upstream.
+    If a node's predicate evaluates False on the materialized hint --
+    typical for HSTU's data-dependent unbacked SymInts when the hint
+    exceeds the derived bound -- AOTI compile aborts. Mitigate via
+    ``stu.scaling_seqlen`` plus a bumped ``model_config.max_seq_len``
+    (see FAQ Q16). AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS=0 (default):
+    inductor's default -- autotune benches with random tensors
+    (``rand_strided``).
     """
     val = os.environ.get("AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS")
     return bool(val) and val[0] == "1"

--- a/tzrec/modules/gr/hstu_transducer.py
+++ b/tzrec/modules/gr/hstu_transducer.py
@@ -105,7 +105,8 @@ class HSTUTransducer(BaseModule):
         stu = dict(stu)
         if "contextual_seq_len" not in stu:
             stu["contextual_seq_len"] = self._input_preprocessor.contextual_seq_len()
-        if "scaling_seqlen" not in stu:
+        # scaling_seqlen has [default = -1]; < 0 means "use the kwarg fallback".
+        if stu.get("scaling_seqlen", -1) < 0:
             stu["scaling_seqlen"] = scaling_seqlen
         self._stu_module: STUStack = STUStack(
             stu_list=[STULayer(**stu) for _ in range(attn_num_layers)],

--- a/tzrec/optim/optimizer_builder.py
+++ b/tzrec/optim/optimizer_builder.py
@@ -51,12 +51,11 @@ def create_sparse_optimizer(
     if optimizer_type == "sgd_optimizer":
         return optimizers.SGD, optimizer_kwargs
     elif optimizer_type == "adagrad_optimizer":
-        if "initial_accumulator_value" in optimizer_kwargs:
+        # config_to_kwargs emits every optional field with its zero default.
+        init_acc = optimizer_kwargs.pop("initial_accumulator_value", 0)
+        if init_acc:
             # see apply_split_helper function patch in tzrec.optim.optimizer.py
-            os.environ["FBGEMM_MOMENTUM1_STATE_INIT_VALUE"] = str(
-                optimizer_kwargs["initial_accumulator_value"]
-            )
-            optimizer_kwargs.pop("initial_accumulator_value")
+            os.environ["FBGEMM_MOMENTUM1_STATE_INIT_VALUE"] = str(init_acc)
         return optimizers.Adagrad, optimizer_kwargs
     elif optimizer_type == "adam_optimizer":
         return optimizers.Adam, optimizer_kwargs

--- a/tzrec/protos/module.proto
+++ b/tzrec/protos/module.proto
@@ -259,6 +259,8 @@ message STU {
     optional uint32 sla_k1 = 14;
     // Semi-Local Attention: global prefix length (0 = disabled)
     optional uint32 sla_k2 = 15;
+    // attention scaling divisor; < 0 (default) = runtime max_seq_len.
+    optional int32 scaling_seqlen = 16 [default = -1];
 }
 
 message GRPositionalEncoder {

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"


### PR DESCRIPTION
## Summary

- Replace the silent `_strip_runtime_asserts_for_sample_input_autotune` workaround with a documented, configurable mechanism. The strip masked a real `torch.fx.Interpreter` failure during AOTI's sample-input autotune: PyTorch's deferred runtime asserts on unbacked SymInts (e.g. `u0 = max(uih_seq_lengths).item()`) evaluate to False because the SymNode's `node.hint` is set once at creation (~`max_seq_len`) and is not re-tightened by later `torch._check`. The Interpreter then dispatches `_assert_scalar(u0 <= K)` against the stale hint and aborts AOTI compile.
- Add `optional int32 scaling_seqlen = 16 [default = -1];` to the `STU` proto so users can decouple HSTU attention scaling from `max_seq_len` and bump `max_seq_len` above the hint without changing inference behavior. `HSTUTransducer.__init__` treats `< 0` (proto default emission) as "unset" and falls back to the constructor kwarg (`= max_seq_len`).
- Refresh the `is_autotune_with_sample_inputs` docstring to drop the stale `_RemoveRuntimeAssertionsPass` reference and point at the FAQ recipe.
- FAQ Q16 (zh-CN) documents the failure mode and the recipe (bump `max_seq_len`; pin `stu.scaling_seqlen` to the original).
- Bump version to 1.2.3.

Trailing `[bugfix]` commit: `FusedAdagradOptimizer.initial_accumulator_value` was always present in the kwargs dict (proto2 + `including_default_value_fields=True`), so the existing `if "initial_accumulator_value" in optimizer_kwargs:` check at `optimizer_builder.py:54` was dead-true. The FBGEMM env var was therefore overwritten on every optimizer build (with `"0"` when the user hadn't configured anything) and persisted across optimizer rebuilds in the same process. Now we pop the field unconditionally and only set the env var when the user supplied a non-zero value.

## Test plan

- [x] `python -m unittest tzrec.tests.rank_integration_test.RankIntegrationTest.test_rank_dlrm_hstu_train_eval_export_autotune_with_sample_inputs` — passes (kuairand-1k, BF16) on both commits.
- [x] Real production-shape dlrm_hstu (fp32) that previously crashed at AOTI compile with `_assert_scalar(u0 <= 2002)` succeeds end-to-end after applying the FAQ recipe (`max_seq_len: 2048 → 2112` with `stu.scaling_seqlen: 2048` pinned). Both `scripted_sparse_model.pt` and `aoti/aoti_model.pt2` produced.
- [ ] H20 CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
