### PR TITLE
[refactor] dataset/sampler: dynamic expand_factor + build_sampler_input + block-suffix combine

### DIFF
--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -28,6 +28,7 @@ from tzrec.acc.utils import (
 )
 from tzrec.constant import Mode
 from tzrec.datasets.utils import (
+    CAND_POS_LENGTHS,
     HARD_NEG_INDICES,
     Batch,
     DenseData,
@@ -268,6 +269,10 @@ class DataParser:
             output_data[HARD_NEG_INDICES] = torch.tensor(
                 input_data[HARD_NEG_INDICES].tolist(), dtype=torch.int32
             )
+        if CAND_POS_LENGTHS in input_data.keys():
+            output_data[CAND_POS_LENGTHS] = torch.tensor(
+                input_data[CAND_POS_LENGTHS].to_numpy(), dtype=torch.int32
+            )
         return output_data
 
     def _parse_feature_normal(
@@ -468,8 +473,12 @@ class DataParser:
         if self.sampler_type in ["hard_negative_sampler", "hard_negative_sampler_v2"]:
             try:
                 additional_infos[HARD_NEG_INDICES] = input_data[HARD_NEG_INDICES]
-            except Exception:
+            except KeyError:
                 logger.warning("No hard negative samples exist in the batch.")
+        try:
+            additional_infos[CAND_POS_LENGTHS] = input_data[CAND_POS_LENGTHS]
+        except KeyError:
+            pass
 
         batch = Batch(
             dense_features=dense_features,

--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyfg
 import torch
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
@@ -266,12 +267,16 @@ class DataParser:
                 )
 
         if HARD_NEG_INDICES in input_data.keys():
-            output_data[HARD_NEG_INDICES] = torch.tensor(
-                input_data[HARD_NEG_INDICES].tolist(), dtype=torch.int32
+            flat = pc.list_flatten(input_data[HARD_NEG_INDICES]).to_numpy()
+            output_data[HARD_NEG_INDICES] = torch.from_numpy(
+                flat.astype(np.int32, copy=False).reshape(-1, 2)
             )
         if CAND_POS_LENGTHS in input_data.keys():
-            output_data[CAND_POS_LENGTHS] = torch.tensor(
-                input_data[CAND_POS_LENGTHS].to_numpy(), dtype=torch.int32
+            # writable=True copies once -- avoids torch's non-writable warning.
+            output_data[CAND_POS_LENGTHS] = torch.from_numpy(
+                input_data[CAND_POS_LENGTHS].to_numpy(
+                    zero_copy_only=False, writable=True
+                )
             )
         return output_data
 

--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -267,15 +267,12 @@ class DataParser:
 
         if HARD_NEG_INDICES in input_data.keys():
             flat = pc.list_flatten(input_data[HARD_NEG_INDICES]).to_numpy()
-            output_data[HARD_NEG_INDICES] = torch.from_numpy(
+            output_data[HARD_NEG_INDICES] = _to_tensor(
                 flat.astype(np.int32, copy=False).reshape(-1, 2)
             )
         if CAND_POS_LENGTHS in input_data.keys():
-            # writable=True copies once -- avoids torch's non-writable warning.
-            output_data[CAND_POS_LENGTHS] = torch.from_numpy(
-                input_data[CAND_POS_LENGTHS].to_numpy(
-                    zero_copy_only=False, writable=True
-                )
+            output_data[CAND_POS_LENGTHS] = _to_tensor(
+                input_data[CAND_POS_LENGTHS].to_numpy()
             )
         return output_data
 
@@ -479,10 +476,14 @@ class DataParser:
                 additional_infos[HARD_NEG_INDICES] = input_data[HARD_NEG_INDICES]
             except KeyError:
                 logger.warning("No hard negative samples exist in the batch.")
-        try:
-            additional_infos[CAND_POS_LENGTHS] = input_data[CAND_POS_LENGTHS]
-        except KeyError:
-            pass
+        # Gate by sampler_type so torch.fx.symbolic_trace (unified AOT export)
+        # doesn't bake `cand_pos_lengths` into the graph when no sampler is
+        # configured.
+        if self.sampler_type is not None:
+            try:
+                additional_infos[CAND_POS_LENGTHS] = input_data[CAND_POS_LENGTHS]
+            except KeyError:
+                pass
 
         batch = Batch(
             dense_features=dense_features,

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -33,7 +33,7 @@ from tzrec.datasets.utils import (
     Batch,
     RecordBatchTensor,
     build_sampler_input,
-    combine_candidate_sequence_block,
+    combine_negs_to_candidate_sequence,
     expand_tdm_sample,
     remove_nullable,
 )
@@ -417,8 +417,8 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         For each sampled key:
           - new key (not in input_data) -> assigned as-is;
           - key with a seq_delim -> block-(B-1)-suffix combine via
-            ``combine_candidate_sequence_block`` (negatives go into row
-            B-1's suffix);
+            ``combine_negs_to_candidate_sequence`` (negatives go into
+            row B-1's suffix);
           - key without a seq_delim -> ``pa.concat_arrays`` (legacy path).
 
         pos_lengths is sourced from the first sequence-field combine call
@@ -434,7 +434,9 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             if seq_delim is None:
                 input_data[k] = pa.concat_arrays([input_data[k], v])
                 continue
-            combined, pl = combine_candidate_sequence_block(input_data[k], v, seq_delim)
+            combined, pl = combine_negs_to_candidate_sequence(
+                input_data[k], v, seq_delim
+            )
             input_data[k] = combined
             if pos_lengths is None:
                 pos_lengths = pl

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -168,9 +168,19 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         # Map input_name -> sequence_delim for sequence_id_features.
         self._seq_field_delims: Dict[str, str] = {}
         for feature in features:
-            if hasattr(feature, "sequence_delim") and feature.sequence_delim:
-                for input_name in feature.inputs:
-                    self._seq_field_delims[input_name] = feature.sequence_delim
+            if not feature.sequence_delim:
+                continue
+            for input_name in feature.inputs:
+                existing = self._seq_field_delims.get(input_name)
+                if existing is not None and existing != feature.sequence_delim:
+                    logger.warning(
+                        "Conflicting sequence_delim for input '%s': %r vs %r; "
+                        "latter wins.",
+                        input_name,
+                        existing,
+                        feature.sequence_delim,
+                    )
+                self._seq_field_delims[input_name] = feature.sequence_delim
 
         self._fg_mode = data_config.fg_mode
         self._fg_encoded_multival_sep = data_config.fg_encoded_multival_sep
@@ -427,9 +437,10 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         item_id_field combine; returns None if no sequence field was
         merged.
         """
-        # Prefer item_id_field; fall back to first-seen if none configured.
+        # Prefer item_id_field; fall back to first-seen seq-field if absent.
         prefer_key = self._sampler_item_id_field
-        pos_lengths: Optional[np.ndarray] = None
+        prefer_pl: Optional[np.ndarray] = None
+        first_pl: Optional[np.ndarray] = None
         for k, v in sampled.items():
             if k not in input_data:
                 input_data[k] = v
@@ -442,9 +453,11 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 input_data[k], v, seq_delim
             )
             input_data[k] = combined
-            if k == prefer_key or (prefer_key is None and pos_lengths is None):
-                pos_lengths = pl
-        return pos_lengths
+            if k == prefer_key:
+                prefer_pl = pl
+            elif first_pl is None:
+                first_pl = pl
+        return prefer_pl if prefer_pl is not None else first_pl
 
     @property
     def sampled_batch_size(self) -> int:

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -366,7 +366,16 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             input_data[HARD_NEG_INDICES] = hard_neg_indices
 
         if use_sample_mask:
-            self._append_neg_sample_mask(input_data, sampled)
+            num_sampled = len(next(iter(sampled.values())))
+            input_data[C_NEG_SAMPLE_MASK] = pa.concat_arrays(
+                [
+                    input_data[C_SAMPLE_MASK],
+                    pa.array(
+                        np.random.random(num_sampled)
+                        < self._data_config.negative_sample_mask_prob
+                    ),
+                ]
+            )
         return input_data
 
     def _apply_tdm_sampler(
@@ -436,23 +445,6 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             if k == prefer_key or (prefer_key is None and pos_lengths is None):
                 pos_lengths = pl
         return pos_lengths
-
-    def _append_neg_sample_mask(
-        self,
-        input_data: Dict[str, pa.Array],
-        sampled: Dict[str, pa.Array],
-    ) -> None:
-        """Append per-negative sample mask after the BASE sample mask."""
-        num_sampled = len(next(iter(sampled.values())))
-        input_data[C_NEG_SAMPLE_MASK] = pa.concat_arrays(
-            [
-                input_data[C_SAMPLE_MASK],
-                pa.array(
-                    np.random.random(num_sampled)
-                    < self._data_config.negative_sample_mask_prob
-                ),
-            ]
-        )
 
     @property
     def sampled_batch_size(self) -> int:

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -165,9 +165,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         ):
             self._selected_input_names = None
 
-        # Map of input_name -> sequence_delim for features declared as
-        # sequence_id_feature. _apply_negative_sampler uses this to detect
-        # which sampled-output keys need block-suffix combine vs plain concat.
+        # Map input_name -> sequence_delim for sequence_id_features.
         self._seq_field_delims: Dict[str, str] = {}
         for feature in features:
             if hasattr(feature, "sequence_delim") and feature.sequence_delim:
@@ -414,17 +412,14 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
     ) -> Optional[np.ndarray]:
         """Merge sampler outputs into input_data in place; return per-row pos lengths.
 
-        For each sampled key:
-          - new key (not in input_data) -> assigned as-is;
-          - key with a seq_delim -> block-(B-1)-suffix combine via
-            ``combine_negs_to_candidate_sequence`` (negatives go into
-            row B-1's suffix);
-          - key without a seq_delim -> ``pa.concat_arrays`` (legacy path).
-
-        pos_lengths is sourced from the first sequence-field combine call
-        (all sequence fields share the same per-row pos counts by
-        construction). Returns None if no sequence field was merged.
+        Per sampled key: new keys are assigned as-is, keys with a
+        `seq_delim` use the block-suffix combine, others fall back to
+        `pa.concat_arrays`. `pos_lengths` is sourced from the configured
+        item_id_field combine; returns None if no sequence field was
+        merged.
         """
+        # Prefer item_id_field; fall back to first-seen if none configured.
+        prefer_key = self._sampler_item_id_field
         pos_lengths: Optional[np.ndarray] = None
         for k, v in sampled.items():
             if k not in input_data:
@@ -438,7 +433,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 input_data[k], v, seq_delim
             )
             input_data[k] = combined
-            if pos_lengths is None:
+            if k == prefer_key or (prefer_key is None and pos_lengths is None):
                 pos_lengths = pl
         return pos_lengths
 

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -34,6 +34,7 @@ from tzrec.datasets.utils import (
     RecordBatchTensor,
     build_sampler_input,
     combine_candidate_sequence_block,
+    expand_tdm_sample,
     remove_nullable,
 )
 from tzrec.features.feature import BaseFeature
@@ -80,74 +81,6 @@ AVAILABLE_PA_TYPES = {
     pa.map_(pa.int32(), pa.string()),
     pa.map_(pa.int32(), pa.int32()),
 }
-
-
-def _expand_tdm_sample(
-    input_data: Dict[str, pa.Array],
-    pos_sampled: Dict[str, pa.Array],
-    neg_sampled: Dict[str, pa.Array],
-    data_config: data_pb2.DataConfig,
-) -> Dict[str, pa.Array]:
-    """Expand input data with sampled data for tdm.
-
-    Combine the sampled positive and negative samples with the item
-    features, then expand the user features based on the original user-item
-    relationships, and supplement the corresponding labels according to the
-    positive and negative samples. Note that in the sampling results, the
-    sampled outcomes for each item are contiguous.
-
-    for example:
-        user_fea:[1, 2], item_fea:[0.1, 0.2], labels:[1,1],
-        pos_sample:[0.11, 0.12, 0.21, 0.22], neg_sample:[-0.11, -0.12, -0.21, -0.22]
-
-        concat item_fea:[0.1, 0.2, 0.11, 0.12, 0.21, 0.22, -0.11, -0.12, -0.21, -0.22]
-        duplicate user_fea and keep origin user-item
-        relationship: [1, 2, 1, 1, 2, 2, 1, 1, 2, 2]
-
-        expand label: [1, 1, 1, 1, 1, 1, 0, 0, 0, 0]
-    """
-    item_fea_names = pos_sampled.keys()
-    all_fea_names = input_data.keys()
-    label_fields = set(data_config.label_fields)
-    user_fea_names = all_fea_names - item_fea_names - label_fields
-
-    for item_fea_name in item_fea_names:
-        input_data[item_fea_name] = pa.concat_arrays(
-            [
-                input_data[item_fea_name],
-                pos_sampled[item_fea_name],
-                neg_sampled[item_fea_name],
-            ]
-        )
-
-    # In the sampling results, the sampled outcomes for each item are contiguous.
-    batch_size = len(input_data[list(label_fields)[0]])
-    num_pos_sampled = len(pos_sampled[list(item_fea_names)[0]])
-    num_neg_sampled = len(neg_sampled[list(item_fea_names)[0]])
-    user_pos_index = np.repeat(np.arange(batch_size), num_pos_sampled // batch_size)
-    user_neg_index = np.repeat(np.arange(batch_size), num_neg_sampled // batch_size)
-    for user_fea_name in user_fea_names:
-        user_fea = input_data[user_fea_name]
-        pos_expand_user_fea = user_fea.take(user_pos_index)
-        neg_expand_user_fea = user_fea.take(user_neg_index)
-        input_data[user_fea_name] = pa.concat_arrays(
-            [
-                input_data[user_fea_name],
-                pos_expand_user_fea,
-                neg_expand_user_fea,
-            ]
-        )
-
-    for label_field in label_fields:
-        input_data[label_field] = pa.concat_arrays(
-            [
-                input_data[label_field].cast(pa.int64()),
-                pa.array([1] * num_pos_sampled, type=pa.int64()),
-                pa.array([0] * num_neg_sampled, type=pa.int64()),
-            ]
-        )
-
-    return input_data
 
 
 class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
@@ -446,10 +379,10 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         """TDMSampler path.
 
         Rebuilds C_SAMPLE_MASK over the [orig | pos | neg] layout that
-        _expand_tdm_sample produces.
+        expand_tdm_sample produces.
         """
         pos_sampled, neg_sampled = self._sampler.get(input_data)
-        input_data = _expand_tdm_sample(
+        input_data = expand_tdm_sample(
             input_data, pos_sampled, neg_sampled, self._data_config
         )
         if use_sample_mask:
@@ -457,7 +390,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             num_neg = len(next(iter(neg_sampled.values())))
             total = len(next(iter(input_data.values())))
             batch_size = total - num_pos - num_neg
-            # Rows after _expand_tdm_sample are laid out as
+            # Rows after expand_tdm_sample are laid out as
             # [orig_targets | pos_sampled | neg_sampled]. Mask the positives
             # (orig + pos_sampled) with sample_mask_prob and the negatives
             # with negative_sample_mask_prob. TDM features are never is_neg,

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -26,12 +26,14 @@ from tzrec.datasets.sampler import BaseSampler, TDMSampler
 from tzrec.datasets.utils import (
     C_NEG_SAMPLE_MASK,
     C_SAMPLE_MASK,
+    CAND_POS_LENGTHS,
     CKPT_ROW_IDX,
     CKPT_SOURCE_ID,
+    HARD_NEG_INDICES,
     Batch,
     RecordBatchTensor,
-    process_hstu_neg_sample,
-    process_hstu_seq_data,
+    build_sampler_input,
+    combine_candidate_sequence_block,
     remove_nullable,
 )
 from tzrec.features.feature import BaseFeature
@@ -177,7 +179,6 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         self._reserved_columns = reserved_columns or []
         self._mode = mode
         self._debug_level = debug_level
-        self._enable_hstu = data_config.enable_hstu
         self.sampler_type = (
             self._data_config.WhichOneof("sampler")
             if self._data_config.HasField("sampler")
@@ -208,6 +209,8 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             self._selected_input_names |= set(data_config.sample_weight_fields)
         if data_config.HasField("sample_cost_field"):
             self._selected_input_names.add(data_config.sample_cost_field)
+        self._sampler_item_id_field: Optional[str] = None
+        self._sampler_user_id_field: Optional[str] = None
         if self._data_config.HasField("sampler") and self._mode != Mode.PREDICT:
             sampler_type = self._data_config.WhichOneof("sampler")
             sampler_config = getattr(self._data_config, sampler_type)
@@ -215,10 +218,12 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 "item_id_field"
             ):
                 self._selected_input_names.add(sampler_config.item_id_field)
+                self._sampler_item_id_field = sampler_config.item_id_field
             if hasattr(sampler_config, "user_id_field") and sampler_config.HasField(
                 "user_id_field"
             ):
                 self._selected_input_names.add(sampler_config.user_id_field)
+                self._sampler_user_id_field = sampler_config.user_id_field
         # if set selected_input_names to None,
         # all columns will be reserved.
         if (
@@ -226,6 +231,15 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             and self._reserved_columns[0] == "ALL_COLUMNS"
         ):
             self._selected_input_names = None
+
+        # Map of input_name -> sequence_delim for features declared as
+        # sequence_id_feature. _apply_negative_sampler uses this to detect
+        # which sampled-output keys need block-suffix combine vs plain concat.
+        self._seq_field_delims: Dict[str, str] = {}
+        for feature in features:
+            if hasattr(feature, "sequence_delim") and feature.sequence_delim:
+                for input_name in feature.inputs:
+                    self._seq_field_delims[input_name] = feature.sequence_delim
 
         self._fg_mode = data_config.fg_mode
         self._fg_encoded_multival_sep = data_config.fg_encoded_multival_sep
@@ -363,85 +377,9 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
             )
         if self._sampler is not None:
             if isinstance(self._sampler, TDMSampler):
-                pos_sampled, neg_sampled = self._sampler.get(input_data)
-                input_data = _expand_tdm_sample(
-                    input_data, pos_sampled, neg_sampled, self._data_config
-                )
-                if use_sample_mask:
-                    num_pos = len(list(pos_sampled.values())[0])
-                    num_neg = len(list(neg_sampled.values())[0])
-                    total = len(list(input_data.values())[0])
-                    batch_size = total - num_pos - num_neg
-                    # Rows after _expand_tdm_sample are laid out as
-                    # [orig_targets | pos_sampled | neg_sampled]. Mask the
-                    # positives (orig + pos_sampled) with sample_mask_prob and
-                    # the negatives with negative_sample_mask_prob. TDM features
-                    # are never is_neg, so only C_SAMPLE_MASK needs to be set.
-                    input_data[C_SAMPLE_MASK] = pa.array(
-                        np.concatenate(
-                            [
-                                np.random.random(batch_size + num_pos)
-                                < self._data_config.sample_mask_prob,
-                                np.random.random(num_neg)
-                                < self._data_config.negative_sample_mask_prob,
-                            ]
-                        )
-                    )
-            elif self._enable_hstu:
-                seq_attr = self._sampler._item_id_field
-
-                (
-                    input_data_k_split,
-                    input_data_k_split_slice,
-                    pre_seq_filter_reshaped_joined,
-                ) = process_hstu_seq_data(
-                    input_data=input_data,
-                    seq_attr=seq_attr,
-                    seq_str_delim=self._sampler.item_id_delim,
-                )
-                if self._mode == Mode.TRAIN:
-                    # Training using all possible target items
-                    input_data[seq_attr] = input_data_k_split_slice
-                elif self._mode == Mode.EVAL:
-                    # Evaluation using the last item for previous sequence
-                    input_data[seq_attr] = input_data_k_split.values.take(
-                        pa.array(input_data_k_split.offsets.to_numpy()[1:] - 1)
-                    )
-                sampled = self._sampler.get(input_data)
-                # To keep consistent with other process, use two functions
-                for k, v in sampled.items():
-                    if k in input_data:
-                        combined = process_hstu_neg_sample(
-                            input_data,
-                            v,
-                            self._sampler._num_sample,
-                            self._sampler.item_id_delim,
-                            seq_attr,
-                        )
-                        # Combine here to make embddings of both user sequence
-                        # and target item are the same
-                        input_data[k] = pa.concat_arrays(
-                            [pre_seq_filter_reshaped_joined, combined]
-                        )
-                    else:
-                        input_data[k] = v
+                input_data = self._apply_tdm_sampler(input_data, use_sample_mask)
             else:
-                sampled = self._sampler.get(input_data)
-                for k, v in sampled.items():
-                    if k in input_data:
-                        input_data[k] = pa.concat_arrays([input_data[k], v])
-                    else:
-                        input_data[k] = v
-                if use_sample_mask:
-                    input_data[C_NEG_SAMPLE_MASK] = pa.concat_arrays(
-                        [
-                            input_data[C_SAMPLE_MASK],
-                            pa.array(
-                                np.random.random(len(list(sampled.values())[0]))
-                                < self._data_config.negative_sample_mask_prob
-                            ),
-                        ]
-                    )
+                input_data = self._apply_negative_sampler(input_data, use_sample_mask)
 
         # TODO(hongsheng.jhs): add additional field like hard_negative
         output_data = self._data_parser.parse(input_data)
@@ -468,6 +406,123 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         # Set checkpoint info on batch
         batch.checkpoint_info = checkpoint_info
         return batch
+
+    def _apply_negative_sampler(
+        self,
+        input_data: Dict[str, pa.Array],
+        use_sample_mask: bool,
+    ) -> Dict[str, pa.Array]:
+        """NegativeSampler / NegativeSamplerV2 / HardNegativeSampler[V2] path.
+
+        Build a shallow-copy sampler_input (item_id flattened, user_id
+        expanded), call the sampler, then merge results into input_data
+        in place.
+        """
+        sampler_input = build_sampler_input(
+            input_data,
+            self._sampler_item_id_field,
+            self._sampler_user_id_field,
+            self._seq_field_delims,
+        )
+        sampled = self._sampler.get(sampler_input)
+
+        hard_neg_indices = sampled.pop(HARD_NEG_INDICES, None)
+        pos_lengths = self._merge_sampled_features(input_data, sampled)
+
+        if pos_lengths is not None:
+            input_data[CAND_POS_LENGTHS] = pa.array(pos_lengths)
+        if hard_neg_indices is not None:
+            input_data[HARD_NEG_INDICES] = hard_neg_indices
+
+        if use_sample_mask:
+            self._append_neg_sample_mask(input_data, sampled)
+        return input_data
+
+    def _apply_tdm_sampler(
+        self,
+        input_data: Dict[str, pa.Array],
+        use_sample_mask: bool,
+    ) -> Dict[str, pa.Array]:
+        """TDMSampler path.
+
+        Rebuilds C_SAMPLE_MASK over the [orig | pos | neg] layout that
+        _expand_tdm_sample produces.
+        """
+        pos_sampled, neg_sampled = self._sampler.get(input_data)
+        input_data = _expand_tdm_sample(
+            input_data, pos_sampled, neg_sampled, self._data_config
+        )
+        if use_sample_mask:
+            num_pos = len(next(iter(pos_sampled.values())))
+            num_neg = len(next(iter(neg_sampled.values())))
+            total = len(next(iter(input_data.values())))
+            batch_size = total - num_pos - num_neg
+            # Rows after _expand_tdm_sample are laid out as
+            # [orig_targets | pos_sampled | neg_sampled]. Mask the positives
+            # (orig + pos_sampled) with sample_mask_prob and the negatives
+            # with negative_sample_mask_prob. TDM features are never is_neg,
+            # so only C_SAMPLE_MASK needs to be set.
+            input_data[C_SAMPLE_MASK] = pa.array(
+                np.concatenate(
+                    [
+                        np.random.random(batch_size + num_pos)
+                        < self._data_config.sample_mask_prob,
+                        np.random.random(num_neg)
+                        < self._data_config.negative_sample_mask_prob,
+                    ]
+                )
+            )
+        return input_data
+
+    def _merge_sampled_features(
+        self,
+        input_data: Dict[str, pa.Array],
+        sampled: Dict[str, pa.Array],
+    ) -> Optional[np.ndarray]:
+        """Merge sampler outputs into input_data in place; return per-row pos lengths.
+
+        For each sampled key:
+          - new key (not in input_data) -> assigned as-is;
+          - key with a seq_delim -> block-(B-1)-suffix combine via
+            ``combine_candidate_sequence_block`` (negatives go into row
+            B-1's suffix);
+          - key without a seq_delim -> ``pa.concat_arrays`` (legacy path).
+
+        pos_lengths is sourced from the first sequence-field combine call
+        (all sequence fields share the same per-row pos counts by
+        construction). Returns None if no sequence field was merged.
+        """
+        pos_lengths: Optional[np.ndarray] = None
+        for k, v in sampled.items():
+            if k not in input_data:
+                input_data[k] = v
+                continue
+            seq_delim = self._seq_field_delims.get(k)
+            if seq_delim is None:
+                input_data[k] = pa.concat_arrays([input_data[k], v])
+                continue
+            combined, pl = combine_candidate_sequence_block(input_data[k], v, seq_delim)
+            input_data[k] = combined
+            if pos_lengths is None:
+                pos_lengths = pl
+        return pos_lengths
+
+    def _append_neg_sample_mask(
+        self,
+        input_data: Dict[str, pa.Array],
+        sampled: Dict[str, pa.Array],
+    ) -> None:
+        """Append per-negative sample mask after the BASE sample mask."""
+        num_sampled = len(next(iter(sampled.values())))
+        input_data[C_NEG_SAMPLE_MASK] = pa.concat_arrays(
+            [
+                input_data[C_SAMPLE_MASK],
+                pa.array(
+                    np.random.random(num_sampled)
+                    < self._data_config.negative_sample_mask_prob
+                ),
+            ]
+        )
 
     @property
     def sampled_batch_size(self) -> int:

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -942,7 +942,7 @@ class DatasetTest(unittest.TestCase):
         iterator = iter(dataloader)
         batch = next(iterator)
         data_dict = batch.to_dict()
-        # After _expand_tdm_sample, every feature has length 40
+        # After expand_tdm_sample, every feature has length 40
         # (batch_size=4 expanded by TDM sampling to 40 rows). float_b has
         # no use_mask so it is never masked. int_a has use_mask=True so the
         # high sample_mask_prob / negative_sample_mask_prob should null out

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -660,16 +660,10 @@ class DatasetTest(unittest.TestCase):
         pos_lengths = batch.additional_infos[CAND_POS_LENGTHS]
         self.assertEqual(pos_lengths.tolist(), [2, 2, 2, 2])
 
-        # Critical: HARD_NEG_INDICES[:, 0] indexes into the flat Q-length
-        # src_ids (post-flatten), not the B-length batch rows.
+        # HARD_NEG_INDICES[:, 0] indexes into the flat Q=8 src_ids (post-flatten),
+        # not the B=4 batch rows. Seed gives every flat position a hard-neg edge.
         hard_neg_indices = batch.additional_infos[HARD_NEG_INDICES]
-        self.assertGreater(hard_neg_indices.numel(), 0)
-        max_src_idx = int(hard_neg_indices[:, 0].max().item())
-        # max < Q=8 confirms indices stay in the flat range.
-        self.assertLess(max_src_idx, 8)
-        # max >= B=4 confirms indices reach beyond the first batch row --
-        # a regression flipping back to [0, B) would fail this.
-        self.assertGreaterEqual(max_src_idx, 4)
+        self.assertEqual(set(hard_neg_indices[:, 0].tolist()), {0, 1, 2, 3, 4, 5, 6, 7})
 
     def test_dataset_with_sample_mask(self):
         input_fields = [

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -28,6 +28,7 @@ from tzrec.datasets.dataset import BaseDataset, BaseReader
 from tzrec.datasets.utils import (
     BASE_DATA_GROUP,
     CAND_POS_LENGTHS,
+    HARD_NEG_INDICES,
     NEG_DATA_GROUP,
 )
 from tzrec.features.feature import BaseFeature, create_features
@@ -481,7 +482,7 @@ class DatasetTest(unittest.TestCase):
         Schema declares `item_id` as `pa.list_(pa.int64())` (Parquet-style
         multi-value column). Exercises `build_sampler_input`'s list-pass-
         through + flatten, the dynamic-`expand_factor` path in the
-        sampler, and `combine_candidate_sequence_block`'s list-typed-negs
+        sampler, and `combine_negs_to_candidate_sequence`'s list-typed-negs
         normalization. Parameterized over Mode.TRAIN / Mode.EVAL so the
         eval-mode `num_eval_sample` path is also covered.
         """
@@ -548,6 +549,127 @@ class DatasetTest(unittest.TestCase):
         # _TestReader yields 2 list elements per row; batch_size = 4 -> K_i = 2.
         pos_lengths = batch.additional_infos[CAND_POS_LENGTHS]
         self.assertEqual(pos_lengths.tolist(), [2, 2, 2, 2])
+
+    @parameterized.expand(
+        [
+            [Mode.TRAIN],
+            [Mode.EVAL],
+        ]
+    )
+    def test_dataset_with_hard_negative_sampler_list_item_id(self, mode):
+        """E2E: HardNegativeSampler with list-typed item_id (Q != B contract).
+
+        Locks the contract documented in sampler.py:660 -- after
+        `build_sampler_input` flattens multi-positive queries,
+        `HARD_NEG_INDICES[:, 0]` indexes into the flat Q-length src_ids,
+        not the original B-length batch rows.
+        """
+        # Item file: ids 0..99 + canonical attrs.
+        item_f = tempfile.NamedTemporaryFile("w")
+        self._temp_files.append(item_f)
+        item_f.write("id:int64\tweight:float\tattrs:string\n")
+        for i in range(100):
+            item_f.write(f"{i}\t{1}\t{i}\n")
+        item_f.flush()
+
+        # User file: ids 0..99.
+        user_f = tempfile.NamedTemporaryFile("w")
+        self._temp_files.append(user_f)
+        user_f.write("id:int64\tweight:float\n")
+        for i in range(100):
+            user_f.write(f"{i}\t{1}\n")
+        user_f.flush()
+
+        # Hard-neg edges: every user u has 2 hard-neg items so any
+        # sampled src_id returns at least one hard-neg row.
+        hard_neg_f = tempfile.NamedTemporaryFile("w")
+        self._temp_files.append(hard_neg_f)
+        hard_neg_f.write("userid:int64\titemid:int64\tweight:float\n")
+        for u in range(100):
+            for offset in (50, 51):
+                hard_neg_f.write(f"{u}\t{(u + offset) % 100}\t{1}\n")
+        hard_neg_f.flush()
+
+        input_fields = [
+            pa.field(name="user_id", type=pa.int64()),
+            pa.field(name="item_id", type=pa.list_(pa.int64())),
+            pa.field(name="label", type=pa.int32()),
+        ]
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="user_id",
+                    expression="user:user_id",
+                    num_buckets=200,
+                    embedding_dim=8,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                sequence_id_feature=feature_pb2.IdFeature(
+                    feature_name="item_id",
+                    expression="item:item_id",
+                    sequence_length=10,
+                    sequence_delim=";",
+                    num_buckets=200,
+                    embedding_dim=8,
+                )
+            ),
+        ]
+        features = create_features(
+            feature_cfgs,
+            neg_fields=["item_id"],
+            force_base_data_group=True,
+        )
+
+        dataset = _TestDataset(
+            data_config=data_pb2.DataConfig(
+                batch_size=4,
+                dataset_type=data_pb2.DatasetType.OdpsDataset,
+                fg_mode=data_pb2.FgMode.FG_NORMAL,
+                label_fields=["label"],
+                hard_negative_sampler=sampler_pb2.HardNegativeSampler(
+                    user_input_path=user_f.name,
+                    item_input_path=item_f.name,
+                    hard_neg_edge_input_path=hard_neg_f.name,
+                    num_sample=8,
+                    num_eval_sample=4,
+                    num_hard_sample=2,
+                    attr_fields=["item_id"],
+                    item_id_field="item_id",
+                    user_id_field="user_id",
+                ),
+                force_base_data_group=True,
+            ),
+            features=features,
+            input_path="",
+            input_fields=input_fields,
+            mode=mode,
+        )
+        dataset.launch_sampler_cluster(2)
+        dataloader = DataLoader(
+            dataset=dataset,
+            batch_size=None,
+            num_workers=2,
+            pin_memory=True,
+            collate_fn=lambda x: x,
+        )
+        iterator = iter(dataloader)
+        batch = next(iterator)
+
+        # _TestReader yields K_i = 2 per row; batch_size = 4 -> Q = 8.
+        pos_lengths = batch.additional_infos[CAND_POS_LENGTHS]
+        self.assertEqual(pos_lengths.tolist(), [2, 2, 2, 2])
+
+        # Critical: HARD_NEG_INDICES[:, 0] indexes into the flat Q-length
+        # src_ids (post-flatten), not the B-length batch rows.
+        hard_neg_indices = batch.additional_infos[HARD_NEG_INDICES]
+        self.assertGreater(hard_neg_indices.numel(), 0)
+        max_src_idx = int(hard_neg_indices[:, 0].max().item())
+        # max < Q=8 confirms indices stay in the flat range.
+        self.assertLess(max_src_idx, 8)
+        # max >= B=4 confirms indices reach beyond the first batch row --
+        # a regression flipping back to [0, B) would fail this.
+        self.assertGreaterEqual(max_src_idx, 4)
 
     def test_dataset_with_sample_mask(self):
         input_fields = [

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -27,6 +27,7 @@ from tzrec.constant import Mode
 from tzrec.datasets.dataset import BaseDataset, BaseReader
 from tzrec.datasets.utils import (
     BASE_DATA_GROUP,
+    CAND_POS_LENGTHS,
     NEG_DATA_GROUP,
 )
 from tzrec.features.feature import BaseFeature, create_features
@@ -80,6 +81,26 @@ class _TestReader(BaseReader):
                     if f.type.value_type == pa.string():
                         data = [
                             [str(np.random.randint(100)) for _ in range(2)]
+                            for _ in range(self._batch_size)
+                        ]
+                    elif f.type.value_type == pa.int64():
+                        data = [
+                            [int(np.random.randint(100)) for _ in range(2)]
+                            for _ in range(self._batch_size)
+                        ]
+                    elif f.type.value_type == pa.int32():
+                        data = [
+                            [int(np.random.randint(100)) for _ in range(2)]
+                            for _ in range(self._batch_size)
+                        ]
+                    elif f.type.value_type == pa.float32():
+                        data = [
+                            [float(np.random.rand()) for _ in range(2)]
+                            for _ in range(self._batch_size)
+                        ]
+                    elif f.type.value_type == pa.float64():
+                        data = [
+                            [float(np.random.rand()) for _ in range(2)]
                             for _ in range(self._batch_size)
                         ]
                     else:
@@ -447,6 +468,86 @@ class DatasetTest(unittest.TestCase):
                 self.assertEqual(
                     batch.sparse_features[BASE_DATA_GROUP].lengths().size(), (12,)
                 )
+
+    @parameterized.expand(
+        [
+            [Mode.TRAIN],
+            [Mode.EVAL],
+        ]
+    )
+    def test_dataset_with_sampler_list_item_id(self, mode):
+        """E2E: list-typed item_id positives through a real NegativeSampler.
+
+        Schema declares `item_id` as `pa.list_(pa.int64())` (Parquet-style
+        multi-value column). Exercises `build_sampler_input`'s list-pass-
+        through + flatten, the dynamic-`expand_factor` path in the
+        sampler, and `combine_candidate_sequence_block`'s list-typed-negs
+        normalization. Parameterized over Mode.TRAIN / Mode.EVAL so the
+        eval-mode `num_eval_sample` path is also covered.
+        """
+        f = tempfile.NamedTemporaryFile("w")
+        self._temp_files.append(f)
+        f.write("id:int64\tweight:float\tattrs:string\n")
+        for i in range(100):
+            f.write(f"{i}\t{1}\t{i}\n")
+        f.flush()
+
+        input_fields = [
+            pa.field(name="item_id", type=pa.list_(pa.int64())),
+            pa.field(name="label", type=pa.int32()),
+        ]
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                sequence_id_feature=feature_pb2.IdFeature(
+                    feature_name="item_id",
+                    expression="item:item_id",
+                    sequence_length=10,
+                    sequence_delim=";",
+                    num_buckets=200,
+                    embedding_dim=8,
+                )
+            ),
+        ]
+        features = create_features(
+            feature_cfgs,
+            neg_fields=["item_id"],
+            force_base_data_group=True,
+        )
+
+        dataset = _TestDataset(
+            data_config=data_pb2.DataConfig(
+                batch_size=4,
+                dataset_type=data_pb2.DatasetType.OdpsDataset,
+                fg_mode=data_pb2.FgMode.FG_NORMAL,
+                label_fields=["label"],
+                negative_sampler=sampler_pb2.NegativeSampler(
+                    input_path=f.name,
+                    num_sample=8,
+                    num_eval_sample=4,
+                    attr_fields=["item_id"],
+                    item_id_field="item_id",
+                ),
+                force_base_data_group=True,
+            ),
+            features=features,
+            input_path="",
+            input_fields=input_fields,
+            mode=mode,
+        )
+        dataset.launch_sampler_cluster(2)
+        dataloader = DataLoader(
+            dataset=dataset,
+            batch_size=None,
+            num_workers=2,
+            pin_memory=True,
+            collate_fn=lambda x: x,
+        )
+        iterator = iter(dataloader)
+        batch = next(iterator)
+
+        # _TestReader yields 2 list elements per row; batch_size = 4 -> K_i = 2.
+        pos_lengths = batch.additional_infos[CAND_POS_LENGTHS]
+        self.assertEqual(pos_lengths.tolist(), [2, 2, 2, 2])
 
     def test_dataset_with_sample_mask(self):
         input_fields = [

--- a/tzrec/datasets/sampler.py
+++ b/tzrec/datasets/sampler.py
@@ -14,7 +14,7 @@ import os
 import random
 import socket
 import time
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import graphlearn as gl
 import numpy as np
@@ -358,6 +358,16 @@ class BaseSampler(metaclass=_meta_cls):
     def _parse_sparse_nodes(
         self, nodes: gl.Nodes
     ) -> Tuple[List[pa.Array], npt.NDArray]:
+        """Parse sparse-neighbor sampler output.
+
+        Returns ``(features, indices)`` where ``indices`` has shape
+        ``(H, 2)`` and ``indices[:, 0]`` is the source-axis offset into
+        the array the caller passed to the sampler. When the caller
+        passes ``B`` row-ids, indices are in ``[0, B)``; when the
+        caller flattens to ``Q`` per-positive ids (e.g. via
+        ``build_sampler_input``), indices are in ``[0, Q)``. ``indices[:, 1]``
+        is the per-source neighbor offset.
+        """
         features = []
         # pyre-ignore [16]
         if len(nodes.indices) == 0:
@@ -428,19 +438,27 @@ class NegativeSampler(BaseSampler):
             ),
         )
         self._item_id_field = config.item_id_field
-        self._sampler = None
+        self._sampler_cache: Dict[int, Any] = {}
         self.item_id_delim = config.item_id_delim
 
     def init(self, client_id: int = -1) -> None:
-        """Init sampler client and samplers."""
+        """Init sampler client; per-expand_factor samplers are created lazily."""
         super().init(client_id)
-        expand_factor = int(math.ceil(self._num_sample / self._batch_size))
-        self._sampler = self._g.negative_sampler(
-            "item", expand_factor, strategy="node_weight"
-        )
+        self._sampler_cache = {}
+
+    def _get_sampler(self, expand_factor: int) -> Any:
+        if expand_factor not in self._sampler_cache:
+            self._sampler_cache[expand_factor] = self._g.negative_sampler(
+                "item", expand_factor, strategy="node_weight"
+            )
+        return self._sampler_cache[expand_factor]
 
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
+
+        `expand_factor` is computed from the actual input length so that
+        flattened multi-positive queries (Q values from B rows) are
+        supported with no padding to batch_size.
 
         Args:
             input_data (dict): input data with item_id.
@@ -449,8 +467,10 @@ class NegativeSampler(BaseSampler):
             Negative sampled feature dict.
         """
         ids = _pa_ids_to_npy(input_data[self._item_id_field])
-        ids = np.pad(ids, (0, self._batch_size - len(ids)), "edge")
-        nodes = self._sampler.get(ids)
+        num_pos = max(1, len(ids))
+        expand_factor = max(1, int(math.ceil(self._num_sample / num_pos)))
+        sampler = self._get_sampler(expand_factor)
+        nodes = sampler.get(ids)
         features = self._parse_nodes(nodes)
         result_dict = dict(zip(self._valid_attr_names, features))
         return result_dict
@@ -509,15 +529,12 @@ class NegativeSamplerV2(BaseSampler):
         )
         self._item_id_field = config.item_id_field
         self._user_id_field = config.user_id_field
-        self._sampler = None
+        self._sampler_cache: Dict[int, Any] = {}
 
     def init(self, client_id: int = -1) -> None:
-        """Init sampler client and samplers."""
+        """Init sampler client; per-expand_factor samplers are created lazily."""
         super().init(client_id)
-        expand_factor = int(math.ceil(self._num_sample / self._batch_size))
-        self._sampler = self._g.negative_sampler(
-            "edge", expand_factor, strategy="random", conditional=True
-        )
+        self._sampler_cache = {}
 
         # prevent gl timeout
         worker_info = get_worker_info()
@@ -528,8 +545,20 @@ class NegativeSamplerV2(BaseSampler):
             {self._user_id_field: pa.array([0]), self._item_id_field: pa.array([0])}
         )
 
+    def _get_sampler(self, expand_factor: int) -> Any:
+        if expand_factor not in self._sampler_cache:
+            self._sampler_cache[expand_factor] = self._g.negative_sampler(
+                "edge", expand_factor, strategy="random", conditional=True
+            )
+        return self._sampler_cache[expand_factor]
+
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
+
+        Caller is responsible for keeping (user_id, item_id) row-aligned;
+        for flattened multi-positive queries, `build_sampler_input` in
+        ``tzrec/datasets/utils.py`` expands user_id by per-row positive
+        count before calling here.
 
         Args:
             input_data (dict): input data with user_id and item_id.
@@ -539,9 +568,10 @@ class NegativeSamplerV2(BaseSampler):
         """
         src_ids = _pa_ids_to_npy(input_data[self._user_id_field])
         dst_ids = _pa_ids_to_npy(input_data[self._item_id_field])
-        src_ids = np.pad(src_ids, (0, self._batch_size - len(src_ids)), "edge")
-        dst_ids = np.pad(dst_ids, (0, self._batch_size - len(dst_ids)), "edge")
-        nodes = self._sampler.get(src_ids, dst_ids)
+        num_pos = max(1, len(dst_ids))
+        expand_factor = max(1, int(math.ceil(self._num_sample / num_pos)))
+        sampler = self._get_sampler(expand_factor)
+        nodes = sampler.get(src_ids, dst_ids)
         features = self._parse_nodes(nodes)
         result_dict = dict(zip(self._valid_attr_names, features))
         return result_dict
@@ -602,34 +632,51 @@ class HardNegativeSampler(BaseSampler):
         )
         self._item_id_field = config.item_id_field
         self._user_id_field = config.user_id_field
-        self._neg_sampler = None
+        self._neg_sampler_cache: Dict[int, Any] = {}
         self._hard_neg_sampler = None
 
     def init(self, client_id: int = -1) -> None:
-        """Init sampler client and samplers."""
+        """Init sampler client and the hard-neg neighbor sampler.
+
+        Regular-neg samplers are created lazily per expand_factor in
+        :meth:`_get_neg_sampler`.
+        """
         super().init(client_id)
-        expand_factor = int(math.ceil(self._num_sample / self._batch_size))
-        self._neg_sampler = self._g.negative_sampler(
-            "item", expand_factor, strategy="node_weight"
-        )
+        self._neg_sampler_cache = {}
         self._hard_neg_sampler = self._g.neighbor_sampler(
             ["hard_neg_edge"], self._num_hard_sample, strategy="full"
         )
 
+    def _get_neg_sampler(self, expand_factor: int) -> Any:
+        if expand_factor not in self._neg_sampler_cache:
+            self._neg_sampler_cache[expand_factor] = self._g.negative_sampler(
+                "item", expand_factor, strategy="node_weight"
+            )
+        return self._neg_sampler_cache[expand_factor]
+
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
+
+        ``hard_neg_indices[:, 0]`` indexes into the caller-supplied
+        ``input_data[user_id_field]`` array: if the caller passed ``B``
+        user ids, indices are in ``[0, B)``; if the caller flattened to
+        ``Q`` user ids (e.g. via ``build_sampler_input``), indices are
+        in ``[0, Q)``.
 
         Args:
             input_data (dict): input data with user_id and item_id.
 
         Returns:
-            Negative sampled feature dict. The first batch_size is negative samples,
-                remainder is hard negative samples
+            Negative sampled feature dict. First num_sample entries are
+            simple negatives; the remaining entries are hard negatives.
+            ``HARD_NEG_INDICES`` is included when any hard neg exists.
         """
         src_ids = _pa_ids_to_npy(input_data[self._user_id_field])
         dst_ids = _pa_ids_to_npy(input_data[self._item_id_field])
-        dst_ids = np.pad(dst_ids, (0, self._batch_size - len(dst_ids)), "edge")
-        nodes = self._neg_sampler.get(dst_ids)
+        num_pos = max(1, len(dst_ids))
+        expand_factor = max(1, int(math.ceil(self._num_sample / num_pos)))
+        neg_sampler = self._get_neg_sampler(expand_factor)
+        nodes = neg_sampler.get(dst_ids)
         neg_features = self._parse_nodes(nodes)
         sparse_nodes = self._hard_neg_sampler.get(src_ids).layer_nodes(1)
         hard_neg_features, hard_neg_indices = self._parse_sparse_nodes(sparse_nodes)
@@ -703,35 +750,51 @@ class HardNegativeSamplerV2(BaseSampler):
         )
         self._item_id_field = config.item_id_field
         self._user_id_field = config.user_id_field
-        self._neg_sampler = None
+        self._neg_sampler_cache: Dict[int, Any] = {}
         self._hard_neg_sampler = None
 
     def init(self, client_id: int = -1) -> None:
-        """Init sampler client and samplers."""
+        """Init sampler client and the hard-neg neighbor sampler.
+
+        Regular-neg samplers are created lazily per expand_factor in
+        :meth:`_get_neg_sampler`.
+        """
         super().init(client_id)
-        expand_factor = int(math.ceil(self._num_sample / self._batch_size))
-        self._neg_sampler = self._g.negative_sampler(
-            "edge", expand_factor, strategy="random", conditional=True
-        )
+        self._neg_sampler_cache = {}
         self._hard_neg_sampler = self._g.neighbor_sampler(
             ["hard_neg_edge"], self._num_hard_sample, strategy="full"
         )
 
+    def _get_neg_sampler(self, expand_factor: int) -> Any:
+        if expand_factor not in self._neg_sampler_cache:
+            self._neg_sampler_cache[expand_factor] = self._g.negative_sampler(
+                "edge", expand_factor, strategy="random", conditional=True
+            )
+        return self._neg_sampler_cache[expand_factor]
+
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
+
+        Caller is responsible for keeping (user_id, item_id) row-aligned;
+        for flattened multi-positive queries, ``build_sampler_input`` in
+        ``tzrec/datasets/utils.py`` expands user_id by per-row positive
+        count before calling here. ``hard_neg_indices[:, 0]`` then
+        indexes into the caller-supplied ``input_data[user_id_field]``.
 
         Args:
             input_data (dict): input data with user_id and item_id.
 
         Returns:
-            Negative sampled feature dict. The first batch_size is negative samples,
-                remainder is hard negative samples
+            Negative sampled feature dict. First num_sample entries are
+            simple negatives; the remaining entries are hard negatives.
+            ``HARD_NEG_INDICES`` is included when any hard neg exists.
         """
         src_ids = _pa_ids_to_npy(input_data[self._user_id_field])
         dst_ids = _pa_ids_to_npy(input_data[self._item_id_field])
-        padded_src_ids = np.pad(src_ids, (0, self._batch_size - len(src_ids)), "edge")
-        dst_ids = np.pad(dst_ids, (0, self._batch_size - len(dst_ids)), "edge")
-        nodes = self._neg_sampler.get(padded_src_ids, dst_ids)
+        num_pos = max(1, len(dst_ids))
+        expand_factor = max(1, int(math.ceil(self._num_sample / num_pos)))
+        neg_sampler = self._get_neg_sampler(expand_factor)
+        nodes = neg_sampler.get(src_ids, dst_ids)
         neg_features = self._parse_nodes(nodes)
         sparse_nodes = self._hard_neg_sampler.get(src_ids).layer_nodes(1)
         hard_neg_features, hard_neg_indices = self._parse_sparse_nodes(sparse_nodes)

--- a/tzrec/datasets/sampler.py
+++ b/tzrec/datasets/sampler.py
@@ -360,13 +360,10 @@ class BaseSampler(metaclass=_meta_cls):
     ) -> Tuple[List[pa.Array], npt.NDArray]:
         """Parse sparse-neighbor sampler output.
 
-        Returns ``(features, indices)`` where ``indices`` has shape
-        ``(H, 2)`` and ``indices[:, 0]`` is the source-axis offset into
-        the array the caller passed to the sampler. When the caller
-        passes ``B`` row-ids, indices are in ``[0, B)``; when the
-        caller flattens to ``Q`` per-positive ids (e.g. via
-        ``build_sampler_input``), indices are in ``[0, Q)``. ``indices[:, 1]``
-        is the per-source neighbor offset.
+        `indices[:, 0]` indexes into the caller-supplied src array:
+        `[0, B)` for row-aligned callers, `[0, Q)` when the caller
+        flattens via `build_sampler_input`. `indices[:, 1]` is the
+        per-source neighbor offset.
         """
         features = []
         # pyre-ignore [16]
@@ -456,9 +453,8 @@ class NegativeSampler(BaseSampler):
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
 
-        `expand_factor` is computed from the actual input length so that
-        flattened multi-positive queries (Q values from B rows) are
-        supported with no padding to batch_size.
+        `expand_factor` is derived from the actual input length, so
+        flattened multi-positive queries flow through without padding.
 
         Args:
             input_data (dict): input data with item_id.
@@ -555,10 +551,8 @@ class NegativeSamplerV2(BaseSampler):
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
 
-        Caller is responsible for keeping (user_id, item_id) row-aligned;
-        for flattened multi-positive queries, `build_sampler_input` in
-        ``tzrec/datasets/utils.py`` expands user_id by per-row positive
-        count before calling here.
+        Caller keeps (user_id, item_id) row-aligned; `build_sampler_input`
+        expands user_id for flattened multi-positive queries.
 
         Args:
             input_data (dict): input data with user_id and item_id.
@@ -657,19 +651,17 @@ class HardNegativeSampler(BaseSampler):
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
 
-        ``hard_neg_indices[:, 0]`` indexes into the caller-supplied
-        ``input_data[user_id_field]`` array: if the caller passed ``B``
-        user ids, indices are in ``[0, B)``; if the caller flattened to
-        ``Q`` user ids (e.g. via ``build_sampler_input``), indices are
-        in ``[0, Q)``.
+        `hard_neg_indices[:, 0]` indexes into the caller-supplied
+        `input_data[user_id_field]`: `[0, B)` for row-aligned input,
+        `[0, Q)` when the caller flattens via `build_sampler_input`.
 
         Args:
             input_data (dict): input data with user_id and item_id.
 
         Returns:
             Negative sampled feature dict. First num_sample entries are
-            simple negatives; the remaining entries are hard negatives.
-            ``HARD_NEG_INDICES`` is included when any hard neg exists.
+            simple negatives; remaining entries are hard negatives.
+            `HARD_NEG_INDICES` is included when any hard neg exists.
         """
         src_ids = _pa_ids_to_npy(input_data[self._user_id_field])
         dst_ids = _pa_ids_to_npy(input_data[self._item_id_field])
@@ -775,19 +767,18 @@ class HardNegativeSamplerV2(BaseSampler):
     def get(self, input_data: Dict[str, pa.Array]) -> Dict[str, pa.Array]:
         """Sampling method.
 
-        Caller is responsible for keeping (user_id, item_id) row-aligned;
-        for flattened multi-positive queries, ``build_sampler_input`` in
-        ``tzrec/datasets/utils.py`` expands user_id by per-row positive
-        count before calling here. ``hard_neg_indices[:, 0]`` then
-        indexes into the caller-supplied ``input_data[user_id_field]``.
+        Caller keeps (user_id, item_id) row-aligned; `build_sampler_input`
+        expands user_id for flattened multi-positive queries.
+        `hard_neg_indices[:, 0]` indexes into the caller-supplied
+        `input_data[user_id_field]` (`[0, B)` or `[0, Q)` accordingly).
 
         Args:
             input_data (dict): input data with user_id and item_id.
 
         Returns:
             Negative sampled feature dict. First num_sample entries are
-            simple negatives; the remaining entries are hard negatives.
-            ``HARD_NEG_INDICES`` is included when any hard neg exists.
+            simple negatives; remaining entries are hard negatives.
+            `HARD_NEG_INDICES` is included when any hard neg exists.
         """
         src_ids = _pa_ids_to_npy(input_data[self._user_id_field])
         dst_ids = _pa_ids_to_npy(input_data[self._item_id_field])

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -585,29 +585,21 @@ def build_sampler_input(
 ) -> Dict[str, pa.Array]:
     """Shallow-copy input_data with item_id (and user_id) flattened for the sampler.
 
-    When `item_id_field` is declared as a sequence_id_feature (i.e. it has
-    an entry in `seq_field_delims`), per-row positives may arrive as either
-    a delimited string or a pyarrow list array. Both are normalized to a
-    list array, flattened to 1D, and `user_id_field` (if any) is expanded
-    by per-row positive count so V2 / HardNeg samplers receive aligned
-    (user_id, item_id) pairs.
-
-    The caller's `input_data` is not mutated -- downstream combine logic
-    keeps the original per-row positive grouping.
+    When `item_id_field` is a sequence_id_feature, per-row positives
+    (delimited string or list array) are flattened to 1D and
+    `user_id_field` (if any) is expanded by per-row positive count.
+    Scalar item_id or unconfigured seq_delim falls through unchanged.
+    The caller's `input_data` is not mutated.
 
     Args:
         input_data: per-row input column dict.
         item_id_field: sampler config's `item_id_field`, or None.
-        user_id_field: sampler config's `user_id_field`, or None
-            (NegativeSampler has none; V2 / HardNeg do).
-        seq_field_delims: input_name -> sequence_delim mapping for
-            sequence_id_features (populated by BaseDataset.__init__).
+        user_id_field: sampler config's `user_id_field`, or None.
+        seq_field_delims: input_name -> sequence_delim mapping.
 
     Returns:
-        A new dict (shallow copy of input_data) with `item_id_field`
-        flattened and `user_id_field` expanded when both apply. When
-        item_id is scalar (e.g. int64) or no seq_delim is configured,
-        returns a shallow copy of input_data with no transformation.
+        A new shallow-copy dict with item_id flattened and user_id
+        expanded when both apply.
     """
     sampler_input = dict(input_data)
     if item_id_field is None or item_id_field not in seq_field_delims:
@@ -643,68 +635,44 @@ def combine_negs_to_candidate_sequence(
         row i < B-1:  pos_i values only
         row B-1:      pos_{B-1} values + appended negs
 
-    All N sampled negatives sit in the last row's suffix. After
-    data_parser flattens the resulting JAGGED_SEQUENCE, downstream
-    consumers see the item embeddings laid out flat in the order
-    `[pos_0, ..., pos_{Q-1}, neg_0, ..., neg_{N-1}]` where
-    `Q = sum(K_i)`. ``pos_lengths`` counts only positives per row --
-    not the appended negs.
+    Output type matches input type: `list<T>` / `large_list<T>` pos
+    produces the same list type out (Arrow-native via
+    `ListArray.from_arrays`); delimited string pos produces string out.
 
-    The helper writes the negs verbatim into the suffix in the order
-    provided -- whether the caller distinguishes "simple" vs "hard"
-    negs is the caller's concern (the typical pattern is to use
-    `HARD_NEG_INDICES` from the sampler output to attribute hard negs
-    to specific queries downstream).
+    Simple-vs-hard neg distinction is invisible in the output layout;
+    callers use `HARD_NEG_INDICES` from the sampler to attribute hard
+    negs to queries downstream.
 
-    Output type matches input type:
-
-    - ``list<T>`` / ``large_list<T>`` pos -> ``list<T>`` / ``large_list<T>``
-      out. Arrow-native: builds the result via
-      ``ListArray.from_arrays(offsets, values)``, no Python row
-      materialization. Slice-safe via ``pc.list_flatten``.
-    - delimited string pos -> string out. Computes ``pos_lengths`` via
-      ``pc.count_substring(pos, seq_delim) + 1`` (with empty rows
-      treated as 0) -- no intermediate ``list<string>`` materialization,
-      no per-row positive split + rejoin. Original row strings are
-      preserved verbatim; only the last row gets ``seq_delim + negs``
-      appended.
-
-    String-path input convention: positive rows are canonical
-    delimiter-separated sequences (non-null, non-empty). The
-    ``count_substring + 1`` math is structurally identical to
-    ``len(split_pattern(pos, seq_delim))``.
+    String-path input convention: canonical delimiter-separated rows
+    (non-null, non-empty). `count_substring + 1` is structurally
+    identical to `len(split_pattern)` for those inputs.
 
     Args:
-        pos_data: per-row positives. Either a delimited string array
-            or a list array.
-        negs: sampled negatives. Flat array, or ``list<T>`` of
-            single-element lists (the sampler emits the latter when the
-            attr's field schema is ``pa.list_(...)`` -- normalized via
-            ``pc.list_flatten`` before appending).
+        pos_data: per-row positives, either delimited string or list array.
+        negs: sampled negatives; flat array or `list<T>` of 1-element
+            lists (flattened internally before appending).
         seq_delim: delimiter for the string path; ignored for the list
             path.
 
     Returns:
-        (combined: pa.Array (same structural type as pos_data, length B),
-         pos_lengths: int32 np.ndarray (length B), per-row K_i counting
-         positives only -- not including the appended negs.)
+        (combined: pa.Array (same type as pos_data, length B),
+         pos_lengths: int32 np.ndarray (length B), per-row positive
+         count only -- not including the appended negs.)
     """
-    # Normalize list-typed negs to flat scalar -- the sampler wraps
-    # each scalar in a 1-element list when the attr's field schema is
-    # list-typed (see _to_arrow_array in sampler.py:168).
+    # Sampler wraps each scalar in a 1-element list for list-typed attrs.
     if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
         negs = pc.list_flatten(negs)
     n_negs = len(negs)
 
     if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
-        # list path -- Arrow-native, no Python materialization.
+        # list path -- Arrow-native.
         pos_lengths = pc.list_value_length(pos_data).to_numpy().astype(np.int32)
         if len(pos_data) == 0 or n_negs == 0:
             return pos_data, pos_lengths
         inner_type = pos_data.type.value_type
-        new_values = pa.concat_arrays(
-            [pc.list_flatten(pos_data), negs.cast(inner_type, safe=False)]
-        )
+        if negs.type != inner_type:
+            negs = negs.cast(inner_type, safe=False)
+        new_values = pa.concat_arrays([pc.list_flatten(pos_data), negs])
         new_lengths = pos_lengths.copy()
         new_lengths[-1] += n_negs
         is_large = pa.types.is_large_list(pos_data.type)
@@ -716,9 +684,7 @@ def combine_negs_to_candidate_sequence(
         list_cls = pa.LargeListArray if is_large else pa.ListArray
         return list_cls.from_arrays(new_offsets, new_values), pos_lengths
     else:
-        # string path -- count_substring for pos_lengths (structurally
-        # equivalent to len(split_pattern)), modify only the last row in
-        # place. Assumes canonical input rows (non-null, non-empty).
+        # string path -- count_substring for pos_lengths, modify last row only.
         pos_str = pos_data.cast(pa.string())
         pos_lengths = (
             pc.add(pc.count_substring(pos_str, pattern=seq_delim), 1)

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -23,6 +23,7 @@ from torchrec.streamable import Pipelineable
 
 from tzrec.protos import data_pb2
 from tzrec.protos.data_pb2 import FieldType
+from tzrec.utils.logging_util import logger
 
 BASE_DATA_GROUP = "__BASE__"
 NEG_DATA_GROUP = "__NEG__"
@@ -667,7 +668,15 @@ def combine_negs_to_candidate_sequence(
     if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
         # list path -- Arrow-native.
         pos_lengths = pc.list_value_length(pos_data).to_numpy().astype(np.int32)
-        if len(pos_data) == 0 or n_negs == 0:
+        if len(pos_data) == 0:
+            if n_negs > 0:
+                logger.warning(
+                    "combine_negs_to_candidate_sequence: empty pos_data with "
+                    "%d negs; negs dropped.",
+                    n_negs,
+                )
+            return pos_data, pos_lengths
+        if n_negs == 0:
             return pos_data, pos_lengths
         inner_type = pos_data.type.value_type
         if negs.type != inner_type:
@@ -692,7 +701,15 @@ def combine_negs_to_candidate_sequence(
             .astype(np.int32)
         )
         rows = pos_str.to_pylist()
-        if len(rows) == 0 or n_negs == 0:
+        if len(rows) == 0:
+            if n_negs > 0:
+                logger.warning(
+                    "combine_negs_to_candidate_sequence: empty pos_data with "
+                    "%d negs; negs dropped.",
+                    n_negs,
+                )
+            return pa.array(rows, type=pa.string()), pos_lengths
+        if n_negs == 0:
             return pa.array(rows, type=pa.string()), pos_lengths
         negs_str = seq_delim.join(negs.cast(pa.string()).to_pylist())
         rows[-1] = rows[-1] + seq_delim + negs_str

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -504,6 +504,79 @@ class Batch(Pipelineable):
         return tensor_dict
 
 
+def expand_tdm_sample(
+    input_data: Dict[str, pa.Array],
+    pos_sampled: Dict[str, pa.Array],
+    neg_sampled: Dict[str, pa.Array],
+    data_config: data_pb2.DataConfig,
+) -> Dict[str, pa.Array]:
+    """Expand input data with sampled data for TDM.
+
+    Combine the sampled positive and negative samples with the item
+    features, then expand the user features based on the original
+    user-item relationships, and supplement the corresponding labels
+    according to the positive and negative samples. The sampled
+    outcomes for each item are contiguous in the sampler output.
+
+    Example::
+
+        user_fea: [1, 2], item_fea: [0.1, 0.2], labels: [1, 1],
+        pos_sample: [0.11, 0.12, 0.21, 0.22],
+        neg_sample: [-0.11, -0.12, -0.21, -0.22]
+
+        concat item_fea:
+            [0.1, 0.2, 0.11, 0.12, 0.21, 0.22, -0.11, -0.12, -0.21, -0.22]
+        duplicate user_fea preserving user-item relationship:
+            [1, 2, 1, 1, 2, 2, 1, 1, 2, 2]
+        expand label:
+            [1, 1, 1, 1, 1, 1, 0, 0, 0, 0]
+
+    Mutates ``input_data`` in place and returns it.
+    """
+    item_fea_names = pos_sampled.keys()
+    all_fea_names = input_data.keys()
+    label_fields = set(data_config.label_fields)
+    user_fea_names = all_fea_names - item_fea_names - label_fields
+
+    for item_fea_name in item_fea_names:
+        input_data[item_fea_name] = pa.concat_arrays(
+            [
+                input_data[item_fea_name],
+                pos_sampled[item_fea_name],
+                neg_sampled[item_fea_name],
+            ]
+        )
+
+    # In the sampling results, the sampled outcomes for each item are contiguous.
+    batch_size = len(input_data[list(label_fields)[0]])
+    num_pos_sampled = len(pos_sampled[list(item_fea_names)[0]])
+    num_neg_sampled = len(neg_sampled[list(item_fea_names)[0]])
+    user_pos_index = np.repeat(np.arange(batch_size), num_pos_sampled // batch_size)
+    user_neg_index = np.repeat(np.arange(batch_size), num_neg_sampled // batch_size)
+    for user_fea_name in user_fea_names:
+        user_fea = input_data[user_fea_name]
+        pos_expand_user_fea = user_fea.take(user_pos_index)
+        neg_expand_user_fea = user_fea.take(user_neg_index)
+        input_data[user_fea_name] = pa.concat_arrays(
+            [
+                input_data[user_fea_name],
+                pos_expand_user_fea,
+                neg_expand_user_fea,
+            ]
+        )
+
+    for label_field in label_fields:
+        input_data[label_field] = pa.concat_arrays(
+            [
+                input_data[label_field].cast(pa.int64()),
+                pa.array([1] * num_pos_sampled, type=pa.int64()),
+                pa.array([0] * num_neg_sampled, type=pa.int64()),
+            ]
+        )
+
+    return input_data
+
+
 def build_sampler_input(
     input_data: Dict[str, pa.Array],
     item_id_field: Optional[str],

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -647,7 +647,8 @@ def combine_negs_to_candidate_sequence(
     data_parser flattens the resulting JAGGED_SEQUENCE, downstream
     consumers see the item embeddings laid out flat in the order
     `[pos_0, ..., pos_{Q-1}, neg_0, ..., neg_{N-1}]` where
-    `Q = sum(K_i)`.
+    `Q = sum(K_i)`. ``pos_lengths`` counts only positives per row --
+    not the appended negs.
 
     The helper writes the negs verbatim into the suffix in the order
     provided -- whether the caller distinguishes "simple" vs "hard"
@@ -655,101 +656,81 @@ def combine_negs_to_candidate_sequence(
     `HARD_NEG_INDICES` from the sampler output to attribute hard negs
     to specific queries downstream).
 
-    Output type:
-      - `list<T>` / `large_list<T>` pos -> `list<T>` / `large_list<T>` out
-        (Arrow-native, no Python materialization).
-      - delimited string pos -> string out (split + Python join).
+    Output type matches input type:
+
+    - ``list<T>`` / ``large_list<T>`` pos -> ``list<T>`` / ``large_list<T>``
+      out. Arrow-native: builds the result via
+      ``ListArray.from_arrays(offsets, values)``, no Python row
+      materialization. Slice-safe via ``pc.list_flatten``.
+    - delimited string pos -> string out. Computes ``pos_lengths`` via
+      ``pc.count_substring(pos, seq_delim) + 1`` (with empty rows
+      treated as 0) -- no intermediate ``list<string>`` materialization,
+      no per-row positive split + rejoin. Original row strings are
+      preserved verbatim; only the last row gets ``seq_delim + negs``
+      appended.
+
+    String-path input convention: positive rows are canonical
+    delimiter-separated sequences (non-null, non-empty). The
+    ``count_substring + 1`` math is structurally identical to
+    ``len(split_pattern(pos, seq_delim))``.
 
     Args:
         pos_data: per-row positives. Either a delimited string array
-            (e.g. "1;2") or a list array (e.g. [[1, 2], [3]]).
-        negs: sampled negatives. Flat array, or `list<T>` of
+            or a list array.
+        negs: sampled negatives. Flat array, or ``list<T>`` of
             single-element lists (the sampler emits the latter when the
-            attr's field schema is `pa.list_(...)` -- normalized via
-            `pc.list_flatten` before appending).
-        seq_delim: delimiter for the string path; ignored for the list path.
+            attr's field schema is ``pa.list_(...)`` -- normalized via
+            ``pc.list_flatten`` before appending).
+        seq_delim: delimiter for the string path; ignored for the list
+            path.
 
     Returns:
         (combined: pa.Array (same structural type as pos_data, length B),
          pos_lengths: int32 np.ndarray (length B), per-row K_i counting
          positives only -- not including the appended negs.)
     """
-    if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
-        return _combine_list_path(pos_data, negs)
-    return _combine_string_path(pos_data, negs, seq_delim)
-
-
-def _combine_list_path(
-    pos_data: pa.Array,
-    negs: pa.Array,
-) -> Tuple[pa.Array, np.ndarray]:
-    """List-typed pos_data + negs -> list-typed output (Arrow-native).
-
-    Builds the result via `ListArray.from_arrays(offsets, values)` so
-    there's no Python-level row materialization. Slice-safe via
-    `pc.list_flatten` (which respects ListArray slicing).
-    """
-    pos_lengths = pc.list_value_length(pos_data).to_numpy().astype(np.int32)
-    if len(pos_data) == 0:
-        return pos_data, pos_lengths
-
-    # The sampler wraps each scalar in a 1-element list when the attr's
-    # field schema is list-typed (see _to_arrow_array in sampler.py:168);
-    # flatten back to scalar T.
+    # Normalize list-typed negs to flat scalar -- the sampler wraps
+    # each scalar in a 1-element list when the attr's field schema is
+    # list-typed (see _to_arrow_array in sampler.py:168).
     if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
         negs = pc.list_flatten(negs)
     n_negs = len(negs)
-    if n_negs == 0:
-        return pos_data, pos_lengths
 
-    inner_type = pos_data.type.value_type
-    negs_cast = negs.cast(inner_type, safe=False)
-    new_values = pa.concat_arrays([pc.list_flatten(pos_data), negs_cast])
-
-    new_lengths = pos_lengths.copy()
-    new_lengths[-1] += n_negs
-    is_large = pa.types.is_large_list(pos_data.type)
-    offset_dtype = np.int64 if is_large else np.int32
-    pa_offset_type = pa.int64() if is_large else pa.int32()
-    new_offsets = pa.array(
-        np.concatenate([[0], new_lengths.cumsum()]).astype(offset_dtype),
-        type=pa_offset_type,
-    )
-    list_cls = pa.LargeListArray if is_large else pa.ListArray
-    return list_cls.from_arrays(new_offsets, new_values), pos_lengths
-
-
-def _combine_string_path(
-    pos_data: pa.Array,
-    negs: pa.Array,
-    seq_delim: str,
-) -> Tuple[pa.Array, np.ndarray]:
-    """String-delimited pos_data + negs -> string-delimited output.
-
-    Splits pos_data into per-row lists via `pc.split_pattern`, joins
-    with `seq_delim` for output. Negs are flattened (if list<T>) and
-    appended to the last row's joined string.
-    """
-    pos_lists = pc.split_pattern(pos_data.cast(pa.string()), seq_delim)
-    pos_lengths = pc.list_value_length(pos_lists).to_numpy().astype(np.int32)
-    pos_flat = pc.list_flatten(pos_lists).cast(pa.string()).to_pylist()
-
-    if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
-        negs = pc.list_flatten(negs)
-    negs_str = seq_delim.join(negs.cast(pa.string()).to_pylist())
-
-    rows: List[str] = []
-    pos_offset = 0
-    last_idx = len(pos_lengths) - 1
-    for i, k_i in enumerate(pos_lengths):
-        pos_part = seq_delim.join(pos_flat[pos_offset : pos_offset + int(k_i)])
-        pos_offset += int(k_i)
-        if i == last_idx:
-            parts = [p for p in (pos_part, negs_str) if p]
-            rows.append(seq_delim.join(parts))
-        else:
-            rows.append(pos_part)
-    return pa.array(rows), pos_lengths
+    if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
+        # list path -- Arrow-native, no Python materialization.
+        pos_lengths = pc.list_value_length(pos_data).to_numpy().astype(np.int32)
+        if len(pos_data) == 0 or n_negs == 0:
+            return pos_data, pos_lengths
+        inner_type = pos_data.type.value_type
+        new_values = pa.concat_arrays(
+            [pc.list_flatten(pos_data), negs.cast(inner_type, safe=False)]
+        )
+        new_lengths = pos_lengths.copy()
+        new_lengths[-1] += n_negs
+        is_large = pa.types.is_large_list(pos_data.type)
+        offset_dtype = np.int64 if is_large else np.int32
+        new_offsets = pa.array(
+            np.concatenate([[0], new_lengths.cumsum()]).astype(offset_dtype),
+            type=pa.int64() if is_large else pa.int32(),
+        )
+        list_cls = pa.LargeListArray if is_large else pa.ListArray
+        return list_cls.from_arrays(new_offsets, new_values), pos_lengths
+    else:
+        # string path -- count_substring for pos_lengths (structurally
+        # equivalent to len(split_pattern)), modify only the last row in
+        # place. Assumes canonical input rows (non-null, non-empty).
+        pos_str = pos_data.cast(pa.string())
+        pos_lengths = (
+            pc.add(pc.count_substring(pos_str, pattern=seq_delim), 1)
+            .to_numpy()
+            .astype(np.int32)
+        )
+        rows = pos_str.to_pylist()
+        if len(rows) == 0 or n_negs == 0:
+            return pa.array(rows, type=pa.string()), pos_lengths
+        negs_str = seq_delim.join(negs.cast(pa.string()).to_pylist())
+        rows[-1] = rows[-1] + seq_delim + negs_str
+        return pa.array(rows, type=pa.string()), pos_lengths
 
 
 def calc_slice_position(

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -32,6 +32,7 @@ C_SAMPLE_MASK = "__SAMPLE_MASK__"
 C_NEG_SAMPLE_MASK = "__NEG_SAMPLE_MASK__"
 
 HARD_NEG_INDICES = "hard_neg_indices"
+CAND_POS_LENGTHS = "cand_pos_lengths"
 
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
@@ -503,129 +504,124 @@ class Batch(Pipelineable):
         return tensor_dict
 
 
-def process_hstu_seq_data(
+def build_sampler_input(
     input_data: Dict[str, pa.Array],
-    seq_attr: str,
-    seq_str_delim: str,
-) -> Tuple[pa.Array, pa.Array, pa.Array]:
-    """Process sequence data for HSTU match model.
+    item_id_field: Optional[str],
+    user_id_field: Optional[str],
+    seq_field_delims: Dict[str, str],
+) -> Dict[str, pa.Array]:
+    """Shallow-copy input_data with item_id (and user_id) flattened for the sampler.
+
+    When `item_id_field` is declared as a sequence_id_feature (i.e. it has
+    an entry in `seq_field_delims`), per-row positives may arrive as either
+    a delimited string or a pyarrow list array. Both are normalized to a
+    list array, flattened to 1D, and `user_id_field` (if any) is expanded
+    by per-row positive count so V2 / HardNeg samplers receive aligned
+    (user_id, item_id) pairs.
+
+    The caller's `input_data` is not mutated -- downstream combine logic
+    keeps the original per-row positive grouping.
 
     Args:
-        input_data: Dictionary containing input arrays
-        seq_attr: Name of the sequence attribute field
-        seq_str_delim: Delimiter used to separate sequence items
+        input_data: per-row input column dict.
+        item_id_field: sampler config's `item_id_field`, or None.
+        user_id_field: sampler config's `user_id_field`, or None
+            (NegativeSampler has none; V2 / HardNeg do).
+        seq_field_delims: input_name -> sequence_delim mapping for
+            sequence_id_features (populated by BaseDataset.__init__).
 
     Returns:
-        Tuple containing:
-        - input_data_k_split: pa.Array, Original sequence items
-        - input_data_k_split_slice: pa.Array, Target items for autoregressive training
-        - pre_seq_filter_reshaped_joined: pa.Array,
-        Training sequence for autoregressive training
+        A new dict (shallow copy of input_data) with `item_id_field`
+        flattened and `user_id_field` expanded when both apply. When
+        item_id is scalar (e.g. int64) or no seq_delim is configured,
+        returns a shallow copy of input_data with no transformation.
     """
-    # default sequence data is string
-    if pa.types.is_string(input_data[seq_attr].type):
-        input_data_k_split = pc.split_pattern(input_data[seq_attr], seq_str_delim)
-        # Get target items for training for autoregressive training
-        # Example: [1,2,3,4,5] -> [2,3,4,5]
-        input_data_k_split_slice = pc.list_flatten(
-            pc.list_slice(input_data_k_split, start=1)
-        )
+    sampler_input = dict(input_data)
+    if item_id_field is None or item_id_field not in seq_field_delims:
+        return sampler_input
 
-        # Directly extract the training sequence for autoregressive training
-        # Operation target example: [1,2,3,4,5] -> [1,2,3,4]
-        # (corresponding target: [2,3,4,5])
-        # As this can not be achieved by pyarrow.compute, and for loop is costly
-        # we need to do this using pa.ListArray.from_arrays using offsets
-        # 1. transfer to numpy and filter out the last item
-        pre_seq = pc.list_flatten(input_data_k_split).to_numpy(zero_copy_only=False)
-        # Mark last items of each seq with '-1'
-        pre_seq[input_data_k_split.offsets.to_numpy()[1:] - 1] = "-1"
-        # Filter out -1 marker elements
-        mask = pre_seq != "-1"
-        pre_seq_filter = pre_seq[mask]
-        # 2. create offsets for reshaping filtered sequence
-        # The offsets should be created extract the training sequence
-        # Example: if the original offsets are [0,2,5,9], after filter,
-        # for the offsets should be [0, 1, 3, 6]
-        # that is, [0] + [2-1, 5-2, 9-3]
-        pre_seq_filter_offsets = pa.array(
-            np.concatenate(
-                [
-                    np.array([0]),
-                    input_data_k_split.offsets[1:].to_numpy(zero_copy_only=False)
-                    - np.arange(
-                        1,
-                        len(
-                            input_data_k_split.offsets[1:].to_numpy(
-                                zero_copy_only=False
-                            )
-                        )
-                        + 1,
-                    ),
-                ]
-            )
-        )
-        pre_seq_filter_reshaped = pa.ListArray.from_arrays(
-            pre_seq_filter_offsets, pre_seq_filter
-        )
-        # Join filtered sequence with delimiter
-        pre_seq_filter_reshaped_joined = pc.binary_join(
-            pre_seq_filter_reshaped, seq_str_delim
-        )
+    seq_delim = seq_field_delims[item_id_field]
+    raw = input_data[item_id_field]
+    if pa.types.is_string(raw.type) or pa.types.is_large_string(raw.type):
+        pos_lists = pc.split_pattern(raw, seq_delim)
+    elif pa.types.is_list(raw.type) or pa.types.is_large_list(raw.type):
+        pos_lists = raw
+    else:
+        # Scalar (e.g. int64 single-positive for DSSM): pass through.
+        return sampler_input
 
-        return (
-            input_data_k_split,
-            input_data_k_split_slice,
-            pre_seq_filter_reshaped_joined,
-        )
+    sampler_input[item_id_field] = pc.list_flatten(pos_lists)
+
+    if user_id_field is not None and user_id_field in input_data:
+        counts = pc.list_value_length(pos_lists).to_numpy()
+        row_indices = pa.array(np.repeat(np.arange(len(counts)), counts))
+        sampler_input[user_id_field] = pc.take(input_data[user_id_field], row_indices)
+    return sampler_input
 
 
-def process_hstu_neg_sample(
-    input_data: Dict[str, pa.Array],
-    v: pa.Array,
-    neg_sample_num: int,
-    seq_str_delim: str,
-    seq_attr: str,
-) -> pa.Array:
-    """Process negative samples for HSTU match model.
+def combine_candidate_sequence_block(
+    pos_data: pa.Array,
+    negs: pa.Array,
+    seq_delim: str,
+) -> Tuple[pa.Array, np.ndarray]:
+    """Block-(B-1)-suffix combine of per-row positives + shared sampled negs.
+
+    Per-row layout:
+        row i < B-1:  pos_i_0;...;pos_i_{K_i-1}
+        row B-1:      pos_{B-1}_0;...;pos_{B-1}_{K-1};neg_0;...;neg_{N-1}
+
+    All N sampled negatives sit in the last row's suffix. After
+    data_parser flattens the resulting JAGGED_SEQUENCE, downstream
+    consumers see the item embeddings laid out flat in the order
+    `[pos_0, ..., pos_{Q-1}, neg_0, ..., neg_{N-1}]` where
+    `Q = sum(K_i)`.
+
+    The combine helper writes the negs verbatim into the suffix in the
+    order provided -- whether the caller distinguishes "simple" vs
+    "hard" negs is the caller's concern (the typical pattern is to use
+    `HARD_NEG_INDICES` from the sampler output to attribute hard negs
+    to specific queries downstream).
 
     Args:
-        input_data: Dict[str, pa.Array], Dictionary containing input arrays
-        v: pa.Array, negative samples.
-        neg_sample_num: int, number of negative samples.
-        seq_str_delim: str, delimiter for sequence string.
-        seq_attr: str, attribute name of sequence.
+        pos_data: per-row positives. Either a delimited string array
+            (e.g. "1;2") or a list array (e.g. [[1, 2], [3]]).
+        negs: 1D flat sampled negatives, OR a list<T> array of
+            single-element lists -- the sampler emits the latter when
+            the attr's field schema is `pa.list_(...)`. Either shape
+            is flattened to scalar elements before joining.
+        seq_delim: delimiter for joining items into a sequence string.
 
     Returns:
-        pa.Array: Processed negative samples
+        (combined: pa.Array of strings (length B),
+         pos_lengths: int32 np.ndarray (length B), per-row K_i)
     """
-    # The goal is to make neg samples concat to the training sequence
-    # Example:
-    # input_data[seq_attr] = ["1;2;3"]
-    # neg_sample_num = 2
-    # v = [4,5,6,7,8,9]
-    # then the output should be [[1,4,5], [2,6,7], [3,8,9]]
-    v_str = v.cast(pa.string())
-    filtered_v_offsets = pa.array(
-        np.concatenate(
-            [
-                np.array([0]),
-                np.arange(neg_sample_num, len(v_str) + 1, neg_sample_num),
-            ]
-        )
-    )
-    # Reshape v for each input_data[seq_attr]
-    # Example:[4,5,6,7,8,9] -> [[4,5], [6,7], [8,9]]
-    filtered_v_palist = pa.ListArray.from_arrays(filtered_v_offsets, v_str)
-    # Using string for join, as not found operation for ListArray achieving this
-    # Example: [[4,5], [6,7], [8,9]] -> ["4;5", "6;7", "8;9"]
-    sampled_joined = pc.binary_join(filtered_v_palist, seq_str_delim)
-    # Combine training sequence and target items
-    # Example: ["1;2;3"] + ["4;5", "6;7", "8;9"]
-    # -> ["1;4;5", "2;6;7", "3;8;9"]
-    return pc.binary_join_element_wise(
-        input_data[seq_attr], sampled_joined, seq_str_delim
-    )
+    if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
+        pos_lists = pos_data
+    else:
+        pos_lists = pc.split_pattern(pos_data.cast(pa.string()), seq_delim)
+
+    pos_lengths = pc.list_value_length(pos_lists).to_numpy().astype(np.int32)
+    pos_flat = pc.list_flatten(pos_lists).cast(pa.string()).to_pylist()
+
+    # Normalize negs to flat scalar pyarrow array. The sampler wraps each
+    # scalar in a 1-element list when the attr's field schema is
+    # list-typed (see _to_arrow_array in sampler.py:168).
+    if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
+        negs = pc.list_flatten(negs)
+    negs_str = seq_delim.join(negs.cast(pa.string()).to_pylist())
+
+    rows: List[str] = []
+    pos_offset = 0
+    last_idx = len(pos_lengths) - 1
+    for i, k_i in enumerate(pos_lengths):
+        pos_part = seq_delim.join(pos_flat[pos_offset : pos_offset + int(k_i)])
+        pos_offset += int(k_i)
+        if i == last_idx:
+            parts = [p for p in (pos_part, negs_str) if p]
+            rows.append(seq_delim.join(parts))
+        else:
+            rows.append(pos_part)
+    return pa.array(rows), pos_lengths
 
 
 def calc_slice_position(

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -632,16 +632,16 @@ def build_sampler_input(
     return sampler_input
 
 
-def combine_candidate_sequence_block(
+def combine_negs_to_candidate_sequence(
     pos_data: pa.Array,
     negs: pa.Array,
     seq_delim: str,
 ) -> Tuple[pa.Array, np.ndarray]:
-    """Block-(B-1)-suffix combine of per-row positives + shared sampled negs.
+    """Append `negs` to row B-1 of `pos_data`; output type matches input type.
 
-    Per-row layout:
-        row i < B-1:  pos_i_0;...;pos_i_{K_i-1}
-        row B-1:      pos_{B-1}_0;...;pos_{B-1}_{K-1};neg_0;...;neg_{N-1}
+    Per-row layout (block-(B-1)-suffix):
+        row i < B-1:  pos_i values only
+        row B-1:      pos_{B-1} values + appended negs
 
     All N sampled negatives sit in the last row's suffix. After
     data_parser flattens the resulting JAGGED_SEQUENCE, downstream
@@ -649,36 +649,91 @@ def combine_candidate_sequence_block(
     `[pos_0, ..., pos_{Q-1}, neg_0, ..., neg_{N-1}]` where
     `Q = sum(K_i)`.
 
-    The combine helper writes the negs verbatim into the suffix in the
-    order provided -- whether the caller distinguishes "simple" vs
-    "hard" negs is the caller's concern (the typical pattern is to use
+    The helper writes the negs verbatim into the suffix in the order
+    provided -- whether the caller distinguishes "simple" vs "hard"
+    negs is the caller's concern (the typical pattern is to use
     `HARD_NEG_INDICES` from the sampler output to attribute hard negs
     to specific queries downstream).
+
+    Output type:
+      - `list<T>` / `large_list<T>` pos -> `list<T>` / `large_list<T>` out
+        (Arrow-native, no Python materialization).
+      - delimited string pos -> string out (split + Python join).
 
     Args:
         pos_data: per-row positives. Either a delimited string array
             (e.g. "1;2") or a list array (e.g. [[1, 2], [3]]).
-        negs: 1D flat sampled negatives, OR a list<T> array of
-            single-element lists -- the sampler emits the latter when
-            the attr's field schema is `pa.list_(...)`. Either shape
-            is flattened to scalar elements before joining.
-        seq_delim: delimiter for joining items into a sequence string.
+        negs: sampled negatives. Flat array, or `list<T>` of
+            single-element lists (the sampler emits the latter when the
+            attr's field schema is `pa.list_(...)` -- normalized via
+            `pc.list_flatten` before appending).
+        seq_delim: delimiter for the string path; ignored for the list path.
 
     Returns:
-        (combined: pa.Array of strings (length B),
-         pos_lengths: int32 np.ndarray (length B), per-row K_i)
+        (combined: pa.Array (same structural type as pos_data, length B),
+         pos_lengths: int32 np.ndarray (length B), per-row K_i counting
+         positives only -- not including the appended negs.)
     """
     if pa.types.is_list(pos_data.type) or pa.types.is_large_list(pos_data.type):
-        pos_lists = pos_data
-    else:
-        pos_lists = pc.split_pattern(pos_data.cast(pa.string()), seq_delim)
+        return _combine_list_path(pos_data, negs)
+    return _combine_string_path(pos_data, negs, seq_delim)
 
+
+def _combine_list_path(
+    pos_data: pa.Array,
+    negs: pa.Array,
+) -> Tuple[pa.Array, np.ndarray]:
+    """List-typed pos_data + negs -> list-typed output (Arrow-native).
+
+    Builds the result via `ListArray.from_arrays(offsets, values)` so
+    there's no Python-level row materialization. Slice-safe via
+    `pc.list_flatten` (which respects ListArray slicing).
+    """
+    pos_lengths = pc.list_value_length(pos_data).to_numpy().astype(np.int32)
+    if len(pos_data) == 0:
+        return pos_data, pos_lengths
+
+    # The sampler wraps each scalar in a 1-element list when the attr's
+    # field schema is list-typed (see _to_arrow_array in sampler.py:168);
+    # flatten back to scalar T.
+    if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
+        negs = pc.list_flatten(negs)
+    n_negs = len(negs)
+    if n_negs == 0:
+        return pos_data, pos_lengths
+
+    inner_type = pos_data.type.value_type
+    negs_cast = negs.cast(inner_type, safe=False)
+    new_values = pa.concat_arrays([pc.list_flatten(pos_data), negs_cast])
+
+    new_lengths = pos_lengths.copy()
+    new_lengths[-1] += n_negs
+    is_large = pa.types.is_large_list(pos_data.type)
+    offset_dtype = np.int64 if is_large else np.int32
+    pa_offset_type = pa.int64() if is_large else pa.int32()
+    new_offsets = pa.array(
+        np.concatenate([[0], new_lengths.cumsum()]).astype(offset_dtype),
+        type=pa_offset_type,
+    )
+    list_cls = pa.LargeListArray if is_large else pa.ListArray
+    return list_cls.from_arrays(new_offsets, new_values), pos_lengths
+
+
+def _combine_string_path(
+    pos_data: pa.Array,
+    negs: pa.Array,
+    seq_delim: str,
+) -> Tuple[pa.Array, np.ndarray]:
+    """String-delimited pos_data + negs -> string-delimited output.
+
+    Splits pos_data into per-row lists via `pc.split_pattern`, joins
+    with `seq_delim` for output. Negs are flattened (if list<T>) and
+    appended to the last row's joined string.
+    """
+    pos_lists = pc.split_pattern(pos_data.cast(pa.string()), seq_delim)
     pos_lengths = pc.list_value_length(pos_lists).to_numpy().astype(np.int32)
     pos_flat = pc.list_flatten(pos_lists).cast(pa.string()).to_pylist()
 
-    # Normalize negs to flat scalar pyarrow array. The sampler wraps each
-    # scalar in a 1-element list when the attr's field schema is
-    # list-typed (see _to_arrow_array in sampler.py:168).
     if pa.types.is_list(negs.type) or pa.types.is_large_list(negs.type):
         negs = pc.list_flatten(negs)
     negs_str = seq_delim.join(negs.cast(pa.string()).to_pylist())

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -206,84 +206,101 @@ class DatasetUtilsTest(unittest.TestCase):
 
         self.assertEqual(total_rows, 400)  # All remaining rows accounted for
 
-    def test_build_sampler_input_string_item_id_no_user_id(self):
-        # NegativeSampler-style: no user_id_field; item_id is delimited string.
-        input_data = {
-            "item_id": pa.array(["1;2", "3"]),
-            "label": pa.array([1, 0]),
-        }
+    # Single parameterized test for build_sampler_input covering the
+    # three transform branches (string flatten + user_id expand, list
+    # flatten + user_id expand, scalar pass-through) plus two defensive
+    # pass-through cases. Every case uniformly verifies:
+    #   - output dict equals expected_output
+    #   - input_data is not mutated (shallow-copy contract)
+    #   - returned dict is a different object from input_data
+    @parameterized.expand(
+        [
+            # (name, input_data, item_id_field, user_id_field,
+            #  seq_field_delims, expected_output)
+            (
+                # NegativeSampler-style: no user_id_field; item_id is
+                # delimited string; gets flattened.
+                "string_item_id_no_user_id",
+                {"item_id": pa.array(["1;2", "3"]), "label": pa.array([1, 0])},
+                "item_id",
+                None,
+                {"item_id": ";"},
+                {"item_id": ["1", "2", "3"], "label": [1, 0]},
+            ),
+            (
+                # NegativeSamplerV2 / HardNeg style: item_id arrives as
+                # list<int64>; user_id is expanded by per-row pos count.
+                "list_item_id_expands_user_id",
+                {
+                    "item_id": pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
+                    "user_id": pa.array(["u0", "u1"]),
+                },
+                "item_id",
+                "user_id",
+                {"item_id": ";"},
+                {"item_id": [1, 2, 3], "user_id": ["u0", "u0", "u1"]},
+            ),
+            (
+                # DSSM-style: item_id is scalar int64. No flatten, no
+                # user_id expand.
+                "scalar_item_id_passthrough",
+                {
+                    "item_id": pa.array([1, 2, 3], type=pa.int64()),
+                    "user_id": pa.array(["u0", "u1", "u2"]),
+                },
+                "item_id",
+                "user_id",
+                {"item_id": ";"},
+                {"item_id": [1, 2, 3], "user_id": ["u0", "u1", "u2"]},
+            ),
+            (
+                # item_id_field has no seq_delim entry -> pass through.
+                "item_id_not_in_seq_field_delims",
+                {"item_id": pa.array(["1", "2"])},
+                "item_id",
+                None,
+                {},
+                {"item_id": ["1", "2"]},
+            ),
+            (
+                # Sampler config without item_id_field at all -> still
+                # shallow-copied, no transformation.
+                "no_item_id_field",
+                {"a": pa.array([1, 2])},
+                None,
+                None,
+                {},
+                {"a": [1, 2]},
+            ),
+        ]
+    )
+    def test_build_sampler_input(
+        self,
+        _name,
+        input_data,
+        item_id_field,
+        user_id_field,
+        seq_field_delims,
+        expected_output,
+    ):
+        # Snapshot input_data so we can verify the function didn't mutate it.
+        input_snapshot = {k: v.to_pylist() for k, v in input_data.items()}
+
         out = build_sampler_input(
             input_data,
-            item_id_field="item_id",
-            user_id_field=None,
-            seq_field_delims={"item_id": ";"},
+            item_id_field=item_id_field,
+            user_id_field=user_id_field,
+            seq_field_delims=seq_field_delims,
         )
-        # input_data is not mutated
-        self.assertEqual(input_data["item_id"].to_pylist(), ["1;2", "3"])
-        # output is flat
-        self.assertEqual(out["item_id"].to_pylist(), ["1", "2", "3"])
-        # other keys carry through
-        self.assertEqual(out["label"].to_pylist(), [1, 0])
-        # returned dict is a different object
+
+        # Contract 1: output equals expected (per-column pylist compare).
+        self.assertEqual({k: v.to_pylist() for k, v in out.items()}, expected_output)
+        # Contract 2: input_data is not mutated.
+        self.assertEqual(
+            {k: v.to_pylist() for k, v in input_data.items()}, input_snapshot
+        )
+        # Contract 3: returned dict is a different object (shallow copy).
         self.assertIsNot(out, input_data)
-
-    def test_build_sampler_input_list_item_id_expands_user_id(self):
-        # NegativeSamplerV2 / HardNeg style: item_id arrives as list<int64>;
-        # user_id is expanded by per-row positive count.
-        input_data = {
-            "item_id": pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
-            "user_id": pa.array(["u0", "u1"]),
-        }
-        out = build_sampler_input(
-            input_data,
-            item_id_field="item_id",
-            user_id_field="user_id",
-            seq_field_delims={"item_id": ";"},
-        )
-        self.assertEqual(out["item_id"].to_pylist(), [1, 2, 3])
-        self.assertEqual(out["user_id"].to_pylist(), ["u0", "u0", "u1"])
-        # original unchanged
-        self.assertEqual(input_data["item_id"].to_pylist(), [[1, 2], [3]])
-        self.assertEqual(input_data["user_id"].to_pylist(), ["u0", "u1"])
-
-    def test_build_sampler_input_scalar_item_id_passthrough(self):
-        # DSSM-style: item_id is scalar int64 (single positive per row).
-        # No flatten, no user_id expansion.
-        input_data = {
-            "item_id": pa.array([1, 2, 3], type=pa.int64()),
-            "user_id": pa.array(["u0", "u1", "u2"]),
-        }
-        out = build_sampler_input(
-            input_data,
-            item_id_field="item_id",
-            user_id_field="user_id",
-            seq_field_delims={"item_id": ";"},
-        )
-        self.assertEqual(out["item_id"].to_pylist(), [1, 2, 3])
-        self.assertEqual(out["user_id"].to_pylist(), ["u0", "u1", "u2"])
-
-    def test_build_sampler_input_item_id_not_in_seq_field_delims(self):
-        # If item_id_field has no seq_delim, treat as scalar and pass through.
-        input_data = {"item_id": pa.array(["1", "2"])}
-        out = build_sampler_input(
-            input_data,
-            item_id_field="item_id",
-            user_id_field=None,
-            seq_field_delims={},
-        )
-        self.assertEqual(out["item_id"].to_pylist(), ["1", "2"])
-
-    def test_build_sampler_input_no_item_id_field(self):
-        # Sampler config without item_id_field at all (defensive path).
-        input_data = {"a": pa.array([1, 2])}
-        out = build_sampler_input(
-            input_data,
-            item_id_field=None,
-            user_id_field=None,
-            seq_field_delims={},
-        )
-        self.assertIsNot(out, input_data)  # still shallow-copied
-        self.assertEqual(out["a"].to_pylist(), [1, 2])
 
     # Single parameterized test for combine_negs_to_candidate_sequence
     # exercising both the string path (output type preserved as string) and

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -379,6 +379,28 @@ class DatasetUtilsTest(unittest.TestCase):
                 [2, 1],
                 pa.large_list(pa.string()),
             ),
+            (
+                # Empty pos batch + non-empty negs -> empty output.
+                # negs are dropped because there's no last row to land
+                # them in (consistent with the list-path empty-batch
+                # behavior).
+                "empty_pos_batch_string",
+                pa.array([], type=pa.string()),
+                pa.array(["10"]),
+                [],
+                [],
+                pa.string(),
+            ),
+            (
+                # Single-row batch: row 0 is also row B-1, gets the
+                # negs.
+                "single_row_string",
+                pa.array(["1;2"]),
+                pa.array(["10"]),
+                ["1;2;10"],
+                [2],
+                pa.string(),
+            ),
         ]
     )
     def test_combine_negs_to_candidate_sequence(

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -14,16 +14,15 @@ import unittest
 
 import numpy as np
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from tzrec.datasets.utils import (
     _normalize_type_str,
+    build_sampler_input,
     calc_remaining_intervals,
     calc_slice_intervals,
     calc_slice_position,
+    combine_candidate_sequence_block,
     get_input_fields_proto,
-    process_hstu_neg_sample,
-    process_hstu_seq_data,
 )
 from tzrec.protos import data_pb2
 from tzrec.protos.data_pb2 import FieldType
@@ -206,80 +205,136 @@ class DatasetUtilsTest(unittest.TestCase):
 
         self.assertEqual(total_rows, 400)  # All remaining rows accounted for
 
-    def test_process_hstu_seq_data(self):
-        """Test processing sequence data for HSTU match model."""
-        input_data = {"sequence": pa.array(["1;2;3;4", "5;6;7;8", "9;10;11;12"])}
-
-        split, slice_result, training_seq = process_hstu_seq_data(
-            input_data=input_data, seq_attr="sequence", seq_str_delim=";"
+    def test_build_sampler_input_string_item_id_no_user_id(self):
+        # NegativeSampler-style: no user_id_field; item_id is delimited string.
+        input_data = {
+            "item_id": pa.array(["1;2", "3"]),
+            "label": pa.array([1, 0]),
+        }
+        out = build_sampler_input(
+            input_data,
+            item_id_field="item_id",
+            user_id_field=None,
+            seq_field_delims={"item_id": ";"},
         )
+        # input_data is not mutated
+        self.assertEqual(input_data["item_id"].to_pylist(), ["1;2", "3"])
+        # output is flat
+        self.assertEqual(out["item_id"].to_pylist(), ["1", "2", "3"])
+        # other keys carry through
+        self.assertEqual(out["label"].to_pylist(), [1, 0])
+        # returned dict is a different object
+        self.assertIsNot(out, input_data)
 
-        # Verify results
-        # Test original split sequences
-        expected_split_values = [
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-        ]
-        self.assertEqual(pc.list_flatten(split).to_pylist(), expected_split_values)
-
-        # Test sliced sequences (target items)
-        expected_slice_values = ["2", "3", "4", "6", "7", "8", "10", "11", "12"]
-        self.assertEqual(slice_result.to_pylist(), expected_slice_values)
-
-        # Test training sequences
-        expected_training_seqs = ["1;2;3", "5;6;7", "9;10;11"]
-        self.assertEqual(training_seq.to_pylist(), expected_training_seqs)
-
-    def test_process_hstu_neg_sample(self):
-        """Test processing negative samples for HSTU match model."""
-        input_data = {"sequence": pa.array(["1", "2", "3"])}
-        neg_samples = pa.array(["101", "102", "103", "104", "105", "106"])
-
-        result = process_hstu_neg_sample(
-            input_data=input_data,
-            v=neg_samples,
-            neg_sample_num=2,
-            seq_str_delim=";",
-            seq_attr="sequence",
+    def test_build_sampler_input_list_item_id_expands_user_id(self):
+        # NegativeSamplerV2 / HardNeg style: item_id arrives as list<int64>;
+        # user_id is expanded by per-row positive count.
+        input_data = {
+            "item_id": pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
+            "user_id": pa.array(["u0", "u1"]),
+        }
+        out = build_sampler_input(
+            input_data,
+            item_id_field="item_id",
+            user_id_field="user_id",
+            seq_field_delims={"item_id": ";"},
         )
+        self.assertEqual(out["item_id"].to_pylist(), [1, 2, 3])
+        self.assertEqual(out["user_id"].to_pylist(), ["u0", "u0", "u1"])
+        # original unchanged
+        self.assertEqual(input_data["item_id"].to_pylist(), [[1, 2], [3]])
+        self.assertEqual(input_data["user_id"].to_pylist(), ["u0", "u1"])
 
-        expected_results = [
-            "1;101;102",
-            "2;103;104",
-            "3;105;106",
-        ]
-        self.assertEqual(result.to_pylist(), expected_results)
-
-    def test_process_hstu_neg_sample_with_different_delim(self):
-        """Test negative sampling with different delimiter."""
-        input_data = {"sequence": pa.array(["1", "2", "3"])}
-
-        neg_samples = pa.array(["101", "102", "103", "104", "105", "106"])
-
-        result = process_hstu_neg_sample(
-            input_data=input_data,
-            v=neg_samples,
-            neg_sample_num=2,
-            seq_str_delim="|",
-            seq_attr="sequence",
+    def test_build_sampler_input_scalar_item_id_passthrough(self):
+        # DSSM-style: item_id is scalar int64 (single positive per row).
+        # No flatten, no user_id expansion.
+        input_data = {
+            "item_id": pa.array([1, 2, 3], type=pa.int64()),
+            "user_id": pa.array(["u0", "u1", "u2"]),
+        }
+        out = build_sampler_input(
+            input_data,
+            item_id_field="item_id",
+            user_id_field="user_id",
+            seq_field_delims={"item_id": ";"},
         )
+        self.assertEqual(out["item_id"].to_pylist(), [1, 2, 3])
+        self.assertEqual(out["user_id"].to_pylist(), ["u0", "u1", "u2"])
 
-        expected_results = [
-            "1|101|102",
-            "2|103|104",
-            "3|105|106",
-        ]
-        self.assertEqual(result.to_pylist(), expected_results)
+    def test_build_sampler_input_item_id_not_in_seq_field_delims(self):
+        # If item_id_field has no seq_delim, treat as scalar and pass through.
+        input_data = {"item_id": pa.array(["1", "2"])}
+        out = build_sampler_input(
+            input_data,
+            item_id_field="item_id",
+            user_id_field=None,
+            seq_field_delims={},
+        )
+        self.assertEqual(out["item_id"].to_pylist(), ["1", "2"])
+
+    def test_build_sampler_input_no_item_id_field(self):
+        # Sampler config without item_id_field at all (defensive path).
+        input_data = {"a": pa.array([1, 2])}
+        out = build_sampler_input(
+            input_data,
+            item_id_field=None,
+            user_id_field=None,
+            seq_field_delims={},
+        )
+        self.assertIsNot(out, input_data)  # still shallow-copied
+        self.assertEqual(out["a"].to_pylist(), [1, 2])
+
+    def test_combine_candidate_sequence_block_single_pos(self):
+        pos_data = pa.array(["1", "2", "3"])
+        negs = pa.array(["10", "20", "30"])
+        result, pos_lengths = combine_candidate_sequence_block(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        # Last row carries the shared neg pool; others hold pos only.
+        self.assertEqual(result.to_pylist(), ["1", "2", "3;10;20;30"])
+        np.testing.assert_array_equal(pos_lengths, np.array([1, 1, 1], dtype=np.int32))
+
+    def test_combine_candidate_sequence_block_multivalue_pos(self):
+        pos_data = pa.array(["1;2", "3;4;5"])  # 5 positives total
+        negs = pa.array(["10", "20"])
+        result, pos_lengths = combine_candidate_sequence_block(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        # row 0 (i<B-1): "1;2"
+        # row 1 (last):  "3;4;5;10;20"
+        self.assertEqual(result.to_pylist(), ["1;2", "3;4;5;10;20"])
+        np.testing.assert_array_equal(pos_lengths, np.array([2, 3], dtype=np.int32))
+
+    def test_combine_candidate_sequence_block_list_pos(self):
+        # pos_data may arrive already as a list array (e.g. from Parquet).
+        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
+        negs = pa.array(["10", "20"])
+        result, pos_lengths = combine_candidate_sequence_block(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertEqual(result.to_pylist(), ["1;2", "3;10;20"])
+        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
+
+    def test_combine_candidate_sequence_block_list_typed_negs(self):
+        # The sampler emits list<T> for negs when the attr's field schema is
+        # list-typed (_to_arrow_array wraps each scalar in a 1-element list).
+        # combine must flatten that shape.
+        pos_data = pa.array(["1", "2"])
+        negs = pa.array([[10], [20], [30]], type=pa.list_(pa.int64()))
+        result, pos_lengths = combine_candidate_sequence_block(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertEqual(result.to_pylist(), ["1", "2;10;20;30"])
+        np.testing.assert_array_equal(pos_lengths, np.array([1, 1], dtype=np.int32))
+
+    def test_combine_candidate_sequence_block_empty_negs(self):
+        pos_data = pa.array(["1", "2"])
+        negs = pa.array([], type=pa.string())
+        result, pos_lengths = combine_candidate_sequence_block(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertEqual(result.to_pylist(), ["1", "2"])
+        np.testing.assert_array_equal(pos_lengths, np.array([1, 1], dtype=np.int32))
 
     def test_normalize_type_str_basic_types(self):
         """Test normalizing basic types."""

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -14,6 +14,7 @@ import unittest
 
 import numpy as np
 import pyarrow as pa
+from parameterized import parameterized
 
 from tzrec.datasets.utils import (
     _normalize_type_str,
@@ -284,92 +285,102 @@ class DatasetUtilsTest(unittest.TestCase):
         self.assertIsNot(out, input_data)  # still shallow-copied
         self.assertEqual(out["a"].to_pylist(), [1, 2])
 
-    def test_combine_negs_to_candidate_sequence_single_pos(self):
-        pos_data = pa.array(["1", "2", "3"])
-        negs = pa.array(["10", "20", "30"])
+    # Single parameterized test for combine_negs_to_candidate_sequence
+    # exercising both the string path (output type preserved as string) and
+    # the list path (output type preserved as list<T> / large_list<T>).
+    @parameterized.expand(
+        [
+            # name, pos_data, negs, expected_rows, expected_pos_lengths, expected_type
+            (
+                "single_pos_string",
+                pa.array(["1", "2", "3"]),
+                pa.array(["10", "20", "30"]),
+                ["1", "2", "3;10;20;30"],
+                [1, 1, 1],
+                pa.string(),
+            ),
+            (
+                "multivalue_pos_string",
+                pa.array(["1;2", "3;4;5"]),
+                pa.array(["10", "20"]),
+                ["1;2", "3;4;5;10;20"],
+                [2, 3],
+                pa.string(),
+            ),
+            (
+                # String pos + list<T> negs: still uses string path; combine
+                # flattens the list-wrapped negs before joining.
+                "string_pos_list_negs",
+                pa.array(["1", "2"]),
+                pa.array([[10], [20], [30]], type=pa.list_(pa.int64())),
+                ["1", "2;10;20;30"],
+                [1, 1],
+                pa.string(),
+            ),
+            (
+                "empty_negs_string",
+                pa.array(["1", "2"]),
+                pa.array([], type=pa.string()),
+                ["1", "2"],
+                [1, 1],
+                pa.string(),
+            ),
+            (
+                # list<T> pos + flat T negs -> list<T> out (no string round-trip).
+                "list_pos_flat_negs",
+                pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
+                pa.array([10, 20], type=pa.int64()),
+                [[1, 2], [3, 10, 20]],
+                [2, 1],
+                pa.list_(pa.int64()),
+            ),
+            (
+                # The sampler emits list<T> of 1-element lists when the
+                # attr's field schema is list-typed (see _to_arrow_array in
+                # sampler.py:168); combine flattens that shape.
+                "list_pos_list_negs",
+                pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
+                pa.array([[10], [20], [30]], type=pa.list_(pa.int64())),
+                [[1, 2], [3, 10, 20, 30]],
+                [2, 1],
+                pa.list_(pa.int64()),
+            ),
+            (
+                "list_pos_empty_negs",
+                pa.array([[1, 2], [3]], type=pa.list_(pa.int64())),
+                pa.array([], type=pa.int64()),
+                [[1, 2], [3]],
+                [2, 1],
+                pa.list_(pa.int64()),
+            ),
+            (
+                # large_list<T> pos -> large_list<T> out.
+                "large_list_pos",
+                pa.array([["a", "b"], ["c"]], type=pa.large_list(pa.string())),
+                pa.array(["d", "e"], type=pa.string()),
+                [["a", "b"], ["c", "d", "e"]],
+                [2, 1],
+                pa.large_list(pa.string()),
+            ),
+        ]
+    )
+    def test_combine_negs_to_candidate_sequence(
+        self,
+        _name,
+        pos_data,
+        negs,
+        expected_rows,
+        expected_pos_lengths,
+        expected_type,
+    ):
         result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
-        # Last row carries the shared neg pool; others hold pos only.
-        self.assertEqual(result.to_pylist(), ["1", "2", "3;10;20;30"])
-        np.testing.assert_array_equal(pos_lengths, np.array([1, 1, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_multivalue_pos(self):
-        pos_data = pa.array(["1;2", "3;4;5"])  # 5 positives total
-        negs = pa.array(["10", "20"])
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
+        self.assertEqual(result.to_pylist(), expected_rows)
+        np.testing.assert_array_equal(
+            pos_lengths, np.array(expected_pos_lengths, dtype=np.int32)
         )
-        # row 0 (i<B-1): "1;2"
-        # row 1 (last):  "3;4;5;10;20"
-        self.assertEqual(result.to_pylist(), ["1;2", "3;4;5;10;20"])
-        np.testing.assert_array_equal(pos_lengths, np.array([2, 3], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_list_pos_returns_list(self):
-        # list pos_data -> list output (no string round-trip).
-        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
-        negs = pa.array([10, 20], type=pa.int64())
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
-        self.assertEqual(result.to_pylist(), [[1, 2], [3, 10, 20]])
-        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_list_pos_list_negs_returns_list(self):
-        # The sampler emits list<T> of 1-element lists when the attr's field
-        # schema is list-typed (see _to_arrow_array in sampler.py:168).
-        # combine flattens that shape before appending.
-        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
-        negs = pa.array([[10], [20], [30]], type=pa.list_(pa.int64()))
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
-        self.assertEqual(result.to_pylist(), [[1, 2], [3, 10, 20, 30]])
-        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_empty_negs_list_pos(self):
-        # list pos_data + empty negs -> list output, unchanged.
-        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
-        negs = pa.array([], type=pa.int64())
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
-        self.assertEqual(result.to_pylist(), [[1, 2], [3]])
-        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_large_list_pos(self):
-        # large_list<T> pos_data -> large_list<T> output.
-        pos_data = pa.array([["a", "b"], ["c"]], type=pa.large_list(pa.string()))
-        negs = pa.array(["d", "e"], type=pa.string())
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertTrue(result.type.equals(pa.large_list(pa.string())))
-        self.assertEqual(result.to_pylist(), [["a", "b"], ["c", "d", "e"]])
-        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_list_typed_negs(self):
-        # String pos_data + list-typed negs still uses the string path
-        # (output is string), and flattens negs before joining.
-        pos_data = pa.array(["1", "2"])
-        negs = pa.array([[10], [20], [30]], type=pa.list_(pa.int64()))
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertEqual(result.to_pylist(), ["1", "2;10;20;30"])
-        np.testing.assert_array_equal(pos_lengths, np.array([1, 1], dtype=np.int32))
-
-    def test_combine_negs_to_candidate_sequence_empty_negs(self):
-        pos_data = pa.array(["1", "2"])
-        negs = pa.array([], type=pa.string())
-        result, pos_lengths = combine_negs_to_candidate_sequence(
-            pos_data=pos_data, negs=negs, seq_delim=";"
-        )
-        self.assertEqual(result.to_pylist(), ["1", "2"])
-        np.testing.assert_array_equal(pos_lengths, np.array([1, 1], dtype=np.int32))
+        self.assertTrue(result.type.equals(expected_type))
 
     def test_normalize_type_str_basic_types(self):
         """Test normalizing basic types."""

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -206,13 +206,7 @@ class DatasetUtilsTest(unittest.TestCase):
 
         self.assertEqual(total_rows, 400)  # All remaining rows accounted for
 
-    # Single parameterized test for build_sampler_input covering the
-    # three transform branches (string flatten + user_id expand, list
-    # flatten + user_id expand, scalar pass-through) plus two defensive
-    # pass-through cases. Every case uniformly verifies:
-    #   - output dict equals expected_output
-    #   - input_data is not mutated (shallow-copy contract)
-    #   - returned dict is a different object from input_data
+    # Every case verifies output, input non-mutation, and dict identity.
     @parameterized.expand(
         [
             # (name, input_data, item_id_field, user_id_field,
@@ -302,9 +296,7 @@ class DatasetUtilsTest(unittest.TestCase):
         # Contract 3: returned dict is a different object (shallow copy).
         self.assertIsNot(out, input_data)
 
-    # Single parameterized test for combine_negs_to_candidate_sequence
-    # exercising both the string path (output type preserved as string) and
-    # the list path (output type preserved as list<T> / large_list<T>).
+    # Every case verifies output rows, pos_lengths, and output type.
     @parameterized.expand(
         [
             # name, pos_data, negs, expected_rows, expected_pos_lengths, expected_type

--- a/tzrec/datasets/utils_test.py
+++ b/tzrec/datasets/utils_test.py
@@ -21,7 +21,7 @@ from tzrec.datasets.utils import (
     calc_remaining_intervals,
     calc_slice_intervals,
     calc_slice_position,
-    combine_candidate_sequence_block,
+    combine_negs_to_candidate_sequence,
     get_input_fields_proto,
 )
 from tzrec.protos import data_pb2
@@ -284,20 +284,20 @@ class DatasetUtilsTest(unittest.TestCase):
         self.assertIsNot(out, input_data)  # still shallow-copied
         self.assertEqual(out["a"].to_pylist(), [1, 2])
 
-    def test_combine_candidate_sequence_block_single_pos(self):
+    def test_combine_negs_to_candidate_sequence_single_pos(self):
         pos_data = pa.array(["1", "2", "3"])
         negs = pa.array(["10", "20", "30"])
-        result, pos_lengths = combine_candidate_sequence_block(
+        result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
         # Last row carries the shared neg pool; others hold pos only.
         self.assertEqual(result.to_pylist(), ["1", "2", "3;10;20;30"])
         np.testing.assert_array_equal(pos_lengths, np.array([1, 1, 1], dtype=np.int32))
 
-    def test_combine_candidate_sequence_block_multivalue_pos(self):
+    def test_combine_negs_to_candidate_sequence_multivalue_pos(self):
         pos_data = pa.array(["1;2", "3;4;5"])  # 5 positives total
         negs = pa.array(["10", "20"])
-        result, pos_lengths = combine_candidate_sequence_block(
+        result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
         # row 0 (i<B-1): "1;2"
@@ -305,32 +305,67 @@ class DatasetUtilsTest(unittest.TestCase):
         self.assertEqual(result.to_pylist(), ["1;2", "3;4;5;10;20"])
         np.testing.assert_array_equal(pos_lengths, np.array([2, 3], dtype=np.int32))
 
-    def test_combine_candidate_sequence_block_list_pos(self):
-        # pos_data may arrive already as a list array (e.g. from Parquet).
+    def test_combine_negs_to_candidate_sequence_list_pos_returns_list(self):
+        # list pos_data -> list output (no string round-trip).
         pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
-        negs = pa.array(["10", "20"])
-        result, pos_lengths = combine_candidate_sequence_block(
+        negs = pa.array([10, 20], type=pa.int64())
+        result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
-        self.assertEqual(result.to_pylist(), ["1;2", "3;10;20"])
+        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
+        self.assertEqual(result.to_pylist(), [[1, 2], [3, 10, 20]])
         np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
 
-    def test_combine_candidate_sequence_block_list_typed_negs(self):
-        # The sampler emits list<T> for negs when the attr's field schema is
-        # list-typed (_to_arrow_array wraps each scalar in a 1-element list).
-        # combine must flatten that shape.
+    def test_combine_negs_to_candidate_sequence_list_pos_list_negs_returns_list(self):
+        # The sampler emits list<T> of 1-element lists when the attr's field
+        # schema is list-typed (see _to_arrow_array in sampler.py:168).
+        # combine flattens that shape before appending.
+        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
+        negs = pa.array([[10], [20], [30]], type=pa.list_(pa.int64()))
+        result, pos_lengths = combine_negs_to_candidate_sequence(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
+        self.assertEqual(result.to_pylist(), [[1, 2], [3, 10, 20, 30]])
+        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
+
+    def test_combine_negs_to_candidate_sequence_empty_negs_list_pos(self):
+        # list pos_data + empty negs -> list output, unchanged.
+        pos_data = pa.array([[1, 2], [3]], type=pa.list_(pa.int64()))
+        negs = pa.array([], type=pa.int64())
+        result, pos_lengths = combine_negs_to_candidate_sequence(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertTrue(result.type.equals(pa.list_(pa.int64())))
+        self.assertEqual(result.to_pylist(), [[1, 2], [3]])
+        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
+
+    def test_combine_negs_to_candidate_sequence_large_list_pos(self):
+        # large_list<T> pos_data -> large_list<T> output.
+        pos_data = pa.array([["a", "b"], ["c"]], type=pa.large_list(pa.string()))
+        negs = pa.array(["d", "e"], type=pa.string())
+        result, pos_lengths = combine_negs_to_candidate_sequence(
+            pos_data=pos_data, negs=negs, seq_delim=";"
+        )
+        self.assertTrue(result.type.equals(pa.large_list(pa.string())))
+        self.assertEqual(result.to_pylist(), [["a", "b"], ["c", "d", "e"]])
+        np.testing.assert_array_equal(pos_lengths, np.array([2, 1], dtype=np.int32))
+
+    def test_combine_negs_to_candidate_sequence_list_typed_negs(self):
+        # String pos_data + list-typed negs still uses the string path
+        # (output is string), and flattens negs before joining.
         pos_data = pa.array(["1", "2"])
         negs = pa.array([[10], [20], [30]], type=pa.list_(pa.int64()))
-        result, pos_lengths = combine_candidate_sequence_block(
+        result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
         self.assertEqual(result.to_pylist(), ["1", "2;10;20;30"])
         np.testing.assert_array_equal(pos_lengths, np.array([1, 1], dtype=np.int32))
 
-    def test_combine_candidate_sequence_block_empty_negs(self):
+    def test_combine_negs_to_candidate_sequence_empty_negs(self):
         pos_data = pa.array(["1", "2"])
         negs = pa.array([], type=pa.string())
-        result, pos_lengths = combine_candidate_sequence_block(
+        result, pos_lengths = combine_negs_to_candidate_sequence(
             pos_data=pos_data, negs=negs, seq_delim=";"
         )
         self.assertEqual(result.to_pylist(), ["1", "2"])

--- a/tzrec/protos/data.proto
+++ b/tzrec/protos/data.proto
@@ -132,13 +132,6 @@ message DataConfig {
     // fg run mode.
     optional FgMode fg_mode = 20 [default = FG_NONE];
 
-    // Field 21 (enable_hstu) was removed when the legacy HSTU dataset-side
-    // preprocessing (process_hstu_seq_data / process_hstu_neg_sample) was
-    // dropped in favor of the modern build_sampler_input flow. Reserved to
-    // prevent silent reuse.
-    reserved 21;
-    reserved "enable_hstu";
-
     // whether to shuffle data
     optional bool shuffle = 22 [default = false];
 

--- a/tzrec/protos/data.proto
+++ b/tzrec/protos/data.proto
@@ -132,8 +132,12 @@ message DataConfig {
     // fg run mode.
     optional FgMode fg_mode = 20 [default = FG_NONE];
 
-    // hstu enable
-    optional bool enable_hstu = 21 [default = false];
+    // Field 21 (enable_hstu) was removed when the legacy HSTU dataset-side
+    // preprocessing (process_hstu_seq_data / process_hstu_neg_sample) was
+    // dropped in favor of the modern build_sampler_input flow. Reserved to
+    // prevent silent reuse.
+    reserved 21;
+    reserved "enable_hstu";
 
     // whether to shuffle data
     optional bool shuffle = 22 [default = false];

--- a/tzrec/tests/match_integration_test.py
+++ b/tzrec/tests/match_integration_test.py
@@ -440,7 +440,6 @@ class MatchIntegrationTest(unittest.TestCase):
             self.test_dir,
             user_id="user_id",
             item_id="item_id",
-            is_hstu=True,
         )
         if self.success:
             self.success = utils.test_eval(

--- a/tzrec/tests/utils.py
+++ b/tzrec/tests/utils.py
@@ -128,36 +128,6 @@ class IdMockInput(MockInput):
         return pa.array(data)
 
 
-class HSTUIdMockInput(MockInput):
-    """Mock sparse id input data class."""
-
-    def __init__(
-        self,
-        name: str,
-        is_multi: bool = False,
-        num_ids: Optional[int] = None,
-        vocab_list: Optional[List[str]] = None,
-        multival_sep: str = chr(3),
-    ) -> None:
-        super().__init__(name)
-        self.is_multi = is_multi
-        self.num_ids = num_ids
-        self.vocab_list = vocab_list
-        self.multival_sep = multival_sep
-
-    def create_data(self, num_rows: int, has_null: bool = True) -> pa.Array:
-        """Create mock data."""
-        # string
-        # num_multi_rows = random.randint(num_rows // 3, 2 * num_rows // 3)
-        num_multi_id = 3
-        data_multi = _create_random_id_data(
-            (num_rows, num_multi_id), self.num_ids, self.vocab_list
-        ).astype(str)
-        data_multi = list(map(lambda x: self.multival_sep.join(x), data_multi))
-        random.shuffle(data_multi)
-        return pa.array(data_multi)
-
-
 class SeqIdMockInput(MockInput):
     """Mock sparse id sequence input data class."""
 
@@ -694,7 +664,6 @@ def build_mock_input_with_fg(
     features: List[BaseFeature],
     user_id: str = "",
     item_id: str = "",
-    is_hstu: bool = False,
 ) -> Dict[str, MockInput]:
     """Build mock input instance list with fg from features."""
     inputs = defaultdict(dict)
@@ -818,23 +787,14 @@ def build_mock_input_with_fg(
                         if isinstance(inputs[side][sub_name], IdMockInput):
                             inputs[side][sub_name].is_multi = False
                 else:
-                    if is_hstu:
-                        # hstu require number of sequence item is over 2
-                        inputs[side][input_name] = HSTUIdMockInput(
-                            input_name,
-                            is_multi=True,
-                            num_ids=feature.num_embeddings,
-                            multival_sep=feature.sequence_delim,
-                        )
-                    else:
-                        inputs[side][input_name] = IdMockInput(
-                            input_name,
-                            is_multi=True,
-                            num_ids=10
-                            if isinstance(feature, CustomFeature)
-                            else feature.num_embeddings,
-                            multival_sep=feature.sequence_delim,
-                        )
+                    inputs[side][input_name] = IdMockInput(
+                        input_name,
+                        is_multi=True,
+                        num_ids=10
+                        if isinstance(feature, CustomFeature)
+                        else feature.num_embeddings,
+                        multival_sep=feature.sequence_delim,
+                    )
     return inputs["user"], inputs["item"]
 
 
@@ -844,7 +804,6 @@ def load_config_for_test(
     user_id: str = "",
     item_id: str = "",
     cate_id: str = "",
-    is_hstu: bool = False,
     num_rows: Optional[int] = None,
 ) -> EasyRecConfig:
     """Modify pipeline config for integration tests."""
@@ -881,9 +840,7 @@ def load_config_for_test(
             num_parts=num_parts,
         )
     else:
-        user_inputs, item_inputs = build_mock_input_with_fg(
-            features, user_id, item_id, is_hstu
-        )
+        user_inputs, item_inputs = build_mock_input_with_fg(features, user_id, item_id)
         _, item_t = create_mock_data(
             os.path.join(test_dir, "item_data"),
             item_inputs,
@@ -977,22 +934,17 @@ def load_config_for_test(
                 os.path.join(test_dir, "item_gl"),
                 item_inputs,
                 item_id,
-                # hstu only uses item_id as negative sample, \
-                # as sampler_config.attr_fields is sequence
-                neg_fields=[item_id] if is_hstu else list(sampler_config.attr_fields),
+                neg_fields=list(sampler_config.attr_fields),
                 attr_delimiter=sampler_config.attr_delimiter,
                 num_rows=data_config.batch_size * num_parts * 4,
             )
-            # assert sampler_type == "negative_sampler", (
-            #     "now only negative_sampler supported."
-            # )
             sampler_config.input_path = item_gl_path
         elif sampler_type == "hard_negative_sampler":
             item_gl_path = create_mock_item_gl_data(
                 os.path.join(test_dir, "item_gl"),
                 item_inputs,
                 item_id,
-                neg_fields=[item_id] if is_hstu else list(sampler_config.attr_fields),
+                neg_fields=list(sampler_config.attr_fields),
                 attr_delimiter=sampler_config.attr_delimiter,
                 num_rows=data_config.batch_size * num_parts * 4,
             )
@@ -1032,7 +984,6 @@ def test_train_eval(
     user_id: str = "",
     item_id: str = "",
     cate_id: str = "",
-    is_hstu: bool = False,
     env_str: str = "",
     num_rows: Optional[int] = None,
 ) -> bool:
@@ -1043,7 +994,6 @@ def test_train_eval(
         user_id,
         item_id,
         cate_id,
-        is_hstu,
         num_rows=num_rows,
     )
 

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"


### PR DESCRIPTION
## Summary

Refactor the `BaseSampler` family and `BaseDataset._build_batch` sampler section to support flattened multi-positive queries cleanly, add two reusable `pa.Array` utilities (`build_sampler_input`, `combine_negs_to_candidate_sequence`), relocate `expand_tdm_sample` to live alongside them, and clean up the now-dead legacy `enable_hstu` data-side path. The HSTUMatch model rewrite that consumes these new APIs lands separately in #462.

Peeled off from PR #462 to keep that PR narrowly scoped to the HSTUMatch model rewrite.

## Changes

### Sampler — dynamic `expand_factor` (`tzrec/datasets/sampler.py`)

All four samplers (`NegativeSampler`, `NegativeSamplerV2`, `HardNegativeSampler`, `HardNegativeSamplerV2`) now compute `expand_factor = max(1, ceil(num_sample / num_pos))` at `get()` time from the actual input length, replacing the static `expand_factor` baked at `init()` time. Per-`expand_factor` sampler instances are cached. The `np.pad(ids, batch_size - len(ids), "edge")` workaround is removed — variable-length inputs (e.g. flattened multi-positive queries) flow through cleanly. The hard-neg neighbor sampler is still created at `init()` (no `expand_factor` — fixed `num_hard_sample`).

Docstring on `_parse_sparse_nodes` and `HardNegativeSampler[V2].get` clarifies that `hard_neg_indices[:, 0]` indexes into the caller-supplied flat `src_ids`: callers that pass `B` row ids see `[0, B)`; callers that flatten to `Q` per-positive ids see `[0, Q)`.

### Dataset — `_build_batch` refactor (`tzrec/datasets/dataset.py`)

Split the inlined ~110-line `if self._sampler is not None` block into three private orchestrators on `BaseDataset`:

- `_apply_negative_sampler` — for `NegativeSampler` / `V2` / `HardNeg` / `HardNegV2`. Calls `build_sampler_input` (pure shallow-copy transform), invokes the sampler, pops `HARD_NEG_INDICES`, merges back into `input_data`, plumbs `CAND_POS_LENGTHS`, and appends `C_NEG_SAMPLE_MASK` inline.
- `_apply_tdm_sampler` — wraps `expand_tdm_sample` + the TDM-specific `C_SAMPLE_MASK` rebuild.
- `_merge_sampled_features` — per-key route (new key / `seq_delim` block-suffix combine / `pa.concat_arrays`). Picks `pos_lengths` source from `self._sampler_item_id_field` with first-seen fallback when `item_id_field` is not in the sampler's `attr_fields`. Warns on conflicting `sequence_delim` for the same `input_name`.

The mutate-then-restore antipattern (`multi_pos_lists` / `saved_user_ids` shadow vars) is eliminated: `build_sampler_input` returns a shallow-copy `sampler_input` so the caller's `input_data` keeps its per-row positive grouping throughout.

Added `self._sampler_item_id_field`, `self._sampler_user_id_field`, `self._seq_field_delims` in `BaseDataset.__init__` to drive the new flow.

### `tzrec/datasets/utils.py` — new / relocated helpers

- `build_sampler_input(input_data, item_id_field, user_id_field, seq_field_delims) -> Dict[str, pa.Array]` (pure, returns shallow copy). Flattens `item_id` from delimited string OR list array to 1D for the sampler; expands `user_id` for `V2` / `HardNeg` samplers when applicable; passes scalar `item_id` through unchanged.
- `combine_negs_to_candidate_sequence(pos_data, negs, seq_delim) -> (combined, pos_lengths)`. Block-(B-1)-suffix combine: per-row positives in rows 0..B-2; row B-1 holds positives + appended negs. **Type-preserving**: `list_` / `large_list_` in → same type out via Arrow-native `pa.ListArray.from_arrays` (no `to_pylist()`, no Python join, no string round-trip); string in → string out. Logs a warning if empty `pos_data` is paired with non-empty negs (otherwise the negs would be dropped silently).
- `expand_tdm_sample` — relocated from `dataset.py` (dropped the leading underscore). All stateless `pa.Array → pa.Array` helpers used by `BaseDataset._build_batch` now live together in `utils.py`.
- `CAND_POS_LENGTHS = "cand_pos_lengths"` constant.

### `tzrec/datasets/data_parser.py` — plumb `CAND_POS_LENGTHS`

- `parse()`: copies `CAND_POS_LENGTHS` via `_to_tensor`; tightens the neighboring `HARD_NEG_INDICES` path to use `pc.list_flatten` + `torch.from_numpy` instead of `.tolist()` + `torch.tensor`.
- `to_batch()`: copies `CAND_POS_LENGTHS` into `Batch.additional_infos`, gated by `self.sampler_type is not None` (mirrors the existing `HARD_NEG_INDICES` pattern). The gate is required so `torch.fx.symbolic_trace` (used by `ENABLE_AOT=2` unified AOTI export) doesn't bake `cand_pos_lengths` into the graph when no sampler is configured — otherwise sampler-less configs (e.g. `dlrm_hstu_kuairand_1k`) fail at export with `KeyError: 'cand_pos_lengths'`.

### Legacy `enable_hstu` cleanup

- `tzrec/protos/data.proto`: removed `optional bool enable_hstu = 21`.
- `tzrec/datasets/utils.py`: removed `process_hstu_seq_data` and `process_hstu_neg_sample`.
- `tzrec/datasets/utils_test.py`: removed the 3 corresponding tests.
- `tzrec/datasets/dataset.py`: removed `self._enable_hstu`, the `elif self._enable_hstu:` branch, and the `process_hstu_*` imports.
- `tzrec/tests/utils.py`: removed `is_hstu` parameter plumbing and `HSTUIdMockInput`.
- `tzrec/tests/match_integration_test.py`: dropped the `is_hstu=True` kwarg from the already-skipped HSTU test.

The master `HSTUMatch` model class is left intact but unusable at runtime (its data flow disappears); its test stays `@unittest.skip("skip hstu match test")` so CI is unaffected. PR #462 unskips it alongside the model rewrite.

### Version bump

`tzrec/version.py`: 1.2.5 → 1.2.6.

## Test plan

Run in conda env with `grpcio-tools<1.63.0` (keeps protobuf 4.x to match the codebase's `including_default_value_fields` API). Run `bash scripts/gen_proto.sh` first.

- [x] `python -m unittest tzrec.datasets.utils_test` — 41 cases, incl. parameterized tables for `build_sampler_input` (5 cases) and `combine_negs_to_candidate_sequence` (10 cases). Each case uniformly checks output rows + `pos_lengths` + output type + input-not-mutated.
- [x] `python -m unittest tzrec.datasets.dataset_test` — 20 cases, incl. new e2e tests for `NegativeSampler` (`test_dataset_with_sampler_list_item_id`) and `HardNegativeSampler` (`test_dataset_with_hard_negative_sampler_list_item_id`), parameterized over `[Mode.TRAIN, Mode.EVAL]`. The HardNeg test asserts `set(hard_neg_indices[:, 0]) == {0..Q-1}` to pin the post-flatten `[0, Q)` contract.
- [x] `python -m unittest tzrec.datasets.data_parser_test` — no regression.
- [x] `python -m unittest tzrec.datasets.sampler_test` — no regression.
- [x] `python -m unittest tzrec.tests.match_integration_test.MatchIntegrationTest.test_dssm_nofg_train_eval_export` — no regression.
- [x] `python -m unittest tzrec.tests.match_integration_test.MatchIntegrationTest.test_dssm_hard_negative_with_fg_train_eval_export` — train/eval/export/predict all succeed.
- [x] `pre-commit run` clean.

The HSTU integration test (`test_hstu_with_fg_train_eval_export`) stays `@unittest.skip("skip hstu match test")` (no behavior change). PR #462 unskips it after rewriting the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)