### PR TITLE
[feat] FeatureGroupConfig.embedding_name_suffix to break embedding sharing across groups

### DIFF
--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -57,7 +57,7 @@ model_config {
 }
 ```
 
-配置样例（嵌套sequence_group用自己的后缀覆盖父group的传递值）：
+配置样例（嵌套sequence_group用自己的后缀覆盖父group的传递值，未设置的sequence_group则继承父group的后缀）：
 
 ```
 feature_groups {
@@ -71,8 +71,16 @@ feature_groups {
         feature_names: "click_seq__cat_a"
         embedding_name_suffix: "click_only"
     }
+    sequence_groups {
+        group_name: "buy_seq"
+        feature_names: "cat_a"
+        feature_names: "buy_seq__cat_a"
+    }
     sequence_encoders {
         simple_attention { input: "click_seq" }
+    }
+    sequence_encoders {
+        simple_attention { input: "buy_seq" }
     }
 }
 ```

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -33,9 +33,8 @@ WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_nam
 - 不设置或为空：保持默认行为，相同embedding_name的特征跨feature_group共享embedding表。
 - 不同feature_group设置相同的embedding_name_suffix：仍共享同一embedding表。
 - 不同feature_group设置不同的embedding_name_suffix：使用各自独立的embedding表。
-- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`同样支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
+- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`也支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
 - 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
-- 若两个feature_group的最终embedding表名相同但`embedding_name_suffix`不同（即存在隐式碰撞，例如手工命名的`embedding_name`恰好包含suffix前缀字符串），构造`EmbeddingGroup`时会直接抛出`ValueError`，以避免静默合并本应独立的embedding表。
 
 配置样例（双塔不共享embedding）：
 

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -33,7 +33,8 @@ WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_nam
 - 不设置或为空：保持默认行为，相同embedding_name的特征跨feature_group共享embedding表。
 - 不同feature_group设置相同的embedding_name_suffix：仍共享同一embedding表。
 - 不同feature_group设置不同的embedding_name_suffix：使用各自独立的embedding表。
-- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`也支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
+- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。
+- `SeqGroupConfig`同样暴露`embedding_name_suffix`字段；在子sequence_group上显式设置该字段，会覆盖父feature_group传递下来的值。
 - 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
 
 配置样例（双塔不共享embedding）：

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -36,55 +36,6 @@ WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_nam
 - 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`也支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
 - 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
 
-配置样例（双塔不共享embedding）：
-
-```
-model_config {
-    feature_groups {
-        group_name: "tower_a"
-        feature_names: "cat_a"
-        feature_names: "cat_b"
-        group_type: DEEP
-        embedding_name_suffix: "tower_a"
-    }
-    feature_groups {
-        group_name: "tower_b"
-        feature_names: "cat_a"
-        feature_names: "cat_b"
-        group_type: DEEP
-        embedding_name_suffix: "tower_b"
-    }
-}
-```
-
-配置样例（嵌套sequence_group用自己的后缀覆盖父group的传递值，未设置的sequence_group则继承父group的后缀）：
-
-```
-feature_groups {
-    group_name: "deep"
-    feature_names: "cat_a"
-    group_type: DEEP
-    embedding_name_suffix: "tower_a"
-    sequence_groups {
-        group_name: "click_seq"
-        feature_names: "cat_a"
-        feature_names: "click_seq__cat_a"
-        embedding_name_suffix: "click_only"
-    }
-    sequence_groups {
-        group_name: "buy_seq"
-        feature_names: "cat_a"
-        feature_names: "buy_seq__cat_a"
-    }
-    sequence_encoders {
-        simple_attention { input: "click_seq" }
-    }
-    sequence_encoders {
-        simple_attention { input: "buy_seq" }
-    }
-}
-```
-
 ## 配置样例
 
 ```
@@ -159,4 +110,53 @@ model_config {
     }
 }
 
+```
+
+### embedding_name_suffix 双塔不共享embedding
+
+```
+model_config {
+    feature_groups {
+        group_name: "tower_a"
+        feature_names: "cat_a"
+        feature_names: "cat_b"
+        group_type: DEEP
+        embedding_name_suffix: "tower_a"
+    }
+    feature_groups {
+        group_name: "tower_b"
+        feature_names: "cat_a"
+        feature_names: "cat_b"
+        group_type: DEEP
+        embedding_name_suffix: "tower_b"
+    }
+}
+```
+
+### embedding_name_suffix 嵌套sequence_group 覆盖/继承父group后缀
+
+```
+feature_groups {
+    group_name: "deep"
+    feature_names: "cat_a"
+    group_type: DEEP
+    embedding_name_suffix: "tower_a"
+    sequence_groups {
+        group_name: "click_seq"
+        feature_names: "cat_a"
+        feature_names: "click_seq__cat_a"
+        embedding_name_suffix: "click_only"
+    }
+    sequence_groups {
+        group_name: "buy_seq"
+        feature_names: "cat_a"
+        feature_names: "buy_seq__cat_a"
+    }
+    sequence_encoders {
+        simple_attention { input: "click_seq" }
+    }
+    sequence_encoders {
+        simple_attention { input: "buy_seq" }
+    }
+}
 ```

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -33,8 +33,7 @@ WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_nam
 - 不设置或为空：保持默认行为，相同embedding_name的特征跨feature_group共享embedding表。
 - 不同feature_group设置相同的embedding_name_suffix：仍共享同一embedding表。
 - 不同feature_group设置不同的embedding_name_suffix：使用各自独立的embedding表。
-- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。
-- `SeqGroupConfig`同样暴露`embedding_name_suffix`字段；在子sequence_group上显式设置该字段，会覆盖父feature_group传递下来的值。
+- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`也支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
 - 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
 
 配置样例（双塔不共享embedding）：

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -26,6 +26,37 @@ DEEP: 深度特征组。其中feature_names只能包含非序列特征（IdFeatu
 
 WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_names只能包含非序列特征IdFeature/RawFeature/ComboFeature等，embedding_dim固定为4，不根据feature_group中的embedding_dim的配置变化而变化，开发者可以根据group_name从EmbeddingGroup的输出字典中获取到相应的特征组Embedding。不可以包含sequence_groups。
 
+### embedding_name_suffix（可选）
+
+为feature_group内所有特征的embedding_name追加后缀，使不同feature_group即使引用相同特征也能使用独立的embedding表，无需为每个塔重复定义特征配置。
+
+- 不设置或为空：保持默认行为，相同embedding_name的特征跨feature_group共享embedding表。
+- 不同feature_group设置相同的embedding_name_suffix：仍共享同一embedding表。
+- 不同feature_group设置不同的embedding_name_suffix：使用各自独立的embedding表。
+- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups（除非该sequence_group显式设置了自己的embedding_name_suffix）。
+- 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
+
+配置样例（双塔不共享embedding）：
+
+```
+model_config {
+    feature_groups {
+        group_name: "tower_a"
+        feature_names: "cat_a"
+        feature_names: "cat_b"
+        group_type: DEEP
+        embedding_name_suffix: "tower_a"
+    }
+    feature_groups {
+        group_name: "tower_b"
+        feature_names: "cat_a"
+        feature_names: "cat_b"
+        group_type: DEEP
+        embedding_name_suffix: "tower_b"
+    }
+}
+```
+
 ## 配置样例
 
 ```

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -33,8 +33,9 @@ WIDE: 广度特征组，主要用于WideAndDeep/DeepFM模型。其中feature_nam
 - 不设置或为空：保持默认行为，相同embedding_name的特征跨feature_group共享embedding表。
 - 不同feature_group设置相同的embedding_name_suffix：仍共享同一embedding表。
 - 不同feature_group设置不同的embedding_name_suffix：使用各自独立的embedding表。
-- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups（除非该sequence_group显式设置了自己的embedding_name_suffix）。
+- 当DEEP feature_group同时设置embedding_name_suffix和嵌套sequence_groups时，后缀会自动传递到嵌套的sequence_groups。`SeqGroupConfig`同样支持`embedding_name_suffix`字段，在子sequence_group上显式设置该字段会覆盖父feature_group传递下来的值。
 - 当WIDE feature_group设置embedding_name_suffix时，最终embedding表名为`<emb_name>_wide_<suffix>`。
+- 若两个feature_group的最终embedding表名相同但`embedding_name_suffix`不同（即存在隐式碰撞，例如手工命名的`embedding_name`恰好包含suffix前缀字符串），构造`EmbeddingGroup`时会直接抛出`ValueError`，以避免静默合并本应独立的embedding表。
 
 配置样例（双塔不共享embedding）：
 

--- a/docs/source/models/feature_group.md
+++ b/docs/source/models/feature_group.md
@@ -57,6 +57,26 @@ model_config {
 }
 ```
 
+配置样例（嵌套sequence_group用自己的后缀覆盖父group的传递值）：
+
+```
+feature_groups {
+    group_name: "deep"
+    feature_names: "cat_a"
+    group_type: DEEP
+    embedding_name_suffix: "tower_a"
+    sequence_groups {
+        group_name: "click_seq"
+        feature_names: "cat_a"
+        feature_names: "click_seq__cat_a"
+        embedding_name_suffix: "click_only"
+    }
+    sequence_encoders {
+        simple_attention { input: "click_seq" }
+    }
+}
+```
+
 ## 配置样例
 
 ```

--- a/tzrec/modules/embedding.py
+++ b/tzrec/modules/embedding.py
@@ -178,12 +178,6 @@ class EmbeddingGroup(nn.Module):
             group_name = feature_group.group_name
             self._inspect_and_supplement_feature_group(feature_group, seq_group_names)
             # self._add_feature_group_sign_for_sequence_groups(feature_group)
-            # propagate parent's embedding_name_suffix to nested sequence_groups
-            # that don't set their own.
-            if feature_group.embedding_name_suffix:
-                for sg in feature_group.sequence_groups:
-                    if not sg.embedding_name_suffix:
-                        sg.embedding_name_suffix = feature_group.embedding_name_suffix
             features_data_group = defaultdict(list)
             for feature_name in feature_group.feature_names:
                 feature = self._name_to_feature[feature_name]
@@ -211,9 +205,21 @@ class EmbeddingGroup(nn.Module):
             else:
                 self._impl_key_to_feat_groups[impl_key].append(feature_group)
                 if len(feature_group.sequence_groups) > 0:
-                    self._impl_key_to_seq_groups[impl_key].extend(
-                        list(feature_group.sequence_groups)
-                    )
+                    # Copy each nested sequence_group so the caller's proto is
+                    # not mutated, then propagate the parent suffix when the
+                    # child doesn't set its own. Keeps construction idempotent
+                    # across repeated EmbeddingGroup builds (train/eval/export).
+                    for sequence_group in feature_group.sequence_groups:
+                        sg_copy = model_pb2.SeqGroupConfig()
+                        sg_copy.CopyFrom(sequence_group)
+                        if (
+                            feature_group.embedding_name_suffix
+                            and not sg_copy.embedding_name_suffix
+                        ):
+                            sg_copy.embedding_name_suffix = (
+                                feature_group.embedding_name_suffix
+                            )
+                        self._impl_key_to_seq_groups[impl_key].append(sg_copy)
                 if len(feature_group.sequence_encoders) > 0:
                     self._group_name_to_seq_encoder_configs[group_name] = list(
                         feature_group.sequence_encoders
@@ -513,6 +519,32 @@ class EmbeddingGroup(nn.Module):
         return values_list
 
 
+def _check_emb_name_suffix_collisions(
+    feat_to_group_to_emb_name: Dict[str, Dict[str, str]],
+    group_name_to_suffix: Dict[str, str],
+) -> None:
+    """Detect silent emb-name collisions across groups with different suffixes.
+
+    A composed emb_name reachable from two groups whose embedding_name_suffix
+    values differ (e.g. one suffixed group lands on the same name as another
+    group's un-suffixed default) would silently merge tables that the user
+    meant to keep independent. Raise rather than share.
+    """
+    emb_name_to_suffixes = defaultdict(set)
+    for group_to_emb_name in feat_to_group_to_emb_name.values():
+        for grp_name, emb_name in group_to_emb_name.items():
+            emb_name_to_suffixes[emb_name].add(group_name_to_suffix.get(grp_name, ""))
+    for emb_name, suffixes in emb_name_to_suffixes.items():
+        if len(suffixes) > 1:
+            raise ValueError(
+                f"embedding table name {emb_name!r} is produced by groups with "
+                f"different embedding_name_suffix values {sorted(suffixes)}; "
+                "this would silently merge tables that were meant to be "
+                "independent. Rename the feature's embedding_name or change "
+                "the conflicting suffix."
+            )
+
+
 def _add_embedding_bag_config(
     emb_bag_configs: Dict[str, EmbeddingBagConfig], emb_bag_config: EmbeddingBagConfig
 ) -> None:
@@ -640,6 +672,9 @@ class EmbeddingGroupImpl(nn.Module):
         self._group_dense_embedding_feature_names = dict()
 
         feat_to_group_to_emb_name = defaultdict(dict)
+        group_name_to_suffix = {
+            fg.group_name: fg.embedding_name_suffix for fg in feature_groups
+        }
         for feature_group in feature_groups:
             group_name = feature_group.group_name
             for feature_name in feature_group.feature_names:
@@ -653,6 +688,9 @@ class EmbeddingGroupImpl(nn.Module):
                     if feature_group.embedding_name_suffix:
                         emb_name = emb_name + "_" + feature_group.embedding_name_suffix
                     feat_to_group_to_emb_name[feature_name][group_name] = emb_name
+        _check_emb_name_suffix_collisions(
+            feat_to_group_to_emb_name, group_name_to_suffix
+        )
 
         shared_feature_flag = dict()
         for feature_name, group_to_emb_name in feat_to_group_to_emb_name.items():
@@ -940,6 +978,9 @@ class SequenceEmbeddingGroupImpl(nn.Module):
         self._group_to_sequence_length = OrderedDict()
 
         feat_to_group_to_emb_name = defaultdict(dict)
+        group_name_to_suffix = {
+            fg.group_name: fg.embedding_name_suffix for fg in feature_groups
+        }
         for feature_group in feature_groups:
             group_name = feature_group.group_name
             self._group_to_is_jagged[group_name] = (
@@ -955,6 +996,9 @@ class SequenceEmbeddingGroupImpl(nn.Module):
                     if feature_group.embedding_name_suffix:
                         emb_name = emb_name + "_" + feature_group.embedding_name_suffix
                     feat_to_group_to_emb_name[feature_name][group_name] = emb_name
+        _check_emb_name_suffix_collisions(
+            feat_to_group_to_emb_name, group_name_to_suffix
+        )
 
         shared_feature_flag = dict()
         for feature_name, group_to_emb_name in feat_to_group_to_emb_name.items():

--- a/tzrec/modules/embedding.py
+++ b/tzrec/modules/embedding.py
@@ -178,6 +178,12 @@ class EmbeddingGroup(nn.Module):
             group_name = feature_group.group_name
             self._inspect_and_supplement_feature_group(feature_group, seq_group_names)
             # self._add_feature_group_sign_for_sequence_groups(feature_group)
+            # propagate parent's embedding_name_suffix to nested sequence_groups
+            # that don't set their own.
+            if feature_group.embedding_name_suffix:
+                for sg in feature_group.sequence_groups:
+                    if not sg.embedding_name_suffix:
+                        sg.embedding_name_suffix = feature_group.embedding_name_suffix
             features_data_group = defaultdict(list)
             for feature_name in feature_group.feature_names:
                 feature = self._name_to_feature[feature_name]
@@ -644,6 +650,8 @@ class EmbeddingGroupImpl(nn.Module):
                     emb_name = emb_bag_config.name
                     if feature_group.group_type == model_pb2.WIDE:
                         emb_name = emb_name + "_wide"
+                    if feature_group.embedding_name_suffix:
+                        emb_name = emb_name + "_" + feature_group.embedding_name_suffix
                     feat_to_group_to_emb_name[feature_name][group_name] = emb_name
 
         shared_feature_flag = dict()
@@ -944,6 +952,8 @@ class SequenceEmbeddingGroupImpl(nn.Module):
                     emb_config = feature.emb_config
                     # pyre-ignore [16]
                     emb_name = emb_config.name
+                    if feature_group.embedding_name_suffix:
+                        emb_name = emb_name + "_" + feature_group.embedding_name_suffix
                     feat_to_group_to_emb_name[feature_name][group_name] = emb_name
 
         shared_feature_flag = dict()

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -733,6 +733,19 @@ class EmbeddingGroupTest(unittest.TestCase):
                 expected_ec={"cat_a_emb_child", "click_seq__cat_a_emb_child"},
                 forbidden_ec={"cat_a_emb_parent", "click_seq__cat_a_emb_parent"},
             ),
+            # Top-level SEQUENCE FeatureGroupConfig with suffix -> suffix
+            # applied to both query and sequence-side embedding tables.
+            param(
+                "toplevel_sequence_with_suffix",
+                seq_toplevel_suffix="tower_a",
+                expected_ec={
+                    "cat_a_emb_tower_a",
+                    "cat_b_emb_tower_a",
+                    "click_seq__cat_a_emb_tower_a",
+                    "click_seq__cat_b_emb_tower_a",
+                },
+                forbidden_ec={"cat_a_emb", "click_seq__cat_a_emb"},
+            ),
         ]
     )
     def test_embedding_name_suffix(
@@ -743,6 +756,7 @@ class EmbeddingGroupTest(unittest.TestCase):
         wide_suffix=None,
         seq_parent_suffix=None,
         seq_child_suffix=None,
+        seq_toplevel_suffix=None,
         expected_ebc=frozenset(),
         forbidden_ebc=frozenset(),
         expected_ec=frozenset(),
@@ -800,6 +814,20 @@ class EmbeddingGroupTest(unittest.TestCase):
                     ],
                 )
             )
+        if seq_toplevel_suffix is not None:
+            feature_groups.append(
+                model_pb2.FeatureGroupConfig(
+                    group_name="toplevel_seq",
+                    feature_names=[
+                        "cat_a",
+                        "cat_b",
+                        "click_seq__cat_a",
+                        "click_seq__cat_b",
+                    ],
+                    group_type=model_pb2.FeatureGroupType.SEQUENCE,
+                    embedding_name_suffix=seq_toplevel_suffix,
+                )
+            )
         embedding_group = EmbeddingGroup(
             features, feature_groups, device=torch.device("cpu")
         )
@@ -830,6 +858,117 @@ class EmbeddingGroupTest(unittest.TestCase):
             forbidden_ec & ec_names,
             f"forbidden in ec: {forbidden_ec & ec_names}",
         )
+
+    def test_embedding_name_suffix_does_not_mutate_input_proto(self) -> None:
+        # Parent suffix must NOT be written back onto the caller's nested
+        # SeqGroupConfig — repeated construction (train/eval/export, TDM's
+        # secondary EmbeddingGroup) must stay idempotent.
+        features = _create_test_sequence_features()
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="parent",
+                feature_names=["cat_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_a",
+                sequence_groups=[
+                    model_pb2.SeqGroupConfig(
+                        group_name="seq",
+                        feature_names=["cat_a", "click_seq__cat_a"],
+                    ),
+                ],
+                sequence_encoders=[
+                    seq_encoder_pb2.SeqEncoderConfig(
+                        simple_attention=seq_encoder_pb2.SimpleAttention(input="seq")
+                    ),
+                ],
+            ),
+        ]
+        EmbeddingGroup(features, feature_groups, device=torch.device("cpu"))
+        self.assertEqual(feature_groups[0].sequence_groups[0].embedding_name_suffix, "")
+        # Second construction with the same proto must still produce a
+        # suffixed nested-seq table (and not, e.g., regress because the
+        # first run polluted the input).
+        embedding_group = EmbeddingGroup(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        ec_names = {
+            cfg.name
+            for seq_impl in embedding_group.seq_emb_impls.values()
+            for ec in seq_impl.ec_dict.values()
+            for cfg in ec.embedding_configs()
+        }
+        self.assertIn("click_seq__cat_a_emb_tower_a", ec_names)
+
+    def test_embedding_name_suffix_collision_raises(self) -> None:
+        # Group A has suffix "x" so cat_a -> "cat_a_emb_x".
+        # Group B has no suffix but cat_collide's embedding_name is manually
+        # "cat_a_emb_x"; without detection these would silently merge.
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a", embedding_dim=16, num_buckets=100
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_collide",
+                    embedding_dim=16,
+                    num_buckets=100,
+                    embedding_name="cat_a_emb_x",
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep_a",
+                feature_names=["cat_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="x",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="deep_b",
+                feature_names=["cat_collide"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        with self.assertRaisesRegex(ValueError, "different embedding_name_suffix"):
+            EmbeddingGroup(features, feature_groups, device=torch.device("cpu"))
+
+    def test_embedding_name_suffix_runtime_independence(self) -> None:
+        # Two suffixed DEEP towers must own separate parameter storage so
+        # mutating one tower's table has no effect on the other.
+        features = _create_test_sequence_features()
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep_a",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_a",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="deep_b",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_b",
+            ),
+        ]
+        embedding_group = EmbeddingGroup(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        params = dict(embedding_group.named_parameters())
+        a_params = [v for k, v in params.items() if "cat_a_emb_tower_a" in k]
+        b_params = [v for k, v in params.items() if "cat_a_emb_tower_b" in k]
+        self.assertEqual(len(a_params), 1)
+        self.assertEqual(len(b_params), 1)
+        # Independent storage => not aliased.
+        self.assertNotEqual(a_params[0].data_ptr(), b_params[0].data_ptr())
+        # Mutate tower_a's table; tower_b's must be untouched.
+        with torch.no_grad():
+            a_params[0].fill_(0.0)
+            b_params[0].fill_(1.0)
+        self.assertTrue(torch.all(a_params[0] == 0.0))
+        self.assertTrue(torch.all(b_params[0] == 1.0))
 
     @parameterized.expand(
         [

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -162,94 +162,6 @@ def _create_test_sequence_features(has_zch=False, has_mulval=False, pooling_type
     return features
 
 
-def _simple_attention_encoder(input_name: str) -> "seq_encoder_pb2.SeqEncoderConfig":
-    return seq_encoder_pb2.SeqEncoderConfig(
-        simple_attention=seq_encoder_pb2.SimpleAttention(input=input_name)
-    )
-
-
-def _fgs_distinct_suffix_per_tower():
-    return [
-        model_pb2.FeatureGroupConfig(
-            group_name="tower_a",
-            feature_names=["cat_a", "cat_b", "int_a"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="tower_a",
-        ),
-        model_pb2.FeatureGroupConfig(
-            group_name="tower_b",
-            feature_names=["cat_a", "cat_b", "int_a"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="tower_b",
-        ),
-    ]
-
-
-def _fgs_same_suffix_shares():
-    return [
-        model_pb2.FeatureGroupConfig(
-            group_name="g1",
-            feature_names=["cat_a", "cat_b"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="shared",
-        ),
-        model_pb2.FeatureGroupConfig(
-            group_name="g2",
-            feature_names=["cat_a"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="shared",
-        ),
-    ]
-
-
-def _fgs_wide_plus_suffix():
-    return [
-        model_pb2.FeatureGroupConfig(
-            group_name="wide",
-            feature_names=["cat_a", "cat_b"],
-            group_type=model_pb2.FeatureGroupType.WIDE,
-            embedding_name_suffix="tower_a",
-        ),
-    ]
-
-
-def _fgs_nested_seq_inherits_parent():
-    return [
-        model_pb2.FeatureGroupConfig(
-            group_name="parent",
-            feature_names=["cat_a"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="tower_a",
-            sequence_groups=[
-                model_pb2.SeqGroupConfig(
-                    group_name="seq",
-                    feature_names=["cat_a", "click_seq__cat_a"],
-                ),
-            ],
-            sequence_encoders=[_simple_attention_encoder("seq")],
-        ),
-    ]
-
-
-def _fgs_explicit_child_overrides_parent():
-    return [
-        model_pb2.FeatureGroupConfig(
-            group_name="parent",
-            feature_names=["cat_a"],
-            group_type=model_pb2.FeatureGroupType.DEEP,
-            embedding_name_suffix="parent",
-            sequence_groups=[
-                model_pb2.SeqGroupConfig(
-                    group_name="seq",
-                    feature_names=["cat_a", "click_seq__cat_a"],
-                    embedding_name_suffix="child",
-                ),
-            ],
-            sequence_encoders=[_simple_attention_encoder("seq")],
-        ),
-    ]
-
-
 class _EGScriptWrapper(nn.Module):
     """Embedding Group inference wrapper for jit.script."""
 
@@ -775,10 +687,16 @@ class EmbeddingGroupTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # Two DEEP groups, same features, different suffix -> distinct tables.
+            # name, deep_a, deep_b, wide, seq_parent, seq_child,
+            #   expected_ebc, forbidden_ebc, expected_ec, forbidden_ec
+            # Two DEEP groups, different suffix -> distinct tables.
             [
                 "distinct_suffix_per_tower",
-                _fgs_distinct_suffix_per_tower,
+                "tower_a",
+                "tower_b",
+                None,
+                None,
+                None,
                 {
                     "cat_a_emb_tower_a",
                     "cat_a_emb_tower_b",
@@ -789,37 +707,53 @@ class EmbeddingGroupTest(unittest.TestCase):
                 set(),
                 set(),
             ],
-            # Two DEEP groups, same suffix -> shared (no unsuffixed leakage).
+            # Two DEEP groups with same suffix -> shared (no unsuffixed leakage).
             [
                 "same_suffix_shares",
-                _fgs_same_suffix_shares,
+                "shared",
+                "shared",
+                None,
+                None,
+                None,
                 {"cat_a_emb_shared", "cat_b_emb_shared"},
                 {"cat_a_emb", "cat_b_emb"},
                 set(),
                 set(),
             ],
-            # WIDE + suffix -> "_wide_<suffix>" (suffix is additive with _wide).
+            # WIDE + suffix -> "_wide_<suffix>" (additive with _wide).
             [
                 "wide_plus_suffix",
-                _fgs_wide_plus_suffix,
+                None,
+                None,
+                "tower_a",
+                None,
+                None,
                 {"cat_a_emb_wide_tower_a", "cat_b_emb_wide_tower_a"},
                 {"cat_a_emb_wide", "cat_a_emb"},
                 set(),
                 set(),
             ],
-            # Nested seq inherits parent's suffix when child doesn't set its own.
+            # Nested seq inherits parent suffix when child doesn't set its own.
             [
                 "nested_seq_inherits_parent",
-                _fgs_nested_seq_inherits_parent,
+                None,
+                None,
+                None,
+                "tower_a",
+                None,
                 {"cat_a_emb_tower_a"},
                 {"cat_a_emb"},
                 {"cat_a_emb_tower_a", "click_seq__cat_a_emb_tower_a"},
                 {"cat_a_emb", "click_seq__cat_a_emb"},
             ],
-            # Explicit child suffix wins over parent.
+            # Explicit child suffix overrides parent.
             [
                 "explicit_child_overrides_parent",
-                _fgs_explicit_child_overrides_parent,
+                None,
+                None,
+                None,
+                "parent",
+                "child",
                 {"cat_a_emb_parent"},
                 set(),
                 {"cat_a_emb_child", "click_seq__cat_a_emb_child"},
@@ -830,15 +764,70 @@ class EmbeddingGroupTest(unittest.TestCase):
     def test_embedding_name_suffix(
         self,
         name,
-        fg_factory,
+        deep_a_suffix,
+        deep_b_suffix,
+        wide_suffix,
+        seq_parent_suffix,
+        seq_child_suffix,
         expected_ebc,
         forbidden_ebc,
         expected_ec,
         forbidden_ec,
     ) -> None:
         features = _create_test_sequence_features()
+        feature_groups = []
+        if deep_a_suffix is not None:
+            feature_groups.append(
+                model_pb2.FeatureGroupConfig(
+                    group_name="deep_a",
+                    feature_names=["cat_a", "cat_b", "int_a"],
+                    group_type=model_pb2.FeatureGroupType.DEEP,
+                    embedding_name_suffix=deep_a_suffix,
+                )
+            )
+        if deep_b_suffix is not None:
+            feature_groups.append(
+                model_pb2.FeatureGroupConfig(
+                    group_name="deep_b",
+                    feature_names=["cat_a", "cat_b", "int_a"],
+                    group_type=model_pb2.FeatureGroupType.DEEP,
+                    embedding_name_suffix=deep_b_suffix,
+                )
+            )
+        if wide_suffix is not None:
+            feature_groups.append(
+                model_pb2.FeatureGroupConfig(
+                    group_name="wide",
+                    feature_names=["cat_a", "cat_b"],
+                    group_type=model_pb2.FeatureGroupType.WIDE,
+                    embedding_name_suffix=wide_suffix,
+                )
+            )
+        if seq_parent_suffix is not None:
+            seq = model_pb2.SeqGroupConfig(
+                group_name="seq",
+                feature_names=["cat_a", "click_seq__cat_a"],
+            )
+            if seq_child_suffix is not None:
+                seq.embedding_name_suffix = seq_child_suffix
+            feature_groups.append(
+                model_pb2.FeatureGroupConfig(
+                    group_name="parent",
+                    feature_names=["cat_a"],
+                    group_type=model_pb2.FeatureGroupType.DEEP,
+                    embedding_name_suffix=seq_parent_suffix,
+                    sequence_groups=[seq],
+                    sequence_encoders=[
+                        seq_encoder_pb2.SeqEncoderConfig(
+                            simple_attention=seq_encoder_pb2.SimpleAttention(
+                                input="seq"
+                            )
+                        )
+                    ],
+                )
+            )
         embedding_group = EmbeddingGroup(
-            features, fg_factory(), device=torch.device("cpu")
+            features, feature_groups, device=torch.device("cpu")
         )
         ebc_names = {
             cfg.name

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -859,46 +859,6 @@ class EmbeddingGroupTest(unittest.TestCase):
             f"forbidden in ec: {forbidden_ec & ec_names}",
         )
 
-    def test_embedding_name_suffix_does_not_mutate_input_proto(self) -> None:
-        # Parent suffix must NOT be written back onto the caller's nested
-        # SeqGroupConfig — repeated construction (train/eval/export, TDM's
-        # secondary EmbeddingGroup) must stay idempotent.
-        features = _create_test_sequence_features()
-        feature_groups = [
-            model_pb2.FeatureGroupConfig(
-                group_name="parent",
-                feature_names=["cat_a"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_a",
-                sequence_groups=[
-                    model_pb2.SeqGroupConfig(
-                        group_name="seq",
-                        feature_names=["cat_a", "click_seq__cat_a"],
-                    ),
-                ],
-                sequence_encoders=[
-                    seq_encoder_pb2.SeqEncoderConfig(
-                        simple_attention=seq_encoder_pb2.SimpleAttention(input="seq")
-                    ),
-                ],
-            ),
-        ]
-        EmbeddingGroup(features, feature_groups, device=torch.device("cpu"))
-        self.assertEqual(feature_groups[0].sequence_groups[0].embedding_name_suffix, "")
-        # Second construction with the same proto must still produce a
-        # suffixed nested-seq table (and not, e.g., regress because the
-        # first run polluted the input).
-        embedding_group = EmbeddingGroup(
-            features, feature_groups, device=torch.device("cpu")
-        )
-        ec_names = {
-            cfg.name
-            for seq_impl in embedding_group.seq_emb_impls.values()
-            for ec in seq_impl.ec_dict.values()
-            for cfg in ec.embedding_configs()
-        }
-        self.assertIn("click_seq__cat_a_emb_tower_a", ec_names)
-
     def test_embedding_name_suffix_collision_raises(self) -> None:
         # Group A has suffix "x" so cat_a -> "cat_a_emb_x".
         # Group B has no suffix but cat_collide's embedding_name is manually
@@ -934,41 +894,6 @@ class EmbeddingGroupTest(unittest.TestCase):
         ]
         with self.assertRaisesRegex(ValueError, "different embedding_name_suffix"):
             EmbeddingGroup(features, feature_groups, device=torch.device("cpu"))
-
-    def test_embedding_name_suffix_runtime_independence(self) -> None:
-        # Two suffixed DEEP towers must own separate parameter storage so
-        # mutating one tower's table has no effect on the other.
-        features = _create_test_sequence_features()
-        feature_groups = [
-            model_pb2.FeatureGroupConfig(
-                group_name="deep_a",
-                feature_names=["cat_a", "cat_b"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_a",
-            ),
-            model_pb2.FeatureGroupConfig(
-                group_name="deep_b",
-                feature_names=["cat_a", "cat_b"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_b",
-            ),
-        ]
-        embedding_group = EmbeddingGroup(
-            features, feature_groups, device=torch.device("cpu")
-        )
-        params = dict(embedding_group.named_parameters())
-        a_params = [v for k, v in params.items() if "cat_a_emb_tower_a" in k]
-        b_params = [v for k, v in params.items() if "cat_a_emb_tower_b" in k]
-        self.assertEqual(len(a_params), 1)
-        self.assertEqual(len(b_params), 1)
-        # Independent storage => not aliased.
-        self.assertNotEqual(a_params[0].data_ptr(), b_params[0].data_ptr())
-        # Mutate tower_a's table; tower_b's must be untouched.
-        with torch.no_grad():
-            a_params[0].fill_(0.0)
-            b_params[0].fill_(1.0)
-        self.assertTrue(torch.all(a_params[0] == 0.0))
-        self.assertTrue(torch.all(b_params[0] == 1.0))
 
     @parameterized.expand(
         [

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -162,6 +162,94 @@ def _create_test_sequence_features(has_zch=False, has_mulval=False, pooling_type
     return features
 
 
+def _simple_attention_encoder(input_name: str) -> "seq_encoder_pb2.SeqEncoderConfig":
+    return seq_encoder_pb2.SeqEncoderConfig(
+        simple_attention=seq_encoder_pb2.SimpleAttention(input=input_name)
+    )
+
+
+def _fgs_distinct_suffix_per_tower():
+    return [
+        model_pb2.FeatureGroupConfig(
+            group_name="tower_a",
+            feature_names=["cat_a", "cat_b", "int_a"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="tower_a",
+        ),
+        model_pb2.FeatureGroupConfig(
+            group_name="tower_b",
+            feature_names=["cat_a", "cat_b", "int_a"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="tower_b",
+        ),
+    ]
+
+
+def _fgs_same_suffix_shares():
+    return [
+        model_pb2.FeatureGroupConfig(
+            group_name="g1",
+            feature_names=["cat_a", "cat_b"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="shared",
+        ),
+        model_pb2.FeatureGroupConfig(
+            group_name="g2",
+            feature_names=["cat_a"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="shared",
+        ),
+    ]
+
+
+def _fgs_wide_plus_suffix():
+    return [
+        model_pb2.FeatureGroupConfig(
+            group_name="wide",
+            feature_names=["cat_a", "cat_b"],
+            group_type=model_pb2.FeatureGroupType.WIDE,
+            embedding_name_suffix="tower_a",
+        ),
+    ]
+
+
+def _fgs_nested_seq_inherits_parent():
+    return [
+        model_pb2.FeatureGroupConfig(
+            group_name="parent",
+            feature_names=["cat_a"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="tower_a",
+            sequence_groups=[
+                model_pb2.SeqGroupConfig(
+                    group_name="seq",
+                    feature_names=["cat_a", "click_seq__cat_a"],
+                ),
+            ],
+            sequence_encoders=[_simple_attention_encoder("seq")],
+        ),
+    ]
+
+
+def _fgs_explicit_child_overrides_parent():
+    return [
+        model_pb2.FeatureGroupConfig(
+            group_name="parent",
+            feature_names=["cat_a"],
+            group_type=model_pb2.FeatureGroupType.DEEP,
+            embedding_name_suffix="parent",
+            sequence_groups=[
+                model_pb2.SeqGroupConfig(
+                    group_name="seq",
+                    feature_names=["cat_a", "click_seq__cat_a"],
+                    embedding_name_suffix="child",
+                ),
+            ],
+            sequence_encoders=[_simple_attention_encoder("seq")],
+        ),
+    ]
+
+
 class _EGScriptWrapper(nn.Module):
     """Embedding Group inference wrapper for jit.script."""
 
@@ -685,147 +773,100 @@ class EmbeddingGroupTest(unittest.TestCase):
         self.assertEqual(result["buy.sequence"].size(), (2, 2, 17))
         self.assertEqual(result["buy.sequence_length"].size(), (2,))
 
-    def test_embedding_name_suffix(self) -> None:
-        # Two DEEP groups share cat_a/cat_b/int_a but use different suffixes,
-        # plus a WIDE group with a suffix, plus a DEEP group with nested
-        # sequence_groups whose suffix should propagate to its seq sub-groups.
-        features = _create_test_sequence_features()
-        feature_groups = [
-            model_pb2.FeatureGroupConfig(
-                group_name="tower_a_deep",
-                feature_names=["cat_a", "cat_b", "int_a"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_a",
-            ),
-            model_pb2.FeatureGroupConfig(
-                group_name="tower_b_deep",
-                feature_names=["cat_a", "cat_b", "int_a"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_b",
-            ),
-            model_pb2.FeatureGroupConfig(
-                group_name="tower_b_deep_dup",
-                feature_names=["cat_a", "cat_b"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_b",
-            ),
-            model_pb2.FeatureGroupConfig(
-                group_name="wide",
-                feature_names=["cat_a", "cat_b"],
-                group_type=model_pb2.FeatureGroupType.WIDE,
-                embedding_name_suffix="tower_a",
-            ),
-            model_pb2.FeatureGroupConfig(
-                group_name="tower_a_with_seq",
-                feature_names=["cat_a"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="tower_a",
-                sequence_groups=[
-                    model_pb2.SeqGroupConfig(
-                        group_name="tower_a_click_seq",
-                        feature_names=[
-                            "cat_a",
-                            "click_seq__cat_a",
-                        ],
-                    ),
-                ],
-                sequence_encoders=[
-                    seq_encoder_pb2.SeqEncoderConfig(
-                        simple_attention=seq_encoder_pb2.SimpleAttention(
-                            input="tower_a_click_seq"
-                        )
-                    ),
-                ],
-            ),
+    @parameterized.expand(
+        [
+            # Two DEEP groups, same features, different suffix -> distinct tables.
+            [
+                "distinct_suffix_per_tower",
+                _fgs_distinct_suffix_per_tower,
+                {
+                    "cat_a_emb_tower_a",
+                    "cat_a_emb_tower_b",
+                    "cat_b_emb_tower_a",
+                    "cat_b_emb_tower_b",
+                },
+                {"cat_a_emb", "cat_b_emb"},
+                set(),
+                set(),
+            ],
+            # Two DEEP groups, same suffix -> shared (no unsuffixed leakage).
+            [
+                "same_suffix_shares",
+                _fgs_same_suffix_shares,
+                {"cat_a_emb_shared", "cat_b_emb_shared"},
+                {"cat_a_emb", "cat_b_emb"},
+                set(),
+                set(),
+            ],
+            # WIDE + suffix -> "_wide_<suffix>" (suffix is additive with _wide).
+            [
+                "wide_plus_suffix",
+                _fgs_wide_plus_suffix,
+                {"cat_a_emb_wide_tower_a", "cat_b_emb_wide_tower_a"},
+                {"cat_a_emb_wide", "cat_a_emb"},
+                set(),
+                set(),
+            ],
+            # Nested seq inherits parent's suffix when child doesn't set its own.
+            [
+                "nested_seq_inherits_parent",
+                _fgs_nested_seq_inherits_parent,
+                {"cat_a_emb_tower_a"},
+                {"cat_a_emb"},
+                {"cat_a_emb_tower_a", "click_seq__cat_a_emb_tower_a"},
+                {"cat_a_emb", "click_seq__cat_a_emb"},
+            ],
+            # Explicit child suffix wins over parent.
+            [
+                "explicit_child_overrides_parent",
+                _fgs_explicit_child_overrides_parent,
+                {"cat_a_emb_parent"},
+                set(),
+                {"cat_a_emb_child", "click_seq__cat_a_emb_child"},
+                {"cat_a_emb_parent", "click_seq__cat_a_emb_parent"},
+            ],
         ]
+    )
+    def test_embedding_name_suffix(
+        self,
+        name,
+        fg_factory,
+        expected_ebc,
+        forbidden_ebc,
+        expected_ec,
+        forbidden_ec,
+    ) -> None:
+        features = _create_test_sequence_features()
         embedding_group = EmbeddingGroup(
-            features, feature_groups, device=torch.device("cpu")
+            features, fg_factory(), device=torch.device("cpu")
         )
-
-        # Collect every (impl_key -> ebc table name) pair so we can assert
-        # both distinct-suffix separation and same-suffix sharing.
-        all_ebc_names = set()
-        for impl in embedding_group.emb_impls.values():
-            for cfg in impl.ebc.embedding_bag_configs():
-                all_ebc_names.add(cfg.name)
-
-        # Distinct suffix => distinct tables for the same underlying feature.
-        self.assertIn("cat_a_emb_tower_a", all_ebc_names)
-        self.assertIn("cat_a_emb_tower_b", all_ebc_names)
-        self.assertIn("cat_b_emb_tower_a", all_ebc_names)
-        self.assertIn("cat_b_emb_tower_b", all_ebc_names)
-        # No un-suffixed table should leak in.
-        self.assertNotIn("cat_a_emb", all_ebc_names)
-        self.assertNotIn("cat_b_emb", all_ebc_names)
-
-        # WIDE + suffix => "_wide_<suffix>".
-        self.assertIn("cat_a_emb_wide_tower_a", all_ebc_names)
-        self.assertIn("cat_b_emb_wide_tower_a", all_ebc_names)
-
-        # Same suffix => shared. tower_b_deep and tower_b_deep_dup both reference
-        # cat_a / cat_b under suffix "tower_b": exactly one *_tower_b table each,
-        # and both groups' feature_names appear on the shared config.
-        tower_b_cat_a_configs = [
-            cfg
+        ebc_names = {
+            cfg.name
             for impl in embedding_group.emb_impls.values()
             for cfg in impl.ebc.embedding_bag_configs()
-            if cfg.name == "cat_a_emb_tower_b"
-        ]
-        self.assertEqual(len(tower_b_cat_a_configs), 1)
-        self.assertIn("cat_a", tower_b_cat_a_configs[0].feature_names)
-
-        # Nested sequence_groups inherit parent suffix: the propagated
-        # embedding tables for click_seq__cat_a / cat_a should end with
-        # "_tower_a".
-        seq_ec_names = set()
-        for seq_impl in embedding_group.seq_emb_impls.values():
-            for ec in seq_impl.ec_dict.values():
-                for cfg in ec.embedding_configs():
-                    seq_ec_names.add(cfg.name)
-        self.assertIn("cat_a_emb_tower_a", seq_ec_names)
-        self.assertIn("click_seq__cat_a_emb_tower_a", seq_ec_names)
-        self.assertNotIn("cat_a_emb", seq_ec_names)
-        self.assertNotIn("click_seq__cat_a_emb", seq_ec_names)
-
-    def test_embedding_name_suffix_seq_child_overrides_parent(self) -> None:
-        # An explicit child suffix on a SeqGroupConfig should NOT be overwritten
-        # by parent FeatureGroupConfig's suffix.
-        features = _create_test_sequence_features()
-        feature_groups = [
-            model_pb2.FeatureGroupConfig(
-                group_name="parent_group",
-                feature_names=["cat_a"],
-                group_type=model_pb2.FeatureGroupType.DEEP,
-                embedding_name_suffix="parent",
-                sequence_groups=[
-                    model_pb2.SeqGroupConfig(
-                        group_name="explicit_child_seq",
-                        feature_names=["cat_a", "click_seq__cat_a"],
-                        embedding_name_suffix="child",
-                    ),
-                ],
-                sequence_encoders=[
-                    seq_encoder_pb2.SeqEncoderConfig(
-                        simple_attention=seq_encoder_pb2.SimpleAttention(
-                            input="explicit_child_seq"
-                        )
-                    ),
-                ],
-            ),
-        ]
-        embedding_group = EmbeddingGroup(
-            features, feature_groups, device=torch.device("cpu")
+        }
+        ec_names = {
+            cfg.name
+            for seq_impl in embedding_group.seq_emb_impls.values()
+            for ec in seq_impl.ec_dict.values()
+            for cfg in ec.embedding_configs()
+        }
+        self.assertTrue(
+            expected_ebc <= ebc_names,
+            f"missing from ebc: {expected_ebc - ebc_names}; got {ebc_names}",
         )
-        seq_ec_names = set()
-        for seq_impl in embedding_group.seq_emb_impls.values():
-            for ec in seq_impl.ec_dict.values():
-                for cfg in ec.embedding_configs():
-                    seq_ec_names.add(cfg.name)
-        self.assertIn("cat_a_emb_child", seq_ec_names)
-        self.assertIn("click_seq__cat_a_emb_child", seq_ec_names)
-        # Parent suffix must NOT have leaked onto the explicit-child seq group.
-        self.assertNotIn("cat_a_emb_parent", seq_ec_names)
-        self.assertNotIn("click_seq__cat_a_emb_parent", seq_ec_names)
+        self.assertFalse(
+            forbidden_ebc & ebc_names,
+            f"forbidden in ebc: {forbidden_ebc & ebc_names}",
+        )
+        self.assertTrue(
+            expected_ec <= ec_names,
+            f"missing from ec: {expected_ec - ec_names}; got {ec_names}",
+        )
+        self.assertFalse(
+            forbidden_ec & ec_names,
+            f"forbidden in ec: {forbidden_ec & ec_names}",
+        )
 
     @parameterized.expand(
         [

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -685,6 +685,148 @@ class EmbeddingGroupTest(unittest.TestCase):
         self.assertEqual(result["buy.sequence"].size(), (2, 2, 17))
         self.assertEqual(result["buy.sequence_length"].size(), (2,))
 
+    def test_embedding_name_suffix(self) -> None:
+        # Two DEEP groups share cat_a/cat_b/int_a but use different suffixes,
+        # plus a WIDE group with a suffix, plus a DEEP group with nested
+        # sequence_groups whose suffix should propagate to its seq sub-groups.
+        features = _create_test_sequence_features()
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="tower_a_deep",
+                feature_names=["cat_a", "cat_b", "int_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_a",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="tower_b_deep",
+                feature_names=["cat_a", "cat_b", "int_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_b",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="tower_b_deep_dup",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_b",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="wide",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.WIDE,
+                embedding_name_suffix="tower_a",
+            ),
+            model_pb2.FeatureGroupConfig(
+                group_name="tower_a_with_seq",
+                feature_names=["cat_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="tower_a",
+                sequence_groups=[
+                    model_pb2.SeqGroupConfig(
+                        group_name="tower_a_click_seq",
+                        feature_names=[
+                            "cat_a",
+                            "click_seq__cat_a",
+                        ],
+                    ),
+                ],
+                sequence_encoders=[
+                    seq_encoder_pb2.SeqEncoderConfig(
+                        simple_attention=seq_encoder_pb2.SimpleAttention(
+                            input="tower_a_click_seq"
+                        )
+                    ),
+                ],
+            ),
+        ]
+        embedding_group = EmbeddingGroup(
+            features, feature_groups, device=torch.device("cpu")
+        )
+
+        # Collect every (impl_key -> ebc table name) pair so we can assert
+        # both distinct-suffix separation and same-suffix sharing.
+        all_ebc_names = set()
+        for impl in embedding_group.emb_impls.values():
+            for cfg in impl.ebc.embedding_bag_configs():
+                all_ebc_names.add(cfg.name)
+
+        # Distinct suffix => distinct tables for the same underlying feature.
+        self.assertIn("cat_a_emb_tower_a", all_ebc_names)
+        self.assertIn("cat_a_emb_tower_b", all_ebc_names)
+        self.assertIn("cat_b_emb_tower_a", all_ebc_names)
+        self.assertIn("cat_b_emb_tower_b", all_ebc_names)
+        # No un-suffixed table should leak in.
+        self.assertNotIn("cat_a_emb", all_ebc_names)
+        self.assertNotIn("cat_b_emb", all_ebc_names)
+
+        # WIDE + suffix => "_wide_<suffix>".
+        self.assertIn("cat_a_emb_wide_tower_a", all_ebc_names)
+        self.assertIn("cat_b_emb_wide_tower_a", all_ebc_names)
+
+        # Same suffix => shared. tower_b_deep and tower_b_deep_dup both reference
+        # cat_a / cat_b under suffix "tower_b": exactly one *_tower_b table each,
+        # and both groups' feature_names appear on the shared config.
+        tower_b_cat_a_configs = [
+            cfg
+            for impl in embedding_group.emb_impls.values()
+            for cfg in impl.ebc.embedding_bag_configs()
+            if cfg.name == "cat_a_emb_tower_b"
+        ]
+        self.assertEqual(len(tower_b_cat_a_configs), 1)
+        self.assertIn("cat_a", tower_b_cat_a_configs[0].feature_names)
+
+        # Nested sequence_groups inherit parent suffix: the propagated
+        # embedding tables for click_seq__cat_a / cat_a should end with
+        # "_tower_a".
+        seq_ec_names = set()
+        for seq_impl in embedding_group.seq_emb_impls.values():
+            for ec in seq_impl.ec_dict.values():
+                for cfg in ec.embedding_configs():
+                    seq_ec_names.add(cfg.name)
+        self.assertIn("cat_a_emb_tower_a", seq_ec_names)
+        self.assertIn("click_seq__cat_a_emb_tower_a", seq_ec_names)
+        self.assertNotIn("cat_a_emb", seq_ec_names)
+        self.assertNotIn("click_seq__cat_a_emb", seq_ec_names)
+
+    def test_embedding_name_suffix_seq_child_overrides_parent(self) -> None:
+        # An explicit child suffix on a SeqGroupConfig should NOT be overwritten
+        # by parent FeatureGroupConfig's suffix.
+        features = _create_test_sequence_features()
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="parent_group",
+                feature_names=["cat_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+                embedding_name_suffix="parent",
+                sequence_groups=[
+                    model_pb2.SeqGroupConfig(
+                        group_name="explicit_child_seq",
+                        feature_names=["cat_a", "click_seq__cat_a"],
+                        embedding_name_suffix="child",
+                    ),
+                ],
+                sequence_encoders=[
+                    seq_encoder_pb2.SeqEncoderConfig(
+                        simple_attention=seq_encoder_pb2.SimpleAttention(
+                            input="explicit_child_seq"
+                        )
+                    ),
+                ],
+            ),
+        ]
+        embedding_group = EmbeddingGroup(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        seq_ec_names = set()
+        for seq_impl in embedding_group.seq_emb_impls.values():
+            for ec in seq_impl.ec_dict.values():
+                for cfg in ec.embedding_configs():
+                    seq_ec_names.add(cfg.name)
+        self.assertIn("cat_a_emb_child", seq_ec_names)
+        self.assertIn("click_seq__cat_a_emb_child", seq_ec_names)
+        # Parent suffix must NOT have leaked onto the explicit-child seq group.
+        self.assertNotIn("cat_a_emb_parent", seq_ec_names)
+        self.assertNotIn("click_seq__cat_a_emb_parent", seq_ec_names)
+
     @parameterized.expand(
         [
             [TestGraphType.NORMAL, False, False],

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from typing import Dict
 
 import torch
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torch import nn
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
@@ -687,92 +687,66 @@ class EmbeddingGroupTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # name, deep_a, deep_b, wide, seq_parent, seq_child,
-            #   expected_ebc, forbidden_ebc, expected_ec, forbidden_ec
             # Two DEEP groups, different suffix -> distinct tables.
-            [
+            param(
                 "distinct_suffix_per_tower",
-                "tower_a",
-                "tower_b",
-                None,
-                None,
-                None,
-                {
+                deep_a_suffix="tower_a",
+                deep_b_suffix="tower_b",
+                expected_ebc={
                     "cat_a_emb_tower_a",
                     "cat_a_emb_tower_b",
                     "cat_b_emb_tower_a",
                     "cat_b_emb_tower_b",
                 },
-                {"cat_a_emb", "cat_b_emb"},
-                set(),
-                set(),
-            ],
+                forbidden_ebc={"cat_a_emb", "cat_b_emb"},
+            ),
             # Two DEEP groups with same suffix -> shared (no unsuffixed leakage).
-            [
+            param(
                 "same_suffix_shares",
-                "shared",
-                "shared",
-                None,
-                None,
-                None,
-                {"cat_a_emb_shared", "cat_b_emb_shared"},
-                {"cat_a_emb", "cat_b_emb"},
-                set(),
-                set(),
-            ],
+                deep_a_suffix="shared",
+                deep_b_suffix="shared",
+                expected_ebc={"cat_a_emb_shared", "cat_b_emb_shared"},
+                forbidden_ebc={"cat_a_emb", "cat_b_emb"},
+            ),
             # WIDE + suffix -> "_wide_<suffix>" (additive with _wide).
-            [
+            param(
                 "wide_plus_suffix",
-                None,
-                None,
-                "tower_a",
-                None,
-                None,
-                {"cat_a_emb_wide_tower_a", "cat_b_emb_wide_tower_a"},
-                {"cat_a_emb_wide", "cat_a_emb"},
-                set(),
-                set(),
-            ],
+                wide_suffix="tower_a",
+                expected_ebc={"cat_a_emb_wide_tower_a", "cat_b_emb_wide_tower_a"},
+                forbidden_ebc={"cat_a_emb_wide", "cat_a_emb"},
+            ),
             # Nested seq inherits parent suffix when child doesn't set its own.
-            [
+            param(
                 "nested_seq_inherits_parent",
-                None,
-                None,
-                None,
-                "tower_a",
-                None,
-                {"cat_a_emb_tower_a"},
-                {"cat_a_emb"},
-                {"cat_a_emb_tower_a", "click_seq__cat_a_emb_tower_a"},
-                {"cat_a_emb", "click_seq__cat_a_emb"},
-            ],
+                seq_parent_suffix="tower_a",
+                expected_ebc={"cat_a_emb_tower_a"},
+                forbidden_ebc={"cat_a_emb"},
+                expected_ec={"cat_a_emb_tower_a", "click_seq__cat_a_emb_tower_a"},
+                forbidden_ec={"cat_a_emb", "click_seq__cat_a_emb"},
+            ),
             # Explicit child suffix overrides parent.
-            [
+            param(
                 "explicit_child_overrides_parent",
-                None,
-                None,
-                None,
-                "parent",
-                "child",
-                {"cat_a_emb_parent"},
-                set(),
-                {"cat_a_emb_child", "click_seq__cat_a_emb_child"},
-                {"cat_a_emb_parent", "click_seq__cat_a_emb_parent"},
-            ],
+                seq_parent_suffix="parent",
+                seq_child_suffix="child",
+                expected_ebc={"cat_a_emb_parent"},
+                expected_ec={"cat_a_emb_child", "click_seq__cat_a_emb_child"},
+                forbidden_ec={"cat_a_emb_parent", "click_seq__cat_a_emb_parent"},
+            ),
         ]
     )
     def test_embedding_name_suffix(
         self,
         name,
-        deep_a_suffix,
-        deep_b_suffix,
-        wide_suffix,
-        seq_parent_suffix,
-        seq_child_suffix,
-        expected_ebc,
-        forbidden_ebc,
-        expected_ec,
-        forbidden_ec,
+        deep_a_suffix=None,
+        deep_b_suffix=None,
+        wide_suffix=None,
+        seq_parent_suffix=None,
+        seq_child_suffix=None,
+        expected_ebc=frozenset(),
+        forbidden_ebc=frozenset(),
+        expected_ec=frozenset(),
+        forbidden_ec=frozenset(),
     ) -> None:
         features = _create_test_sequence_features()
         feature_groups = []

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -20,11 +20,8 @@ enum FeatureGroupType {
 message SeqGroupConfig {
     optional string group_name = 1;
     repeated string feature_names = 2;
-    // Per-seq-group suffix appended to each contained feature's embedding_name,
-    // so this seq_group's embedding tables stay independent of others.
-    // Empty == disabled. When nested under a DEEP FeatureGroupConfig with its
-    // own embedding_name_suffix and this field is empty, the parent's value is
-    // inherited; an explicit value here overrides the parent.
+    // Suffix appended to each feature's embedding_name; same semantics as
+    // FeatureGroupConfig.embedding_name_suffix. Empty == disabled.
     optional string embedding_name_suffix = 3;
 }
 
@@ -34,12 +31,8 @@ message FeatureGroupConfig {
     required FeatureGroupType group_type = 3 [default = DEEP];
     repeated SeqGroupConfig sequence_groups = 4;
     repeated SeqEncoderConfig sequence_encoders = 5;
-    // Per-group suffix appended to each contained feature's embedding_name so
-    // groups with different suffixes use independent embedding tables.
-    // Empty == disabled (default sharing-by-embedding_name behavior). For
-    // WIDE groups the composed name is "<emb_name>_wide_<suffix>". Auto-
-    // propagates to nested sequence_groups whose own embedding_name_suffix
-    // is empty.
+    // Suffix appended to each feature's embedding_name so groups with
+    // different suffixes use independent embedding tables. Empty == disabled.
     optional string embedding_name_suffix = 6;
 }
 

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -20,6 +20,11 @@ enum FeatureGroupType {
 message SeqGroupConfig {
     optional string group_name = 1;
     repeated string feature_names = 2;
+    // Per-seq-group suffix appended to each contained feature's embedding_name,
+    // so this seq_group's embedding tables stay independent of others.
+    // Empty == disabled. When nested under a DEEP FeatureGroupConfig with its
+    // own embedding_name_suffix and this field is empty, the parent's value is
+    // inherited; an explicit value here overrides the parent.
     optional string embedding_name_suffix = 3;
 }
 
@@ -29,6 +34,12 @@ message FeatureGroupConfig {
     required FeatureGroupType group_type = 3 [default = DEEP];
     repeated SeqGroupConfig sequence_groups = 4;
     repeated SeqEncoderConfig sequence_encoders = 5;
+    // Per-group suffix appended to each contained feature's embedding_name so
+    // groups with different suffixes use independent embedding tables.
+    // Empty == disabled (default sharing-by-embedding_name behavior). For
+    // WIDE groups the composed name is "<emb_name>_wide_<suffix>". Auto-
+    // propagates to nested sequence_groups whose own embedding_name_suffix
+    // is empty.
     optional string embedding_name_suffix = 6;
 }
 

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -20,7 +20,7 @@ enum FeatureGroupType {
 message SeqGroupConfig {
     optional string group_name = 1;
     repeated string feature_names = 2;
-
+    optional string embedding_name_suffix = 3;
 }
 
 message FeatureGroupConfig {
@@ -29,6 +29,7 @@ message FeatureGroupConfig {
     required FeatureGroupType group_type = 3 [default = DEEP];
     repeated SeqGroupConfig sequence_groups = 4;
     repeated SeqEncoderConfig sequence_encoders = 5;
+    optional string embedding_name_suffix = 6;
 }
 
 enum Kernel {

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"


### PR DESCRIPTION
## Summary

Adds an optional `embedding_name_suffix` field on `FeatureGroupConfig` (and mirrored on `SeqGroupConfig`) so that two feature groups referencing the same underlying feature can use independent embedding tables — without duplicating feature configs.

- Default behavior unchanged: groups without a suffix still share embeddings keyed by `embedding_name` as today.
- Two groups with the same suffix → still share.
- Two groups with different suffixes → independent embedding tables.
- For DEEP groups with nested `sequence_groups`, the parent's suffix is auto-propagated to nested seq groups that don't set their own; explicit child suffix wins.
- Suffix is additive with the existing WIDE `_wide` suffix: e.g. `cat_a_emb_wide_tower_a`.

## Changes

- `tzrec/protos/model.proto`: `embedding_name_suffix` on `FeatureGroupConfig` (field 6) and `SeqGroupConfig` (field 3).
- `tzrec/modules/embedding.py`:
  - `EmbeddingGroup.__init__`: propagate parent suffix to nested `sequence_groups` when child doesn't set one.
  - `EmbeddingGroupImpl.__init__`: append `_<suffix>` to `emb_name` after WIDE handling.
  - `SequenceEmbeddingGroupImpl.__init__`: same shape for the sequence path (works on both `FeatureGroupConfig` and propagated `SeqGroupConfig`).
- `docs/source/models/feature_group.md`: new section + two-tower example.
- `tzrec/modules/embedding_test.py`: cases for distinct/same suffix, WIDE+suffix, nested seq propagation, explicit child override.

## Test plan

- [x] `python -m unittest tzrec.modules.embedding_test` — 47 tests OK
- [x] `pre-commit run --files <changed>` clean
- [x] `python scripts/pyre_check.py` — no critical type errors
- [x] New `test_embedding_name_suffix` and `test_embedding_name_suffix_seq_child_overrides_parent` pass