### PR TITLE
fix: accumulate domain loss predictions instead of overwriting

### DIFF
--- a/tzrec/models/pepnet.py
+++ b/tzrec/models/pepnet.py
@@ -185,9 +185,9 @@ class PEPNet(MultiTaskRank):
                 tower_loss_name, domain_index = tower_domain_loss_predict_name.rsplit(
                     "_", 1
                 )
-                new_predictions[tower_loss_name] = [
+                new_predictions[tower_loss_name].append(
                     (domain_index, tower_domain_loss_predict_value)
-                ]
+                )
             domain_index = batch.labels[self._domain_input_name]
             for tower_loss_name, tower_loss_predict_values in new_predictions.items():
                 tower_loss_domain_predict = torch.stack(


### PR DESCRIPTION
## What
修复 `PEPNet._select_domain_task_output` 中 domain 预测值累积的 bug。

## Why
`new_predictions` 初始化为 `defaultdict(list)`，但旧代码使用 `=` 赋值单元素列表，导致每次循环覆盖之前的值。最终只有最后一个 `(domain_index, value)` 参与排序和 stack，使得多 domain 场景下的 `torch.gather` 选择结果错误。

## How
将 `new_predictions[tower_loss_name] = [...]` 改为 `.append(...)`，正确累积所有 domain 的预测值。