### PR TITLE
fix(pepnet): fix domain output overwrite in _select_domain_task_output

### DIFF
--- a/tzrec/models/pepnet.py
+++ b/tzrec/models/pepnet.py
@@ -185,9 +185,9 @@ class PEPNet(MultiTaskRank):
                 tower_loss_name, domain_index = tower_domain_loss_predict_name.rsplit(
                     "_", 1
                 )
-                new_predictions[tower_loss_name] = [
-                    (domain_index, tower_domain_loss_predict_value)
-                ]
+                new_predictions[tower_loss_name].append(
+                    (int(domain_index), tower_domain_loss_predict_value)
+                )
             domain_index = batch.labels[self._domain_input_name]
             for tower_loss_name, tower_loss_predict_values in new_predictions.items():
                 tower_loss_domain_predict = torch.stack(

--- a/tzrec/models/pepnet_test.py
+++ b/tzrec/models/pepnet_test.py
@@ -370,6 +370,97 @@ class PEPNetTest(unittest.TestCase):
         self.assertEqual(predictions["logits_t2"].size(), (2,))
         self.assertEqual(predictions["probs_t2"].size(), (2,))
 
+    def test_select_domain_task_output(self) -> None:
+        """Test domain selection correctness and numeric sort for ≥10 domains."""
+        tower_names = ["t1", "t2"]
+        domain_count = 10
+        batch_size = 4
+        domain_labels = torch.tensor([0, 3, 9, 5])
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="f1", embedding_dim=4, num_buckets=10
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="domainf", embedding_dim=4, num_buckets=10
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        pepnet_config = multi_task_rank_pb2.PEPNet(
+            task_domain_num=domain_count,
+            domain_input_name="domainf",
+            task_towers=[
+                tower_pb2.TaskTower(
+                    tower_name=tn,
+                    label_name=f"label{i}",
+                    mlp=module_pb2.MLP(hidden_units=[4]),
+                    losses=[
+                        loss_pb2.LossConfig(
+                            binary_cross_entropy=loss_pb2.BinaryCrossEntropy()
+                        )
+                    ],
+                )
+                for i, tn in enumerate(tower_names)
+            ],
+        )
+        model_config = model_pb2.ModelConfig(
+            feature_groups=[
+                model_pb2.FeatureGroupConfig(
+                    group_name="all",
+                    feature_names=["f1"],
+                    group_type=model_pb2.FeatureGroupType.DEEP,
+                ),
+                model_pb2.FeatureGroupConfig(
+                    group_name="domain",
+                    feature_names=["domainf"],
+                    group_type=model_pb2.FeatureGroupType.DEEP,
+                ),
+            ],
+            pepnet=pepnet_config,
+        )
+        pepnet = PEPNet(
+            model_config=model_config,
+            features=features,
+            labels=["label0", "label1", "domainf"],
+        )
+        init_parameters(pepnet, device=torch.device("cpu"))
+
+        predictions = {}
+        for tower_name in tower_names:
+            for d in range(domain_count):
+                pred_val = torch.full((batch_size,), float(d), dtype=torch.float32)
+                predictions[f"logits_{tower_name}_{d}"] = pred_val
+                predictions[f"probs_{tower_name}_{d}"] = torch.sigmoid(pred_val)
+
+        batch = Batch(
+            dense_features={},
+            sparse_features={},
+            labels={"domainf": domain_labels},
+        )
+
+        selected = pepnet._select_domain_task_output(predictions, batch)
+
+        for tower_name in tower_names:
+            for suffix in ("logits", "probs"):
+                key = f"{suffix}_{tower_name}"
+                self.assertIn(key, selected)
+                got = selected[key]
+                expected = torch.full((batch_size,), float("nan"))
+                for i in range(batch_size):
+                    expected[i] = {
+                        suffix == "logits": float(domain_labels[i].item()),
+                        suffix == "probs": torch.sigmoid(
+                            torch.tensor(float(domain_labels[i].item()))
+                        ).item(),
+                    }[True]
+                self.assertTrue(
+                    torch.allclose(got, expected),
+                    f"{key}: expected {expected}, got {got}",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要
修复 PEPNet 模型 `_select_domain_task_output` 中的两个 bug：

### Bug 1：域输出被覆盖（第 188 行）
`new_predictions[tower_loss_name]` 使用的是赋值 (`=`) 而非 `append()`，导致每个 `tower_loss_name` 只保留了最后一个域的输出。当 `task_domain_num > 1` 时，`torch.gather` 收到的 stacked tensor 形状为 `[batch, 1]` 而非 `[batch, task_domain_num]`，崩溃报错：
RuntimeError: index 1 is out of bounds for dimension 1 with size 1

### Bug 2：≥10 个域时的字符串排序问题（第 189 行）
`domain_index` 来自 `rsplit("_", 1)[1]` 是字符串类型，`sorted(..., key=lambda x: x[0])` 按字典序排列。当 `task_domain_num >= 10` 时，`"10"` 排在 `"2"` 之前，导致 stacked tensor 的列序与 `batch.labels` 传入 `torch.gather` 的整数索引不一致。修复方式是在 `append()` 时转为 `int`。

### 测试缺口
现有 `test_pepnet` 只覆盖了 `predict()` 的前向传播和 shape 断言。有 bug 的代码路径（`loss()` → `_select_domain_task_output`）从未被测试覆盖。新增 `test_select_domain_task_output`，构造 2 个 tower × 10 个域的合成 predictions dict，直接调用 `_select_domain_task_output`，验证 gathered 的 logits/probs 与每行的 `domainf` 标签一致。

