### PR TITLE
[bugfix] aoti: backport pytorch/pytorch#178147 int_array dedup key

### DIFF
--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -44,6 +44,59 @@ def _aoti_compile_cfg() -> Dict[str, Any]:
     return cfg
 
 
+def _backport_pt178147_int_array_dedup() -> None:
+    """Backport pytorch/pytorch#178147 onto torch < the release that includes it.
+
+    Upstream ``CppWrapperCpu.codegen_int_array_var`` (cpp_wrapper_cpu.py) keys
+    its int_array dedup cache on ``id(writeline)``. ``writeline`` is
+    ``<IndentedBuffer>.writeline``, a fresh bound-method object materialized on
+    every attribute access; CPython's small-object allocator recycles those
+    addresses, so two distinct destination IndentedBuffers can present the
+    same id() across calls. A false cache hit then returns an int_array name
+    whose declaration was queued at a *later* position in the assembled
+    wrapper.cpp, producing intermittently::
+
+        error: 'int_array_NN' was not declared in this scope
+
+    Upstream fix (pytorch/pytorch#178147, merged 2026-05-10): key on
+    ``id(writeline.__self__)`` -- the underlying IndentedBuffer, stable for
+    the whole compile -- with a fallback to ``id(writeline)`` for free
+    functions. Not present in torch 2.11.0; will be in the next release.
+
+    REMOVE THIS PATCH when tzrec's torch pin advances to a release that
+    includes pytorch/pytorch#178147.
+    """
+    from torch._inductor.codegen import cpp_wrapper_cpu as _cwc
+
+    cls = _cwc.CppWrapperCpu
+
+    if getattr(cls.codegen_int_array_var, "_tzrec_pt178147_backport", False):
+        return
+
+    def codegen_int_array_var(
+        self,
+        int_array,
+        writeline,
+        known_statically=False,
+        graph=None,
+    ):
+        wl_key = id(getattr(writeline, "__self__", writeline))
+        cache_key = (
+            int_array,
+            wl_key,
+            known_statically,
+            id(graph) if graph else None,
+        )
+        if cache_key not in self.codegen_int_array_var_cache:
+            self.codegen_int_array_var_cache[cache_key] = (
+                self._codegen_int_array_var_impl(int_array, writeline, known_statically)
+            )
+        return self.codegen_int_array_var_cache[cache_key]
+
+    codegen_int_array_var._tzrec_pt178147_backport = True  # type: ignore[attr-defined]
+    cls.codegen_int_array_var = codegen_int_array_var
+
+
 def load_model_aot(
     model_path: str, device: torch.device
 ) -> Union[CombinedModelWrapper, UnifiedAOTIModelWrapper]:
@@ -168,6 +221,7 @@ def export_model_aot(
             args=(sparse_output,),
             dynamic_shapes=(dynamic_shapes,),
         )
+    _backport_pt178147_int_array_dedup()
     with torch._inductor.config.patch(_aoti_compile_cfg()):
         aoti_dir = os.path.join(save_dir, "aoti")
         os.makedirs(aoti_dir, exist_ok=True)


### PR DESCRIPTION
## Summary

- Installs a runtime monkey-patch of `torch._inductor.codegen.cpp_wrapper_cpu.CppWrapperCpu.codegen_int_array_var` from `tzrec/acc/aot_utils.py:export_model_aot`, backporting upstream [pytorch/pytorch#178147](https://github.com/pytorch/pytorch/pull/178147) (merged 2026-05-10) onto our pinned `torch 2.11.0+cu129`.
- Fixes the intermittent CI failure `error: 'int_array_NN' was not declared in this scope` we hit on PR #511 [CI run 25898635529](https://github.com/alibaba/TorchEasyRec/actions/runs/25898635529/job/76117092172?pr=511) (`models.ultra_hstu_test.UltraHSTUTest.test_ultra_hstu_2_multi_hetero`, AOT_INDUCTOR + multi_hetero combo).

## Root cause

The upstream cache in torch 2.11.0 keys on `id(writeline)`. `writeline` is `<IndentedBuffer>.writeline` — a fresh bound-method object materialized on every attribute access. CPython's small-object allocator recycles their addresses, so two distinct destination IndentedBuffers can collide on `id()` across calls (live in a single compile: `wrapper_call`, `writer` from `ReinterpretView.codegen_reference`, the wrapper-code `lines` buffer). A false cache hit returns a name whose `static constexpr int64_t int_array_NN[] = ...` declaration was queued at a *later* lexical position in the assembled `wrapper.cpp` — forward reference, C++ rejects.

Whether the collision happens depends on GC / allocator schedule, hence the flake. PR #511's CI run was unlucky; other recent unrelated PRs have hit different tests on similar transient compile errors.

## Upstream fix being backported

Key on `id(writeline.__self__)` — the underlying `IndentedBuffer`, stable for the whole compile — with a fallback to `id(writeline)` for free functions:

```python
wl_key = id(getattr(writeline, "__self__", writeline))
cache_key = (int_array, wl_key, known_statically, id(graph) if graph else None)
```

The patch is identical in semantics to upstream PR #178147; PR #178147's root-cause writeup matches this one verbatim.

## Why a monkey-patch in `aot_utils.py`

- Scoped blast radius: only AOT export goes through this code path; the patch is installed at the only call site, not at module import.
- Patching the base class also covers `CppWrapperCpuArrayRef` and `CppWrapperGpu` (both inherit `codegen_int_array_var` and don't override; only definition site is `cpp_wrapper_cpu.py`).
- Idempotent (`_tzrec_pt178147_backport` marker check): safe across multiple AOT exports per process.

**Removal criterion (in the docstring):** delete this helper + its single call site when tzrec's torch pin advances to a release that includes pytorch/pytorch#178147.

## Local verification

Re-ran the exact failing combo via the patched worktree (`tzrec120` env, A10 host):

| Variant                              | wrapper.cpp lines | int_array decls | Forward refs |
|--------------------------------------|------------------:|----------------:|-------------:|
| Upstream (this run happened lucky)   |            10 213 |             430 |            0 |
| Bypass cache (correctness floor)     |            10 347 |             564 |            0 |
| **`__self__`-keyed (this PR)**       |        **9 952**  |        **169**  |        **0** |

Surprising-but-explicable: the buggy `id(writeline)` key was *over-segmenting* (each freshly-materialized bound method treated as a distinct destination), so it failed to dedup across legitimately-same destinations. The fixed key both eliminates the forward-reference class of bug AND tightens the dedup the upstream code intended (~2.5% smaller wrapper.cpp).

The patch marker is verified installed on `CppWrapperCpu.codegen_int_array_var` after the first `export_model_aot()` call.

## Test plan

- [x] Standalone repro (`/tmp/tzrec_repro/repro_via_aot_utils.py`): AOT compile passes with `[worktree-repro] AOT compile OK` and `[worktree-repro] patch marker confirmed`. Local `dlopen` then fails with `GLIBCXX_3.4.30 not found` — separate libstdc++ ABI mismatch on the A10 host, not in scope.
- [x] Wrapper.cpp invariant check: 0 forward references in the patched build (regex check on every `int_array_NN` use vs declaration).
- [x] `pre-commit run --files tzrec/acc/aot_utils.py` clean.
- [ ] CI on this branch — watch through 2-3 reruns to demonstrate the flake is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)