### PR TITLE
[fix] DataParser: cast int seq-input columns to string in PREDICT mode

### DIFF
--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -11,7 +11,7 @@
 
 import os
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -152,6 +152,16 @@ class DataParser:
                     continue
                 self.feature_input_names |= set(feature.inputs)
 
+        # Sequence-typed input columns the C++ FG handler will tokenize.
+        # PREDICT bypasses the sampler that normally casts these via
+        # combine_negs_to_candidate_sequence, so we cast int -> string in
+        # `parse()` to satisfy the handler's input contract.
+        self._sequence_input_names: Set[str] = set()
+        if self._fg_mode in (FgMode.FG_DAG, FgMode.FG_NORMAL):
+            self._sequence_input_names = {
+                name for feature in features for name in feature.sequence_input_names
+            }
+
         self.user_inputs = set()
         self.user_feats = set()
         if is_input_tile():
@@ -211,6 +221,11 @@ class DataParser:
             else:
                 # For offline predict, len(data) is batch_size, tile_size need set to 1.
                 output_data["batch_size"] = torch.tensor(1)
+
+        for col_name in self._sequence_input_names:
+            arr = input_data.get(col_name)
+            if arr is not None and pa.types.is_integer(arr.type):
+                input_data[col_name] = arr.cast(pa.string(), safe=False)
 
         if self._fg_mode in (FgMode.FG_DAG, FgMode.FG_BUCKETIZE):
             self._parse_feature_fg_handler(input_data, output_data)

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -728,20 +728,27 @@ class BaseFeature(object, metaclass=_meta_cls):
                 self._inputs = [v for _, v in self.side_inputs]
         return self._inputs
 
+    def _is_sequence_input(self, side: str, name: str) -> bool:
+        """Whether an input is sequence-typed at the FG handler interface.
+
+        Mirrors the C++ ``SequenceFeature::Init`` rule so top-level
+        ``sequence_*`` features and grouped ``sequence_feature`` sub-features
+        agree on which inputs the handler tokenizes as sequences.
+        """
+        if not self.is_sequence:
+            return False
+        if (
+            hasattr(self.config, "sequence_fields")
+            and len(self.config.sequence_fields) > 0
+        ):
+            return name in self.config.sequence_fields
+        if self.__class__.__name__ in SINGLE_INPUT_FEATURE_CLASSES:
+            return side != "feature"
+        return side == "item"
+
     def _need_seq_prefix(self, side: str, name: str) -> bool:
         """Check input fields should add prefix of group sequence or not."""
-        if self._is_grouped_seq:
-            if (
-                hasattr(self.config, "sequence_fields")
-                and len(self.config.sequence_fields) > 0
-            ):
-                return name in self.config.sequence_fields
-            elif self.__class__.__name__ in SINGLE_INPUT_FEATURE_CLASSES:
-                return side != "feature"
-            else:
-                return side == "item"
-        else:
-            return False
+        return self._is_grouped_seq and self._is_sequence_input(side, name)
 
     @property
     def side_inputs(self) -> List[Tuple[str, str]]:
@@ -771,6 +778,23 @@ class BaseFeature(object, metaclass=_meta_cls):
                 )
                 self._side_inputs.append((side, f"{seq_prefix}{name}"))
         return self._side_inputs
+
+    @property
+    def sequence_input_names(self) -> List[str]:
+        """Input column names that the FG handler treats as sequence-typed.
+
+        Empty for non-sequence features and for ``FG_NONE`` (no FG handler
+        runs; ``side_inputs`` may also be undefined for pre-encoded columns).
+        """
+        if not self.sequence_delim or self.fg_mode == FgMode.FG_NONE:
+            return []
+        return [
+            full_name
+            for (side, raw_name), (_, full_name) in zip(
+                self._build_side_inputs() or [], self.side_inputs
+            )
+            if self._is_sequence_input(side, raw_name)
+        ]
 
     @property
     def stub_type(self) -> bool:


### PR DESCRIPTION
## Summary

The C++ FG handler rejects scalar `int` arrow columns for sequence-class feature inputs (`sequence_id_feature`, `sequence_raw_feature`, grouped seq sub-features) with:

```
feature <X> has invalid input type: ... vector<optional<long int>>
AssertionError: sparse sequence feature internal error
```

In TRAIN/EVAL the negative sampler runs and `combine_negs_to_candidate_sequence` (`tzrec/datasets/utils.py:628-715`, string-path branch) casts these columns to delimited strings, so the handler always sees the expected format. In **PREDICT** the sampler doesn't run, the int column reaches the handler unchanged, and the parse fails — blocking `export`'s dummy batch load (`Mode.PREDICT` dataloader at `export_util.py:172`) and any downstream `test_predict` on configs that use a top-level `sequence_id_feature`.

This is a general parser issue. HSTUMatch (PR #506) was the first model to hit it, but any pipeline with sampler-targeted sequence_id_feature + export/predict is affected.

## Approach

- **`tzrec/features/feature.py`**: extract `_is_sequence_input(side, name)` — the canonical "is this an FG-handler sequence input?" predicate, mirroring the C++ `SequenceFeature::Init` rule (`feature_generator/.../sequence_feature.cc:75-115`): explicit `sequence_fields` wins, else single-input class → `side != \"feature\"`, else multi-input → `side == \"item\"`. `_need_seq_prefix` now delegates to it (observable behavior unchanged). New public `BaseFeature.sequence_input_names` property returns the subset of `self.inputs` that the handler will tokenize. Empty for `FG_NONE` (no FG handler runs) and for non-sequence features.

- **`tzrec/datasets/data_parser.py`**: precompute `self._sequence_input_names` in `__init__`, gated to `FG_DAG` / `FG_NORMAL` (the two modes whose C++ path runs `ToJaggedTensor`'s string-tokenization branch). Cast matching int columns to `pa.string()` in `parse()` right before the fg-mode dispatch. No `Mode` guard: the cast is naturally idempotent for already-string columns (`pa.types.is_integer` is False), so TRAIN/EVAL with sampler stays a no-op.

## Why not just call `FgHandler::SequenceInputToNames()`?

That pyfg method exists but returns `feat->inputs()` unfiltered by the C++ `seq_fields_mask_` — it would include the non-seq map column of a grouped LookupFeature etc. The Python `_is_sequence_input` mirrors the C++ filtering rule precisely, with no pyfg wheel rebuild.

## Why not `FG_BUCKETIZE`?

`FG_BUCKETIZE` runs the bucketize-only C++ path (`ToBucketizedJaggedTensor`, `sequence_id_feature.cc:466-495`), which already accepts `vector<optional<int>>` directly via the `is_optional<U>` arm. Casting to string there would re-route through string tokenization unnecessarily.

## Test plan

- [x] `python -m unittest tzrec.features.feature_test` — 26/26 pass (covers `_need_seq_prefix` paths via grouped sequence configs).
- [x] `python -m unittest tzrec.datasets.data_parser_test tzrec.features.id_feature_test tzrec.features.lookup_feature_test tzrec.features.raw_feature_test tzrec.features.combo_feature_test tzrec.features.match_feature_test tzrec.features.custom_feature_test` — all green (no regressions).
- [x] Pre-existing failures (`test_sequence_tokenize_feature_*`) confirmed to fail on clean master too — not caused by this PR.
- [x] `pre-commit run` — clean.
- [ ] CI: full sweep with the cast in place.

Follow-up: PR #506 (HSTUMatch) will rebase on this fix to add `test_hstu_with_fg_train_eval_export` (train → eval → AOT export → per-tower predict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)