### PR TITLE
[refactor] MatchTowerWoEG accepts feature_groups (plural); DSSMTower takes EmbeddingGroup

### DIFF
--- a/tzrec/models/dssm_v2.py
+++ b/tzrec/models/dssm_v2.py
@@ -35,9 +35,12 @@ class DSSMTower(MatchTowerWoEG):
         output_dim (int): user/item output embedding dimension.
         similarity (Similarity): when use COSINE similarity,
             will norm the output embedding.
-        feature_group (FeatureGroupConfig): feature group config.
-        feature_group_dims (list): feature dimension for each feature.
+        feature_groups (list): feature group configs the tower consumes.
         features (list): list of features.
+        embedding_group (EmbeddingGroup): shared embedding group used to
+            resolve per-feature dims at construction time (not stored).
+        model_config (ModelConfig): full model config; used to opt into
+            variational dropout when the model declares one.
     """
 
     def __init__(
@@ -45,18 +48,20 @@ class DSSMTower(MatchTowerWoEG):
         tower_config: tower_pb2.Tower,
         output_dim: int,
         similarity: simi_pb2.Similarity,
-        feature_group: model_pb2.FeatureGroupConfig,
-        feature_dims: Dict[str, int],
+        feature_groups: List[model_pb2.FeatureGroupConfig],
         features: List[BaseFeature],
+        embedding_group: EmbeddingGroup,
         model_config: model_pb2.ModelConfig,
     ) -> None:
-        super().__init__(tower_config, output_dim, similarity, feature_group, features)
+        super().__init__(tower_config, output_dim, similarity, feature_groups, features)
         self._model_config = model_config
-        self._feature_dims = feature_dims
-        self.group_variational_dropouts = None
-        self.group_variational_dropout_loss = {}
+        self._feature_dims: Dict[str, int] = embedding_group.group_feature_dims(
+            tower_config.input
+        )
+        self.group_variational_dropouts: Optional[nn.ModuleDict] = None
+        self.group_variational_dropout_loss: Dict[str, torch.Tensor] = {}
         self.init_variational_dropouts()
-        tower_feature_in = sum(feature_dims.values())
+        tower_feature_in = sum(self._feature_dims.values())
         self.mlp = MLP(tower_feature_in, **config_to_kwargs(tower_config.mlp))
         if self._output_dim > 0:
             self.output = nn.Linear(self.mlp.output_dim(), output_dim)
@@ -69,16 +74,16 @@ class DSSMTower(MatchTowerWoEG):
             variational_dropout_config_dict = config_to_kwargs(
                 variational_dropout_config
             )
-            if self._feature_group.group_type != model_pb2.SEQUENCE:
+            if self._feature_groups[0].group_type != model_pb2.SEQUENCE:
                 if len(self._feature_dims) > 1:
                     variational_dropout = VariationalDropout(
                         self._feature_dims,
-                        self._feature_group.group_name,
+                        self._feature_groups[0].group_name,
                         **variational_dropout_config_dict,
                     )
-                    self.group_variational_dropouts[self._feature_group.group_name] = (
-                        variational_dropout
-                    )
+                    self.group_variational_dropouts[
+                        self._feature_groups[0].group_name
+                    ] = variational_dropout
 
     def run_variational_dropout(self, feature: torch.Tensor) -> torch.Tensor:
         """Run the variational dropout."""
@@ -92,15 +97,17 @@ class DSSMTower(MatchTowerWoEG):
             )
         return feature
 
-    def forward(self, feature: torch.Tensor) -> torch.Tensor:
+    def forward(self, grouped_features: Dict[str, torch.Tensor]) -> torch.Tensor:
         """Forward the tower.
 
         Args:
-            feature (torch.Tensor): input batch data.
+            grouped_features: dict of grouped feature tensors; the tower
+                extracts its own group via `self._group_name`.
 
         Return:
-            embedding (dict): tower output embedding.
+            embedding tensor.
         """
+        feature = grouped_features[self._group_name]
         feature = self.run_variational_dropout(feature)
         output = self.mlp(feature)
         if self._output_dim > 0:
@@ -144,11 +151,9 @@ class DSSMV2(MatchModel):
             self._model_config.user_tower,
             self._model_config.output_dim,
             self._model_config.similarity,
-            user_group,
-            self.embedding_group.group_feature_dims(
-                self._model_config.user_tower.input
-            ),
+            [user_group],
             user_features,
+            self.embedding_group,
             model_config,
         )
 
@@ -156,11 +161,9 @@ class DSSMV2(MatchModel):
             self._model_config.item_tower,
             self._model_config.output_dim,
             self._model_config.similarity,
-            item_group,
-            self.embedding_group.group_feature_dims(
-                self._model_config.item_tower.input
-            ),
+            [item_group],
             item_features,
+            self.embedding_group,
             model_config,
         )
 
@@ -174,12 +177,14 @@ class DSSMV2(MatchModel):
             predictions (dict): a dict of predicted result.
         """
         grouped_features = self.embedding_group(batch)
-
         batch_size = batch.labels[self._labels[0]].size(0)
-        user_feat = grouped_features[self._model_config.user_tower.input][:batch_size]
-        item_feat = grouped_features[self._model_config.item_tower.input]
-        user_tower_emb = self.user_tower(user_feat)
-        item_tower_emb = self.item_tower(item_feat)
+        # User-side: slice to batch_size on its single group's tensor before
+        # handing to the user tower. Item tower sees the full, unsliced dict.
+        # (Single-key dict avoids the dict-comprehension FX-trace error.)
+        user_input_name = self._model_config.user_tower.input
+        user_grouped = {user_input_name: grouped_features[user_input_name][:batch_size]}
+        user_tower_emb = self.user_tower(user_grouped)
+        item_tower_emb = self.item_tower(grouped_features)
         _update_dict_tensor(
             self._loss_collection, self.user_tower.group_variational_dropout_loss
         )

--- a/tzrec/models/match_model.py
+++ b/tzrec/models/match_model.py
@@ -125,7 +125,6 @@ class MatchTower(BaseModule):
             tower_pb2.Tower,
             tower_pb2.DATTower,
             tower_pb2.MINDUserTower,
-            tower_pb2.MINDItemTower,
         ],
         output_dim: int,
         similarity: simi_pb2.Similarity,
@@ -191,14 +190,16 @@ class MatchTower(BaseModule):
 
 
 class MatchTowerWoEG(nn.Module):
-    """Base match tower without embedding group for share embedding.
+    """Base match tower without embedding group (uses shared embedding).
 
     Args:
         tower_config (Tower): user/item tower config.
         output_dim (int): user/item output embedding dimension.
         similarity (Similarity): when use COSINE similarity,
             will norm the output embedding.
-        feature_group (FeatureGroupConfig): feature group config.
+        feature_groups (list): feature group configs the tower consumes.
+            The primary group (named by `tower_config.input`) is the first;
+            additional groups (e.g. contextual) follow.
         features (list): list of features.
     """
 
@@ -210,7 +211,7 @@ class MatchTowerWoEG(nn.Module):
         ],
         output_dim: int,
         similarity: simi_pb2.Similarity,
-        feature_group: model_pb2.FeatureGroupConfig,
+        feature_groups: List[model_pb2.FeatureGroupConfig],
         features: List[BaseFeature],
     ) -> None:
         super().__init__()
@@ -218,7 +219,7 @@ class MatchTowerWoEG(nn.Module):
         self._group_name = tower_config.input
         self._output_dim = output_dim
         self._similarity = similarity
-        self._feature_group = feature_group
+        self._feature_groups = feature_groups
         self._features = features
 
 
@@ -477,10 +478,10 @@ class TowerWoEGWrapper(nn.Module):
 
     def __init__(self, module: nn.Module, tower_name: str = "user_tower") -> None:
         super().__init__()
-        self._feature_groups = [module._feature_group]
-        self.embedding_group = EmbeddingGroup(module._features, self._feature_groups)
+        self.embedding_group = EmbeddingGroup(module._features, module._feature_groups)
         setattr(self, tower_name, module)
         self._features = module._features
+        self._feature_groups = module._feature_groups
         self._tower_name = tower_name
         self._group_name = module._group_name
 
@@ -494,8 +495,5 @@ class TowerWoEGWrapper(nn.Module):
             embedding (dict): tower output embedding.
         """
         grouped_features = self.embedding_group(batch)
-        return {
-            f"{self._tower_name}_emb": getattr(self, self._tower_name)(
-                grouped_features[self._group_name]
-            )
-        }
+        tower = getattr(self, self._tower_name)
+        return {f"{self._tower_name}_emb": tower(grouped_features)}

--- a/tzrec/models/mind.py
+++ b/tzrec/models/mind.py
@@ -210,7 +210,7 @@ class MINDItemTower(MatchTower):
 
     def __init__(
         self,
-        tower_config: tower_pb2.MINDItemTower,
+        tower_config: tower_pb2.Tower,
         output_dim: int,
         similarity: simi_pb2.Similarity,
         item_feature_group: model_pb2.FeatureGroupConfig,

--- a/tzrec/protos/tower.proto
+++ b/tzrec/protos/tower.proto
@@ -189,11 +189,3 @@ message MINDUserTower {
     // concat mlp config for user interests vector
     required MLP concat_mlp = 7;
 }
-
-
-message MINDItemTower {
-    // item feature group name
-    required string input = 1;
-    // mlp config
-    required MLP mlp = 2;
-}


### PR DESCRIPTION
## Summary

Pull the model-side Tower-WoEG sub-refactor from the upcoming HSTUMatch PR onto master so the upstream `MatchTowerWoEG` API is plural-aware now and the eventual HSTUMatch rebase carries fewer changes. Net diff: 4 files, +46/-51 lines.

The refactor:

- **`MatchTowerWoEG`** takes a list of `FeatureGroupConfig` instead of a single one. Subclasses that conceptually consume multiple groups (contextual + sequence, action + watchtime + timestamp, etc.) can pass the full list; current single-group consumers wrap their group in `[group]` at the call site.
- **`TowerWoEGWrapper.__init__`** reads the inner module's `_feature_groups` directly (no more `[module._feature_group]` wrapping). **`TowerWoEGWrapper.predict`** hands the full `grouped_features` dict to the inner tower; the tower extracts its group via `self._group_name`.
- **`DSSMTower`** (the only `MatchTowerWoEG` subclass on master): plural `feature_groups` + an `embedding_group` constructor arg (resolves `feature_dims` internally; one fewer thing for the caller to thread). `forward` takes `Dict[str, Tensor]`.
- **`DSSMV2.predict`** wraps the user-side group's tensor in a single-key dict (not a dict-comprehension over `grouped_features.items()` — that pattern is not FX-trace-safe; documented in PR #506's commit) and hands the unsliced `grouped_features` to the item tower.
- **`mind.py`** annotation `tower_config: tower_pb2.MINDItemTower` → `tower_pb2.Tower`. Stale annotation: `match_model.proto:74` has declared `MIND.item_tower = Tower` for a while.
- **`tower.proto`**: delete the dead `MINDItemTower` message — no remaining references after the Python annotation fix and the Union cleanup in `MatchTower`.

## Why

This refactor unblocks two-tower models whose user tower legitimately consumes multiple feature groups (HSTUMatch consumes UIH + optional contextual + action / watchtime / timestamp groups). It also fixes a few stale type annotations and removes one unused proto message. Backward-compatible at the proto wire level (master's `MIND.item_tower` was already `Tower`).

## Test plan

- [x] `python -m unittest tzrec.models.dssm_v2_test tzrec.models.mind_test` — 8 tests OK on local A10.
- [x] `python -m unittest tzrec.tests.match_integration_test.MatchIntegrationTest.test_dssm_v2_with_fg_train_eval_export tzrec.tests.match_integration_test.MatchIntegrationTest.test_dssm_v2_mlp_emb_with_fg_train_eval_export tzrec.tests.match_integration_test.MatchIntegrationTest.test_mind_train_eval_export` — 3 tests OK on local A10.
- [x] `pre-commit run --files …` — clean.
- [ ] CI: full match + rank integration suite (covers `test_dssm_v2_with_fg_train_eval_export_aot` which exercises `TowerWoEGWrapper` through the AOT export helpers).

## Out of scope

- `HSTUMatchTower` → `HSTUUserTower` proto rename and `tzrec/models/hstu.py` changes — ship with the rest of the HSTUMatch PR rebased onto this.
- `TowerWrapper` / `TowerWoEGWrapper` constructor-param additions (`base_model_config`) — the HSTUMatch PR's older approach was reverted by #509 already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)