### PR TITLE
[bugfix] export: cache feature-permute order to avoid per-forward H2D sync

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -34,12 +34,16 @@ from torchrec.distributed.train_pipeline.utils import Tracer
 from torchrec.inference.modules import quantize_embeddings
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig
 from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
     EmbeddingBagCollectionInterface,
     EmbeddingCollection,
     EmbeddingCollectionInterface,
 )
 from torchrec.quant.embedding_modules import (
     EmbeddingCollection as QuantEmbeddingCollection,
+)
+from torchrec.quant.embedding_modules import (
+    quant_prep_enable_cache_features_order,
 )
 from torchrec.sparse import jagged_tensor
 
@@ -213,9 +217,16 @@ def export_model_normal(
             logger.info("quantize embeddings...")
             additional_qconfig_spec_keys = []
             additional_mapping = {}
+            cache_order_types = [EmbeddingBagCollection]
             if acc_utils.is_ec_quant():
                 additional_qconfig_spec_keys.append(EmbeddingCollection)
                 additional_mapping[EmbeddingCollection] = QuantEmbeddingCollection
+                cache_order_types.append(EmbeddingCollection)
+            # Cache the feature-permute order as an on-device buffer instead of
+            # rebuilding `torch.tensor(order, device=cuda)` (a blocking H2D copy)
+            # on every forward. Must run before quantize_embeddings so the quant
+            # modules pick it up via `from_float`.
+            quant_prep_enable_cache_features_order(model, cache_order_types)
             quantize_embeddings(
                 model,
                 dtype=acc_utils.quant_dtype(),

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.13"
+__version__ = "1.2.14"


### PR DESCRIPTION
## Problem

Quantized inference export (`tzrec/utils/export_util.py`, scripted path) calls `quantize_embeddings()` directly **without** first enabling `cache_features_order`. The exported graph therefore takes the uncached `KeyedJaggedTensor.permute()` branch, so **every forward** rebuilds `torch.tensor(order, dtype=int, device=cuda)` — one blocking H2D copy + `cudaStreamSynchronize` per embedding module (a real model hit 5 such calls/forward, the largest with 351 indices).

Under concurrent multi-thread warmup on a virtualized GPU, these blocking syncs were observed to wedge the process at model init (all warmup threads parked in `cudaStreamSynchronize`, main thread joining them).

## Fix

Call `quant_prep_enable_cache_features_order(...)` before `quantize_embeddings()` so the quant modules pick up `cache_features_order` via `from_float`. This caches the permute order as an on-device buffer computed once, eliminating the per-forward H2D sync. Feature order is static at inference, so caching is safe; the buffer is a registered buffer that rides with the module's `.to(device)`.

`EmbeddingCollection` is included only when it is actually quantized (`is_ec_quant()`), mirroring the quantization mapping right above it — `EmbeddingBagCollection` is always quantized by `quantize_embeddings`, so it is always enabled. (Setting the flag on a type that is not converted is inert — `from_float` and the quant forward are the only readers — but gating keeps the intent explicit.)

## Verification

On torchrec 1.5.0, the traced graph changes from `_permute_kjt(kjt, [index, index_1])` (rebuilds tensor on cuda each forward) to `_permute_kjt(kjt, [1, 0], self.ebc._features_order_tensor)` (uses cached on-device buffer). Output unchanged. Only the scripted quant export path is affected (AOT/TRT untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
