### PR TITLE
[bugfix] replace deprecated torch._check_is_size with torch._check

### DIFF
--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -50,7 +50,6 @@ def _to_tensor(x: npt.NDArray) -> torch.Tensor:
 def _tile_size(x: torch.Tensor) -> int:
     tile_size = x.item()
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
-        torch._check_is_size(tile_size)
         # check tile_size = 1 to make dynamo check size happy,
         # because in DataParser.parse, we always set tile_size = 1.
         torch._check(tile_size == 1)

--- a/tzrec/ops/_triton/triton_jagged_tensors.py
+++ b/tzrec/ops/_triton/triton_jagged_tensors.py
@@ -510,7 +510,7 @@ def triton_split_2d_jagged_fwd(
             # assert total_len_left + total_len_right == total_seq_len
             total_len_a = total_len_left
             total_len_b = total_len_right
-            torch._check_is_size(total_len_a)
+            torch._check(total_len_a >= 0)
             # torch._check(total_len_a > 0)
             # torch._check(total_len_a < 10**9)
         else:

--- a/tzrec/ops/utils.py
+++ b/tzrec/ops/utils.py
@@ -28,7 +28,7 @@ def switch_to_contiguous_if_needed(x: torch.Tensor) -> torch.Tensor:
         # Tell Dynamo this data-dependent value is in the range (0, 10**9)
         # torch._check(x.size(0) > 0)
         # torch._check(x.size(0) < 10**9)
-        torch._check_is_size(x.size(0))
+        torch._check(x.size(0) >= 0)
     if x.stride(-1) == 1:
         return x
     return x.contiguous()

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -611,7 +611,8 @@ def _rtp_slice_with_seq_len(
     x: torch.Tensor, seq_len: torch.Tensor, max_seq_len: int
 ) -> torch.Tensor:
     seq_len_int = seq_len.max().item()
-    torch._check_is_size(seq_len_int, max=max_seq_len)
+    torch._check(seq_len_int >= 0)
+    torch._check(seq_len_int <= max_seq_len)
     return x[:, :seq_len_int, :]
 
 

--- a/tzrec/utils/fx_util.py
+++ b/tzrec/utils/fx_util.py
@@ -64,8 +64,8 @@ def fx_int_item(x: torch.Tensor) -> int:
     """Fx trace wrapper for `int(x.item())`."""
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
         int_item = x.item()
-        torch._check_is_size(int_item, max=2**31)
         torch._check(int_item > 0)
+        torch._check(int_item <= 2**31 - 1)
     else:
         int_item = int(x.item())
     # pyre-ignore[7]
@@ -77,7 +77,8 @@ def fx_numel(x: torch.Tensor) -> int:
     """Fx trace wrapper for x.numel()."""
     total_len = x.numel()
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
-        torch._check_is_size(total_len, max=2**31)
+        torch._check(total_len >= 0)
+        torch._check(total_len <= 2**31 - 1)
     return total_len
 
 


### PR DESCRIPTION
## Summary

PyTorch 2.11 emits a `FutureWarning` from every `torch._check_is_size(...)` call:

> `_check_is_size will be removed in a future PyTorch release along with guard_size_oblivious. Use _check(i >= 0) instead.`

The warning fires on every AOTI export / Dynamo compile that goes through HSTU preprocessors, jagged-tensor splits, `.item()` extractions, or the RTP slice path. Apply the upstream-recommended substitution at all 6 call sites:

| Original | Replacement |
|---|---|
| `torch._check_is_size(i)` | `torch._check(i >= 0)` |
| `torch._check_is_size(i, max=M)` | `torch._check(i >= 0)` + `torch._check(i <= M)` |

Touched files:
- `tzrec/ops/utils.py` (`switch_to_contiguous_if_needed`)
- `tzrec/ops/_triton/triton_jagged_tensors.py` (`triton_split_2d_jagged_fwd`)
- `tzrec/utils/fx_util.py` (`fx_int_item`, `fx_numel`)
- `tzrec/utils/export_util.py` (`_rtp_slice_with_seq_len`)
- `tzrec/datasets/data_parser.py` (`_tile_size`)

Minor folded-in cleanups:
- `fx_util.py`: tighten the int32 cap from `2**31` to `2**31 - 1` (`INT32_MAX`) — the prior bound permitted a value that overflows int32 by one.
- `data_parser._tile_size`: drop the redundant non-negativity check since the adjacent `torch._check(tile_size == 1)` is strictly stronger.

PyTorch is also retiring `guard_size_oblivious` alongside `_check_is_size`, so no real feature is being lost — this is the supported path going forward.

## Test plan

- [x] `grep -rn "_check_is_size" tzrec/` returns no hits
- [x] `pre-commit run` clean on all 5 changed files
- [x] `python -W error::FutureWarning -c "import tzrec.ops.utils; ..."` no FutureWarning raised
- [x] `torch.compile(fx_numel, dynamic=True, fullgraph=True)` compiles and returns correct result (smoke verifies the new `_check` constraints lower without `_assert_scalar` failure)
- [x] `python -m unittest tzrec.datasets.data_parser_test` — 17/17 pass
- [ ] AOTI export of an HSTU model (e.g. `tzrec/tests/...`) shows no `_check_is_size` FutureWarning in the compile log

🤖 Generated with [Claude Code](https://claude.com/claude-code)