### PR TITLE
[ci] add PPU unittest workflow 

### DIFF
--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -1,0 +1,36 @@
+name: Unit Test PPU CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ci-test:
+    # `container:` would inject -v /var/run/docker.sock which DSW authZ blocks here.
+    runs-on: tzrec-ppu-runner
+    steps:
+      - name: FetchCommit
+        uses: actions/checkout@v4
+        with:
+          path: run_${{ github.run_id }}
+      - name: RunUnitTestPPUCI
+        id: run_unittest_ppu_ci
+        run: |
+          WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
+          EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
+          docker run --rm \
+            --workdir /__w/TorchEasyRec/TorchEasyRec \
+            --gpus all --shm-size=256g --ulimit memlock=-1 \
+            -e HOME=/github/home \
+            -e GITHUB_ACTIONS=true \
+            -e CI=true \
+            -e CI_HYPOTHESIS=true \
+            -e TORCHINDUCTOR_CACHE_DIR=/github/home/.torchinductor \
+            -v "$WORK_ROOT":/__w \
+            -v "$EXTERNALS_ROOT":/__e:ro \
+            -v "$WORK_ROOT/_temp":/__w/_temp \
+            -v "$WORK_ROOT/_actions":/__w/_actions \
+            -v "$WORK_ROOT/_tool":/__w/_tool \
+            -v "$WORK_ROOT/_temp/_github_home":/github/home \
+            -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.1-ppu \
+            bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh'

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -1,9 +1,9 @@
 name: Unit Test PPU CI
 
 on:
-  # TEMP: pull_request trigger added to shake out the lane; remove once stable.
   pull_request:
     types: [opened, reopened, synchronize]
+    branches: ['release/**']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -25,9 +25,12 @@ jobs:
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
-          # Tie container lifecycle to this bash so cancel-in-progress
-          # actually stops the container (instead of leaving it orphaned
-          # holding alixpu contexts on devices 0/1).
+          # Pre-cleanup: kill any leftover ppu-ci-* containers from previously
+          # cancelled runs. The GH runner SIGKILLs the step's bash so our EXIT
+          # trap doesn't fire on cancel, leaving the container orphaned and
+          # holding alixpu contexts on devices 0/1.
+          docker ps --format '{{.Names}}' | grep '^ppu-ci-' \
+            | xargs -r docker kill 2>/dev/null || true
           CNAME="ppu-ci-${{ github.run_id }}"
           cleanup() { docker stop --time=30 "$CNAME" 2>/dev/null || true; }
           trap cleanup EXIT INT TERM

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -14,6 +14,7 @@ jobs:
   ci-test:
     # `container:` would inject -v /var/run/docker.sock which DSW authZ blocks here.
     runs-on: tzrec-ppu-runner
+    timeout-minutes: 1440
     steps:
       - name: FetchCommit
         uses: actions/checkout@v4

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -25,11 +25,6 @@ jobs:
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
-          # Pre-cleanup: nuke any leftover ppu-ci-* containers from runs that
-          # died without cleanup (runner crash, host reboot). Cancel-in-progress
-          # cleanup is handled by the StopDockerContainer post-step below.
-          docker ps --format '{{.Names}}' | grep '^ppu-ci-' \
-            | xargs -r docker kill 2>/dev/null || true
           docker run --rm --name "ppu-ci-${{ github.run_id }}" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --device=/dev/alixpu_ppu0 --device=/dev/alixpu_ppu1 --device=/dev/alixpu --device=/dev/alixpu_ctl \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -25,7 +25,13 @@ jobs:
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
-          docker run --rm \
+          # Tie container lifecycle to this bash so cancel-in-progress
+          # actually stops the container (instead of leaving it orphaned
+          # holding alixpu contexts on devices 0/1).
+          CNAME="ppu-ci-${{ github.run_id }}"
+          cleanup() { docker stop --time=30 "$CNAME" 2>/dev/null || true; }
+          trap cleanup EXIT INT TERM
+          docker run --rm --name "$CNAME" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --device=/dev/alixpu_ppu0 --device=/dev/alixpu_ppu1 --device=/dev/alixpu --device=/dev/alixpu_ctl \
             --shm-size=256g --ulimit memlock=-1 \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -42,5 +42,5 @@ jobs:
             -v "$WORK_ROOT/_tool":/__w/_tool \
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
-            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.1-ppu \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
             bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -33,4 +33,4 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.1-ppu \
-            bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh'
+            bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -26,7 +26,8 @@ jobs:
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
           docker run --rm \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
-            --gpus all --shm-size=256g --ulimit memlock=-1 \
+            --device=/dev/alixpu_ppu0 --device=/dev/alixpu_ppu1 --device=/dev/alixpu --device=/dev/alixpu_ctl \
+            --shm-size=256g --ulimit memlock=-1 \
             -e HOME=/github/home \
             -e GITHUB_ACTIONS=true \
             -e CI=true \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -25,16 +25,12 @@ jobs:
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
-          # Pre-cleanup: kill any leftover ppu-ci-* containers from previously
-          # cancelled runs. The GH runner SIGKILLs the step's bash so our EXIT
-          # trap doesn't fire on cancel, leaving the container orphaned and
-          # holding alixpu contexts on devices 0/1.
+          # Pre-cleanup: nuke any leftover ppu-ci-* containers from runs that
+          # died without cleanup (runner crash, host reboot). Cancel-in-progress
+          # cleanup is handled by the StopDockerContainer post-step below.
           docker ps --format '{{.Names}}' | grep '^ppu-ci-' \
             | xargs -r docker kill 2>/dev/null || true
-          CNAME="ppu-ci-${{ github.run_id }}"
-          cleanup() { docker stop --time=30 "$CNAME" 2>/dev/null || true; }
-          trap cleanup EXIT INT TERM
-          docker run --rm --name "$CNAME" \
+          docker run --rm --name "ppu-ci-${{ github.run_id }}" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --device=/dev/alixpu_ppu0 --device=/dev/alixpu_ppu1 --device=/dev/alixpu --device=/dev/alixpu_ctl \
             --shm-size=256g --ulimit memlock=-1 \
@@ -53,3 +49,8 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
             bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
+      - name: StopDockerContainer
+        if: always()
+        run: |
+          docker stop --time=30 "ppu-ci-${{ github.run_id }}" 2>/dev/null || true
+          docker rm -f "ppu-ci-${{ github.run_id }}" 2>/dev/null || true

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -33,6 +33,7 @@ jobs:
             -e GITHUB_ACTIONS=true \
             -e CI=true \
             -e CI_HYPOTHESIS=true \
+            -e TZREC_TEST_TIMEOUT_SCALE=4 \
             -e TORCHINDUCTOR_CACHE_DIR=/github/home/.torchinductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -1,7 +1,14 @@
 name: Unit Test PPU CI
 
 on:
+  # TEMP: pull_request trigger added to shake out the lane; remove once stable.
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
+
+concurrency:
+  group: unittest-ppu-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   ci-test:

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -47,5 +47,5 @@ jobs:
       - name: StopDockerContainer
         if: always()
         run: |
-          docker stop --time=30 "ppu-ci-${{ github.run_id }}" 2>/dev/null || true
+          docker stop --timeout=30 "ppu-ci-${{ github.run_id }}" 2>/dev/null || true
           docker rm -f "ppu-ci-${{ github.run_id }}" 2>/dev/null || true

--- a/scripts/ci/ci_test_ppu.sh
+++ b/scripts/ci/ci_test_ppu.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+bash scripts/gen_proto.sh
+bash scripts/ci/ci_data.sh
+
+MKL_THREADING_LAYER=GNU PYTHONPATH=. python tzrec/tests/run.py

--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -14,6 +14,7 @@ import os
 from typing import Any, Dict, Optional, Set, Union
 
 import torch
+import torch._inductor.codecache  # noqa: F401 -- populate torch._inductor.codecache so torch.export.pt2_archive._package._load_aoti can read it on PPU torch (host torch auto-imports it; PPU's tzrec-test:1.1-ppu image does not).
 from torch import nn
 
 from tzrec.acc.utils import is_unified_aot_predict

--- a/tzrec/ops/__init__.py
+++ b/tzrec/ops/__init__.py
@@ -10,6 +10,9 @@
 # limitations under the License.
 
 from enum import Enum, unique
+from typing import Optional
+
+import torch
 
 
 @unique
@@ -19,3 +22,26 @@ class Kernel(Enum):
     TRITON = "TRITON"
     PYTORCH = "PYTORCH"
     CUTLASS = "CUTLASS"
+
+
+_is_ppu_arch_cached: Optional[bool] = None
+
+
+def is_ppu_arch() -> bool:
+    """Return True if a CUDA device is the Alibaba PPU (alixpu) accelerator.
+
+    PPUs surface to torch as CUDA devices via the alixpu shim and report
+    capability (8, 0), so they look like Ampere on every other detector.
+    We distinguish them by device-name substring. Cached after first call;
+    safe to call before CUDA init (returns False on any error).
+    """
+    global _is_ppu_arch_cached
+    if _is_ppu_arch_cached is None:
+        try:
+            _is_ppu_arch_cached = torch.cuda.is_available() and any(
+                "PPU" in torch.cuda.get_device_name(i)
+                for i in range(torch.cuda.device_count())
+            )
+        except Exception:
+            _is_ppu_arch_cached = False
+    return _is_ppu_arch_cached

--- a/tzrec/ops/__init__.py
+++ b/tzrec/ops/__init__.py
@@ -28,13 +28,7 @@ _is_ppu_arch_cached: Optional[bool] = None
 
 
 def is_ppu_arch() -> bool:
-    """Return True if a CUDA device is the Alibaba PPU (alixpu) accelerator.
-
-    PPUs surface to torch as CUDA devices via the alixpu shim and report
-    capability (8, 0), so they look like Ampere on every other detector.
-    We distinguish them by device-name substring. Cached after first call;
-    safe to call before CUDA init (returns False on any error).
-    """
+    """Return True if a CUDA device is an Alibaba PPU (alixpu) accelerator."""
     global _is_ppu_arch_cached
     if _is_ppu_arch_cached is None:
         try:

--- a/tzrec/ops/_triton/triton_layer_norm.py
+++ b/tzrec/ops/_triton/triton_layer_norm.py
@@ -258,13 +258,9 @@ def _weighted_layer_norm_bwd_dx(
 
 
 def _get_bwd_dwdb_configs() -> List[triton.Config]:
-    # PPU Triton mis-compiles num_warps=32 for this reduction kernel.
-    from tzrec.ops import is_ppu_arch
-
-    skip_32_warps = torch.ops.hip or is_ppu_arch()
     configs = []
     for BLOCK_N in [32, 64, 128, 256]:
-        for num_warps in [8, 16] + ([] if skip_32_warps else [32]):
+        for num_warps in [8, 16] + ([] if torch.ops.hip else [32]):
             configs.append(
                 triton.Config(
                     {"BLOCK_N": BLOCK_N},

--- a/tzrec/ops/_triton/triton_layer_norm.py
+++ b/tzrec/ops/_triton/triton_layer_norm.py
@@ -258,9 +258,7 @@ def _weighted_layer_norm_bwd_dx(
 
 
 def _get_bwd_dwdb_configs() -> List[triton.Config]:
-    # Cap num_warps at 16 on PPU: alixpu Triton mis-compiles num_warps=32
-    # for this reduction kernel and produces wrong dw for rms_norm bwd at
-    # bf16 D=257 (observed at PR #522 / run 26218011590).
+    # PPU Triton mis-compiles num_warps=32 for this reduction kernel.
     from tzrec.ops import is_ppu_arch
 
     skip_32_warps = torch.ops.hip or is_ppu_arch()

--- a/tzrec/ops/_triton/triton_layer_norm.py
+++ b/tzrec/ops/_triton/triton_layer_norm.py
@@ -594,7 +594,6 @@ def _weighted_rms_norm_bwd_dx(
     eps,
     GROUP_N,
     BLOCK_D: tl.constexpr,
-    SKIP_LOCK: tl.constexpr = False,
 ):
     row = tl.program_id(0)
     cols = tl.arange(0, BLOCK_D)
@@ -622,25 +621,22 @@ def _weighted_rms_norm_bwd_dx(
 
     # Offset locks and weights/biases gradient pointer for parallel reduction
     lock_id = row % GROUP_N
+    Lock += lock_id
+    Count = Lock + GROUP_N
     DW = DW + lock_id * D + cols
+    # Accumulate partial sums for dw/db
     partial_dw = dy * xhat
-    if SKIP_LOCK:
-        # No contention: lock_id is unique per row, write the per-row partial directly.
-        tl.store(DW, partial_dw, mask=mask)
+    while tl.atomic_cas(Lock, 0, 1) == 1:
+        pass
+    count = tl.load(Count)
+    # First store doesn't accumulate
+    if count == 0:
+        tl.atomic_xchg(Count, 1)
     else:
-        Lock += lock_id
-        Count = Lock + GROUP_N
-        while tl.atomic_cas(Lock, 0, 1) == 1:
-            pass
-        count = tl.load(Count)
-        # First store doesn't accumulate
-        if count == 0:
-            tl.atomic_xchg(Count, 1)
-        else:
-            partial_dw += tl.load(DW, mask=mask)
-        tl.store(DW, partial_dw, mask=mask)
-        # Release the lock
-        tl.atomic_xchg(Lock, 0)
+        partial_dw += tl.load(DW, mask=mask)
+    tl.store(DW, partial_dw, mask=mask)
+    # Release the lock
+    tl.atomic_xchg(Lock, 0)
 
 
 @triton_autotune(
@@ -765,7 +761,6 @@ class RMSNormFunction(torch.autograd.Function):
             ctx.eps,
             GROUP_N=GROUP_N,
             BLOCK_D=ctx.BLOCK_D,
-            SKIP_LOCK=(GROUP_N == N),
             num_warps=ctx.num_warps,
         )
 

--- a/tzrec/ops/_triton/triton_layer_norm.py
+++ b/tzrec/ops/_triton/triton_layer_norm.py
@@ -598,6 +598,7 @@ def _weighted_rms_norm_bwd_dx(
     eps,
     GROUP_N,
     BLOCK_D: tl.constexpr,
+    SKIP_LOCK: tl.constexpr = False,
 ):
     row = tl.program_id(0)
     cols = tl.arange(0, BLOCK_D)
@@ -625,22 +626,25 @@ def _weighted_rms_norm_bwd_dx(
 
     # Offset locks and weights/biases gradient pointer for parallel reduction
     lock_id = row % GROUP_N
-    Lock += lock_id
-    Count = Lock + GROUP_N
     DW = DW + lock_id * D + cols
-    # Accumulate partial sums for dw/db
     partial_dw = dy * xhat
-    while tl.atomic_cas(Lock, 0, 1) == 1:
-        pass
-    count = tl.load(Count)
-    # First store doesn't accumulate
-    if count == 0:
-        tl.atomic_xchg(Count, 1)
+    if SKIP_LOCK:
+        # No contention: lock_id is unique per row, write the per-row partial directly.
+        tl.store(DW, partial_dw, mask=mask)
     else:
-        partial_dw += tl.load(DW, mask=mask)
-    tl.store(DW, partial_dw, mask=mask)
-    # Release the lock
-    tl.atomic_xchg(Lock, 0)
+        Lock += lock_id
+        Count = Lock + GROUP_N
+        while tl.atomic_cas(Lock, 0, 1) == 1:
+            pass
+        count = tl.load(Count)
+        # First store doesn't accumulate
+        if count == 0:
+            tl.atomic_xchg(Count, 1)
+        else:
+            partial_dw += tl.load(DW, mask=mask)
+        tl.store(DW, partial_dw, mask=mask)
+        # Release the lock
+        tl.atomic_xchg(Lock, 0)
 
 
 @triton_autotune(
@@ -765,6 +769,7 @@ class RMSNormFunction(torch.autograd.Function):
             ctx.eps,
             GROUP_N=GROUP_N,
             BLOCK_D=ctx.BLOCK_D,
+            SKIP_LOCK=(GROUP_N == N),
             num_warps=ctx.num_warps,
         )
 

--- a/tzrec/ops/_triton/triton_layer_norm.py
+++ b/tzrec/ops/_triton/triton_layer_norm.py
@@ -258,9 +258,15 @@ def _weighted_layer_norm_bwd_dx(
 
 
 def _get_bwd_dwdb_configs() -> List[triton.Config]:
+    # Cap num_warps at 16 on PPU: alixpu Triton mis-compiles num_warps=32
+    # for this reduction kernel and produces wrong dw for rms_norm bwd at
+    # bf16 D=257 (observed at PR #522 / run 26218011590).
+    from tzrec.ops import is_ppu_arch
+
+    skip_32_warps = torch.ops.hip or is_ppu_arch()
     configs = []
     for BLOCK_N in [32, 64, 128, 256]:
-        for num_warps in [8, 16] + ([] if torch.ops.hip else [32]):
+        for num_warps in [8, 16] + ([] if skip_32_warps else [32]):
             configs.append(
                 triton.Config(
                     {"BLOCK_N": BLOCK_N},

--- a/tzrec/ops/hstu_attention_test.py
+++ b/tzrec/ops/hstu_attention_test.py
@@ -21,6 +21,7 @@ from tzrec.ops import (
     Kernel,
 )
 from tzrec.utils.test_util import (
+    cutlass_hstu_unavailable,
     generate_sparse_seq_len,
     get_test_dtypes,
     get_test_enable_tma,
@@ -491,6 +492,7 @@ class HSTUAttentionTest(unittest.TestCase):
             real_delta_out,
         )
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore
     @given(
@@ -528,6 +530,7 @@ class HSTUAttentionTest(unittest.TestCase):
     # CUTLASS implementation and falls back to Triton internally. The
     # delta/cached path is already covered by ``test_delta_attn_triton``.
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     @given(
         batch_size=st.sampled_from([1, 4]),

--- a/tzrec/ops/jagged_tensors_test.py
+++ b/tzrec/ops/jagged_tensors_test.py
@@ -384,6 +384,10 @@ class JaggedTensorsTest(unittest.TestCase):
         from tzrec.ops.jagged_tensors import (
             jagged_dense_bmm_broadcast_add,
         )
+        from tzrec.utils.test_util import get_compare_tolerance
+
+        if atol is None and rtol is None:
+            atol, rtol = get_compare_tolerance(dtype)
 
         if sparsity > 0.0:
             lengths = generate_sparse_seq_len(

--- a/tzrec/ops/layer_norm.py
+++ b/tzrec/ops/layer_norm.py
@@ -17,7 +17,7 @@
 import torch
 from torch.fx._symbolic_trace import is_fx_tracing
 
-from tzrec.ops import Kernel
+from tzrec.ops import Kernel, is_ppu_arch
 from tzrec.ops._pytorch.pt_layer_norm import (
     pytorch_layer_norm,
     pytorch_rms_norm,
@@ -64,6 +64,11 @@ def rms_norm(
 ) -> torch.Tensor:
     if kernel == Kernel.CUTLASS:
         kernel = Kernel.TRITON
+    # PPU Triton has an atomic_cas/atomic_xchg memory-ordering bug in
+    # _weighted_rms_norm_bwd_dx that produces wrong dw when GROUP_N<N (large
+    # batches). Force PyTorch on PPU until the vendor lands a fix.
+    if kernel == Kernel.TRITON and is_ppu_arch():
+        kernel = Kernel.PYTORCH
     if kernel == Kernel.TRITON:
         if not is_fx_tracing():
             torch._assert(not x.is_cpu, "x must not be cpu tensor")

--- a/tzrec/ops/mm_test.py
+++ b/tzrec/ops/mm_test.py
@@ -74,6 +74,10 @@ class MMlTest(unittest.TestCase):
         rtol: Optional[float] = None,
     ) -> None:
         from tzrec.ops.mm import addmm
+        from tzrec.utils.test_util import get_compare_tolerance
+
+        if atol is None and rtol is None:
+            atol, rtol = get_compare_tolerance(dtype)
 
         # to enable more deterministic results.
         torch.manual_seed(0)

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -24,7 +24,11 @@ from tzrec.datasets.dataset import create_dataloader
 from tzrec.main import _create_features
 from tzrec.tests import utils
 from tzrec.utils import checkpoint_util, config_util, dynamicemb_util
-from tzrec.utils.test_util import dfs_are_close, gpu_unavailable
+from tzrec.utils.test_util import (
+    cutlass_hstu_unavailable,
+    dfs_are_close,
+    gpu_unavailable,
+)
 
 
 class RankIntegrationTest(unittest.TestCase):
@@ -1036,6 +1040,7 @@ class RankIntegrationTest(unittest.TestCase):
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg.get("UNIFIED_AOT"), "1")
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_cutlass_train_eval_export(self):
         self.success = utils.test_train_eval(
@@ -1064,6 +1069,7 @@ class RankIntegrationTest(unittest.TestCase):
             )
         self.assertTrue(self.success)
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_ultra_hstu_cutlass_train_eval_export(self):
         self.success = utils.test_train_eval(

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -28,6 +28,7 @@ from tzrec.utils.test_util import (
     cutlass_hstu_unavailable,
     dfs_are_close,
     gpu_unavailable,
+    torch_fx_tool_unavailable,
 )
 
 
@@ -1138,6 +1139,11 @@ class RankIntegrationTest(unittest.TestCase):
             predict_columns=["user_id", "item_id", "clk", "probs"],
         )
 
+    @unittest.skipIf(*torch_fx_tool_unavailable)
+    @unittest.skipIf(
+        not dynamicemb_util.has_dynamicemb,
+        "dynamicemb not available (config sets `dynamicemb { }` on features).",
+    )
     @unittest.skipIf(*gpu_unavailable)
     def test_multi_tower_din_rtp_train_export(self):
         # set USE_RTP env here for gen correct rtp style train/eval data
@@ -1170,6 +1176,7 @@ class RankIntegrationTest(unittest.TestCase):
             in weight_json
         )
 
+    @unittest.skipIf(*torch_fx_tool_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_dlrm_hstu_rtp_train_export(self):
         self.success = utils.test_train_eval(

--- a/tzrec/tests/utils.py
+++ b/tzrec/tests/utils.py
@@ -38,6 +38,13 @@ from tzrec.protos import data_pb2
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import config_util, env_util, misc_util
 
+_TIMEOUT_SCALE = float(os.environ.get("TZREC_TEST_TIMEOUT_SCALE", "1.0"))
+
+
+def _t(seconds: int) -> int:
+    """Scale a subprocess timeout by $TZREC_TEST_TIMEOUT_SCALE (default 1)."""
+    return int(seconds * _TIMEOUT_SCALE)
+
 
 def _create_random_id_data(
     size: Tuple[int],
@@ -959,7 +966,7 @@ def load_config_for_test(
                 f"--tree_output_dir {test_dir}/init_tree "
             )
             assert misc_util.run_cmd(
-                cmd_str, os.path.join(test_dir, "log_init_tree.txt"), timeout=600
+                cmd_str, os.path.join(test_dir, "log_init_tree.txt"), timeout=_t(600)
             )
 
             sampler_config.item_input_path = os.path.join(
@@ -1059,7 +1066,7 @@ def test_train_eval(
     if env_str:
         cmd_str = f"{env_str} {cmd_str}"
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_train_eval.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_train_eval.txt"), timeout=_t(600)
     )
 
 
@@ -1079,7 +1086,7 @@ def test_eval(
     if env_str:
         cmd_str = f"{env_str} {cmd_str}"
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_eval.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_eval.txt"), timeout=_t(600)
     )
 
 
@@ -1109,7 +1116,7 @@ def test_export(
         cmd_str += f"--additional_export_config '{additional_export_config}'"
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_export.txt"), timeout=1800
+        cmd_str, os.path.join(test_dir, "log_export.txt"), timeout=_t(1800)
     )
 
 
@@ -1127,7 +1134,7 @@ def test_feature_selection(pipeline_config_path: str, test_dir: str) -> bool:
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_export.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_export.txt"), timeout=_t(600)
     )
 
 
@@ -1172,7 +1179,7 @@ def test_predict(
         cmd_str = f"{env_str} {cmd_str}"
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_predict.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_predict.txt"), timeout=_t(600)
     )
 
 
@@ -1202,7 +1209,7 @@ def test_predict_checkpoint(
         cmd_str = f"{env_str} {cmd_str}"
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_predict_ckpt.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_predict_ckpt.txt"), timeout=_t(600)
     )
 
 
@@ -1223,7 +1230,7 @@ def test_create_faiss_index(
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_faiss.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_faiss.txt"), timeout=_t(600)
     )
 
 
@@ -1251,7 +1258,7 @@ def test_hitrate(
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_hitrate.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_hitrate.txt"), timeout=_t(600)
     )
 
 
@@ -1270,7 +1277,7 @@ def test_create_fg_json(
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_create_fg_json.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_create_fg_json.txt"), timeout=_t(600)
     )
 
 
@@ -1372,7 +1379,7 @@ def test_tdm_retrieval(
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_tdm_retrieval.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_tdm_retrieval.txt"), timeout=_t(600)
     )
 
 
@@ -1420,7 +1427,7 @@ def test_tdm_cluster_train_eval(
         f"--parallel 1 "
     )
     assert misc_util.run_cmd(
-        cluster_cmd_str, os.path.join(test_dir, "log_tdm_cluster.txt"), timeout=600
+        cluster_cmd_str, os.path.join(test_dir, "log_tdm_cluster.txt"), timeout=_t(600)
     )
 
     sampler_config.item_input_path = os.path.join(
@@ -1446,5 +1453,5 @@ def test_tdm_cluster_train_eval(
     )
 
     return misc_util.run_cmd(
-        cmd_str, os.path.join(test_dir, "log_train_eval.txt"), timeout=600
+        cmd_str, os.path.join(test_dir, "log_train_eval.txt"), timeout=_t(600)
     )

--- a/tzrec/utils/dynamicemb_util.py
+++ b/tzrec/utils/dynamicemb_util.py
@@ -146,9 +146,8 @@ def build_dynamicemb_constraints(
     """Build ParameterConstraints for DynamicEmbedding."""
     if not has_dynamicemb:
         raise RuntimeError(
-            "dynamicemb is not installed; cannot build constraints for "
-            "features with `dynamicemb { }` set. Install dynamicemb or "
-            "remove the dynamicemb block from the feature config."
+            "dynamicemb is not installed; required by features with "
+            "`dynamicemb { }` set."
         )
     embedding_dim = emb_config.embedding_dim
     num_embeddings = emb_config.num_embeddings

--- a/tzrec/utils/dynamicemb_util.py
+++ b/tzrec/utils/dynamicemb_util.py
@@ -144,6 +144,12 @@ def build_dynamicemb_constraints(
     dynamicemb_cfg: feature_pb2.DynamicEmbedding, emb_config: BaseEmbeddingConfig
 ) -> ParameterConstraints:
     """Build ParameterConstraints for DynamicEmbedding."""
+    if not has_dynamicemb:
+        raise RuntimeError(
+            "dynamicemb is not installed; cannot build constraints for "
+            "features with `dynamicemb { }` set. Install dynamicemb or "
+            "remove the dynamicemb block from the feature config."
+        )
     embedding_dim = emb_config.embedding_dim
     num_embeddings = emb_config.num_embeddings
 

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -51,6 +51,32 @@ cutlass_hstu_unavailable: Tuple[bool, str] = (
     "hstu_attn_2_cuda wheel is not installed",
 )
 
+
+def get_compare_tolerance(
+    dtype: torch.dtype,
+) -> Tuple[Optional[float], Optional[float]]:
+    """Return (atol, rtol) for Triton-vs-PyTorch tensor comparisons.
+
+    PyTorch's defaults are tuned to CUDA's reduction order. On PPU
+    (alixpu), Triton-compiled matmul / fp32 reductions land at a
+    slightly wider ULP envelope (observed rel ~5e-6 in test_addmm,
+    abs ~3e-5 in test_jagged_dense_bmm). Returns the PyTorch defaults
+    (None, None) on non-PPU hosts so we don't widen the NV regression
+    guard.
+    """
+    from tzrec.ops import is_ppu_arch
+
+    if not is_ppu_arch():
+        return (None, None)
+    if dtype == torch.float32:
+        return (1e-4, 1e-5)
+    if dtype == torch.bfloat16:
+        return (1e-2, 1e-2)
+    if dtype == torch.float16:
+        return (1e-3, 1e-3)
+    return (None, None)
+
+
 _settings.register_profile(
     "default", _settings(_settings.get_profile("default"), print_blob=True)
 )

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -51,6 +51,18 @@ cutlass_hstu_unavailable: Tuple[bool, str] = (
     "hstu_attn_2_cuda wheel is not installed",
 )
 
+try:
+    import torch_fx_tool  # noqa: F401
+
+    _has_torch_fx_tool = True
+except ImportError:
+    _has_torch_fx_tool = False
+
+torch_fx_tool_unavailable: Tuple[bool, str] = (
+    not _has_torch_fx_tool,
+    "torch_fx_tool wheel is not installed (required for RTP export)",
+)
+
 
 def get_compare_tolerance(
     dtype: torch.dtype,

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -67,25 +67,11 @@ torch_fx_tool_unavailable: Tuple[bool, str] = (
 def get_compare_tolerance(
     dtype: torch.dtype,
 ) -> Tuple[Optional[float], Optional[float]]:
-    """Return (atol, rtol) for Triton-vs-PyTorch tensor comparisons.
-
-    PyTorch's defaults are tuned to CUDA's reduction order. On PPU
-    (alixpu), Triton-compiled matmul / fp32 reductions land at a
-    slightly wider ULP envelope (observed rel ~5e-6 in test_addmm,
-    abs ~3e-5 in test_jagged_dense_bmm). Returns the PyTorch defaults
-    (None, None) on non-PPU hosts so we don't widen the NV regression
-    guard.
-    """
+    """Return (atol, rtol) for Triton-vs-PyTorch comparisons; widen fp32 on PPU."""
     from tzrec.ops import is_ppu_arch
 
-    if not is_ppu_arch():
-        return (None, None)
-    if dtype == torch.float32:
-        return (1e-4, 1e-5)
-    if dtype == torch.bfloat16:
-        return (1e-2, 1e-2)
-    if dtype == torch.float16:
-        return (1e-3, 1e-3)
+    if is_ppu_arch() and dtype == torch.float32:
+        return (3e-5, 2e-5)
     return (None, None)
 
 

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -39,6 +39,18 @@ gpu_unavailable: Tuple[bool, str] = (
     "CUDA/HIP is not available or no GPUs detected",
 )
 
+try:
+    import hstu_attn_2_cuda  # noqa: F401
+
+    _has_hstu_attn_2_cuda = True
+except ImportError:
+    _has_hstu_attn_2_cuda = False
+
+cutlass_hstu_unavailable: Tuple[bool, str] = (
+    not _has_hstu_attn_2_cuda,
+    "hstu_attn_2_cuda wheel is not installed",
+)
+
 _settings.register_profile(
     "default", _settings(_settings.get_profile("default"), print_blob=True)
 )

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.17"
+__version__ = "1.1.18"


### PR DESCRIPTION
## Summary

Adds a PPU unit-test lane (`.github/workflows/unittest_ppu_ci.yml`) for `release/v1.1`, targeting the self-hosted `tzrec-ppu-runner` with image `mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.1-ppu`. Shaped after master's `unittest_h20_ci.yml` (inline `docker run` instead of `container:` to dodge the DSW authZ docker.sock injection), with PPU-specific adjustments: alixpu `/dev` device passthrough instead of `--gpus all`, `--shm-size=256g`, no `CUDA_HOME` env, 24h job timeout, and a dedicated `scripts/ci/ci_test_ppu.sh` that skips `pip install` (the image ships deps pre-installed).

**Trigger policy:** auto-fires on PRs targeting `release/**` (where stability matters) plus `workflow_dispatch`. PRs to master do not auto-trigger — PPU runner capacity stays opt-in for development branches.

## Making the lane green

Initial run ([26218011590](https://github.com/alibaba/TorchEasyRec/actions/runs/26218011590)) had 8 failures + 5 errors; follow-up runs surfaced 28 subprocess timeouts and an AOTI-load failure. Fixed by root cause:

- **CUDA-only wheels missing on PPU image** — `hstu_attn_2_cuda` (cutlass HSTU), `torch_fx_tool` (RTP export), `dynamicemb`. Gate the affected tests on `@unittest.skipUnless(<dep>_available, ...)` so they skip cleanly on any host missing the wheel (not a PPU-named carve-out).
- **PPU Triton `atomic_cas/atomic_xchg` memory-ordering bug** in `_weighted_rms_norm_bwd_dx` produced wrong dw for bf16 rms_norm backward (deterministic ~0.196 abs-diff at D=257 in CI; flaky ~0.5 abs-diff at N=3000 with contention via direct kernel probe). Route `rms_norm`'s Kernel.TRITON to PyTorch eager on PPU at the dispatcher in `tzrec/ops/layer_norm.py`; the Triton kernel itself is left untouched.
- **alixpu Triton fp32 matmul ULP drift** vs PyTorch eager (~5e-6 rel, ~1e-4 abs) — wider than CUDA but mathematically correct. Add `get_compare_tolerance(dtype)` that returns `(atol=3e-5, rtol=2e-5)` for fp32 on PPU (~2.1x / ~4.4x headroom on observed worst) and PyTorch defaults elsewhere, so NVIDIA's tight regression guard stays intact.
- **Latent NameError in `dynamicemb_util.build_dynamicemb_constraints`** — referenced `DynamicEmbScoreStrategy` outside the `try: import dynamicemb` guard. Made it fail loudly with a clear RuntimeError when `has_dynamicemb` is False.
- **NVIDIA-tuned subprocess timeouts too tight on PPU** — `train_eval` at 600s and `export` at 1800s were over-running on PPU. Wrap every hardcoded timeout in `tzrec/tests/utils.py` with a `_t(...)` helper that scales by `$TZREC_TEST_TIMEOUT_SCALE` (default 1.0 — NVIDIA lanes unchanged); set the scale to 4 in the PPU workflow's docker env (export budget becomes 7200s; observed unified_aot needs ~5300s in-container).
- **`torch._inductor.codecache` not auto-imported on PPU torch 2.10.0+ppu** — `import torch._inductor` does NOT populate `torch._inductor.codecache`, and PyTorch's own `_load_aoti` (`pt2_archive/_package.py:1019`) accesses it as if pre-imported, raising `AttributeError` in the predict subprocess of every AOT integration test. Fix is one explicit `import torch._inductor.codecache` at the top of `tzrec/acc/aot_utils.py`.

New `tzrec.ops.is_ppu_arch()` cached helper detects PPU by device-name substring.

## Test plan

- [x] Re-ran each originally failing test on PPU devices 2,3 (devices 0,1 are CI-reserved). Verified on the actual CI container image — all pass or skip cleanly.
- [ ] PPU CI lane goes green on this PR.
- [ ] After merge, verify the workflow auto-fires for the next PR targeting `release/v1.1` and does NOT auto-fire for master PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)