### PR TITLE
[feat] support keep_checkpoint_max with async checkpoint pruning

### DIFF
--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -63,6 +63,7 @@ LR策略可以支持按epoch更新或者按step更新
 - num_epochs: 训练的epoch数
 - save_checkpoints_steps: 保存模型的步数间隔，保存模型后会做一次评估
 - save_checkpoints_epochs: 保存模型的Epoch数间隔，保存模型后会做一次评估，与save_checkpoints_steps不能同时设置
+- keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}
   - 需要设置fine_tune_ckpt_var_map的情形:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -323,6 +323,7 @@ def _train_and_evaluate(
     model_dir: str,
     train_config: TrainConfig,
     eval_config: EvalConfig,
+    ckpt_manager: checkpoint_util.CheckpointManager,
     skip_steps: int = -1,
     ckpt_path: Optional[str] = None,
     eval_result_filename: str = TRAIN_EVAL_RESULT_FILENAME,
@@ -412,7 +413,7 @@ def _train_and_evaluate(
         # Restore model and optimizer checkpoint
         if i_step == 0 and ckpt_path is not None:
             if ignore_restore_optimizer:
-                checkpoint_util.restore_model(
+                ckpt_manager.restore(
                     ckpt_path, model, None, train_config.fine_tune_ckpt_param_map
                 )
             else:
@@ -421,7 +422,7 @@ def _train_and_evaluate(
                 peek_batch = next(train_iterator)
                 pipeline.progress(iter([peek_batch]))
                 train_iterator = itertools.chain([peek_batch], train_iterator)
-                checkpoint_util.restore_model(
+                ckpt_manager.restore(
                     ckpt_path, model, optimizer, train_config.fine_tune_ckpt_param_map
                 )
 
@@ -459,13 +460,7 @@ def _train_and_evaluate(
             if save_checkpoints_steps > 0 and i_step > 0:
                 if i_step % save_checkpoints_steps == 0:
                     last_ckpt_step = i_step
-                    ckpt_dir = os.path.join(model_dir, f"model.ckpt-{i_step}")
-                    checkpoint_util.save_model(
-                        ckpt_dir,
-                        model,
-                        optimizer,
-                    )
-                    checkpoint_util.save_dataloader_state(ckpt_dir, dataloader_state)
+                    ckpt_manager.save(i_step, model, optimizer, dataloader_state)
                     if eval_dataloader is not None:
                         _evaluate(
                             model,
@@ -484,13 +479,7 @@ def _train_and_evaluate(
         if save_checkpoints_epochs > 0 and i_step > 0:
             if (i_epoch + 1) % save_checkpoints_epochs == 0:
                 last_ckpt_step = i_step
-                ckpt_dir = os.path.join(model_dir, f"model.ckpt-{i_step}")
-                checkpoint_util.save_model(
-                    ckpt_dir,
-                    model,
-                    optimizer,
-                )
-                checkpoint_util.save_dataloader_state(ckpt_dir, dataloader_state)
+                ckpt_manager.save(i_step, model, optimizer, dataloader_state)
                 if eval_dataloader is not None:
                     _evaluate(
                         model,
@@ -525,13 +514,7 @@ def _train_and_evaluate(
     if train_config.is_profiling:
         prof.stop()
     if last_ckpt_step != i_step:
-        ckpt_dir = os.path.join(model_dir, f"model.ckpt-{i_step}")
-        checkpoint_util.save_model(
-            ckpt_dir,
-            model,
-            optimizer,
-        )
-        checkpoint_util.save_dataloader_state(ckpt_dir, dataloader_state)
+        ckpt_manager.save(i_step, model, optimizer, dataloader_state)
         if eval_dataloader is not None:
             _evaluate(
                 model,
@@ -544,6 +527,7 @@ def _train_and_evaluate(
                 check_all_workers_data_status=check_all_workers_data_status,
             )
             model.train()
+    ckpt_manager.close()
 
 
 def train_and_evaluate(
@@ -610,10 +594,17 @@ def train_and_evaluate(
             gl_cluster=gl_cluster,
         )
 
+    ckpt_manager = checkpoint_util.CheckpointManager(
+        pipeline_config.model_dir,
+        keep_checkpoint_max=train_config.keep_checkpoint_max,
+        export_config=pipeline_config.export_config,
+    )
+
     # Get Restore Ckpt Path
     ckpt_path = None
     skip_steps = -1
     if pipeline_config.train_config.fine_tune_checkpoint:
+        # fine_tune_checkpoint is an external dir, outside the manager's model_dir.
         ckpt_path, _ = checkpoint_util.latest_checkpoint(
             pipeline_config.train_config.fine_tune_checkpoint
         )
@@ -624,9 +615,7 @@ def train_and_evaluate(
             )
     if os.path.exists(pipeline_config.model_dir):
         # Restore dataloader state if continuing training
-        latest_ckpt_path, skip_steps = checkpoint_util.latest_checkpoint(
-            pipeline_config.model_dir
-        )
+        latest_ckpt_path, skip_steps = ckpt_manager.latest_checkpoint()
         if latest_ckpt_path:
             if continue_train:
                 ckpt_path = latest_ckpt_path
@@ -641,7 +630,7 @@ def train_and_evaluate(
     # Restore dataloader checkpoint state
     dataloader_state: Optional[Dict[str, int]] = None
     if ckpt_path and continue_train:
-        dataloader_state = checkpoint_util.restore_dataloader_state(ckpt_path)
+        dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
         if dataloader_state:
             train_dataloader.dataset.load_state_dict(dataloader_state)
 
@@ -778,6 +767,7 @@ def train_and_evaluate(
         pipeline_config.model_dir,
         train_config=train_config,
         eval_config=pipeline_config.eval_config,
+        ckpt_manager=ckpt_manager,
         skip_steps=skip_steps,
         ckpt_path=ckpt_path,
         check_all_workers_data_status=check_all_workers_data_status,
@@ -837,11 +827,10 @@ def evaluate(
         model, device=device, mixed_precision=train_config.mixed_precision
     )
 
+    ckpt_manager = checkpoint_util.CheckpointManager(pipeline_config.model_dir)
     global_step = None
     if not checkpoint_path:
-        checkpoint_path, global_step = checkpoint_util.latest_checkpoint(
-            pipeline_config.model_dir
-        )
+        checkpoint_path, global_step = ckpt_manager.latest_checkpoint()
     planner = create_planner(
         device=device,
         # pyre-ignore [16]
@@ -864,7 +853,7 @@ def evaluate(
     )
 
     if checkpoint_path:
-        checkpoint_util.restore_model(checkpoint_path, model)
+        ckpt_manager.restore(checkpoint_path, model)
     else:
         raise ValueError("Eval checkpoint path should be specified.")
 
@@ -947,17 +936,16 @@ def export(
     model = InferWrapper(model)
 
     if not checkpoint_path:
+        ckpt_manager = checkpoint_util.CheckpointManager(
+            pipeline_config.model_dir, export_config=pipeline_config.export_config
+        )
         if (
             pipeline_config.HasField("export_config")
             and pipeline_config.export_config.exporter_type == "best"
         ):
-            checkpoint_path, _ = checkpoint_util.best_checkpoint(
-                pipeline_config.model_dir, pipeline_config.export_config
-            )
+            checkpoint_path, _ = ckpt_manager.best_checkpoint()
         else:
-            checkpoint_path, _ = checkpoint_util.latest_checkpoint(
-                pipeline_config.model_dir
-            )
+            checkpoint_path, _ = ckpt_manager.latest_checkpoint()
 
     if isinstance(model.model, MatchModel):
         for name, module in model.model.named_children():
@@ -1386,11 +1374,10 @@ def predict_checkpoint(
         output_cols=output_cols,
     )
 
+    ckpt_manager = checkpoint_util.CheckpointManager(pipeline_config.model_dir)
     global_step = None
     if not checkpoint_path:
-        checkpoint_path, global_step = checkpoint_util.latest_checkpoint(
-            pipeline_config.model_dir
-        )
+        checkpoint_path, global_step = ckpt_manager.latest_checkpoint()
     planner = create_planner(
         device=device,
         # pyre-ignore [16]
@@ -1413,7 +1400,7 @@ def predict_checkpoint(
     model.eval()
 
     if checkpoint_path:
-        checkpoint_util.restore_model(checkpoint_path, model)
+        ckpt_manager.restore(checkpoint_path, model)
     else:
         raise ValueError("Predict checkpoint path should be specified.")
 

--- a/tzrec/protos/train.proto
+++ b/tzrec/protos/train.proto
@@ -70,5 +70,7 @@ message TrainConfig {
     optional uint32 gradient_accumulation_steps = 18;
     // dense gradient clipping config
     optional GradClipping grad_clipping = 19;
+    // maximum number of recent checkpoints to keep; 0 keeps all.
+    optional uint32 keep_checkpoint_max = 20 [default = 0];
     // TBD: qcomm config
 }

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -12,7 +12,11 @@
 import glob
 import json
 import os
+import queue
 import re
+import shutil
+import threading
+import weakref
 from dataclasses import replace
 from typing import Dict, List, Optional, Tuple
 
@@ -37,6 +41,9 @@ from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.protos import export_pb2
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
+
+# queue token meaning "run a prune pass"; ``None`` means "stop the worker".
+_PRUNE_REQUEST = object()
 
 
 class PartialLoadPlanner(DefaultLoadPlanner):
@@ -254,6 +261,183 @@ def best_checkpoint(
     else:
         logger.info(f"not find {eval_result_filename}, will search latest checkpoint")
         return latest_checkpoint(model_dir)
+
+
+class CheckpointManager:
+    """Saves training checkpoints and prunes old ones asynchronously.
+
+    ``prune`` never deletes on the calling thread: it enqueues a coalesced
+    request to a single daemon worker that does all filesystem work (listing,
+    best-checkpoint lookup, deletion), so the training loop never blocks on
+    ``model_dir`` I/O. ``glob`` of ``model_dir`` is the source of truth on every
+    pass, so the manager holds no checkpoint registry. Load/discovery methods
+    delegate to the module-level free functions.
+
+    Args:
+        model_dir: directory holding ``model.ckpt-<step>`` checkpoints.
+        keep_checkpoint_max: max number of recent checkpoints to keep; 0 keeps all.
+        export_config: when ``exporter_type == "best"``, the current best checkpoint
+            (by eval metric) is always retained even if older than the kept window.
+        eval_result_filename: eval result file (relative to ``model_dir``) used to
+            locate the best checkpoint.
+    """
+
+    def __init__(
+        self,
+        model_dir: str,
+        keep_checkpoint_max: int = 0,
+        export_config: Optional[export_pb2.ExportConfig] = None,
+        eval_result_filename: str = TRAIN_EVAL_RESULT_FILENAME,
+    ) -> None:
+        self._model_dir = model_dir
+        self._keep_checkpoint_max = keep_checkpoint_max
+        self._export_config = export_config
+        self._eval_result_filename = eval_result_filename
+        self._prune_queue: "queue.Queue[object]" = queue.Queue()
+        self._prune_pending = False
+        self._lock = threading.Lock()
+        self._prune_worker: Optional[threading.Thread] = None
+        self._finalizer: Optional[weakref.finalize] = None
+
+    def save(
+        self,
+        step: int,
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer] = None,
+        dataloader_state: Optional[Dict[str, int]] = None,
+    ) -> str:
+        """Save a checkpoint at the given step, then request an async prune."""
+        ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
+        save_model(ckpt_dir, model, optimizer)
+        if dataloader_state is not None:
+            save_dataloader_state(ckpt_dir, dataloader_state)
+        self.prune()
+        return ckpt_dir
+
+    def prune(self) -> None:
+        """Request an async prune pass (keep recent N + best). Rank 0 only.
+
+        Cheap and non-blocking: only flips a flag and enqueues one coalesced
+        request. The flag drops the request when a pass is already queued or
+        in-flight, so the queue stays bounded. All filesystem work happens on
+        the worker thread.
+        """
+        if self._keep_checkpoint_max <= 0:
+            return
+        if int(os.environ.get("RANK", 0)) != 0:
+            return
+        with self._lock:
+            if self._prune_pending:
+                return
+            self._prune_pending = True
+        self._ensure_prune_worker()
+        self._prune_queue.put(_PRUNE_REQUEST)
+
+    def close(self) -> None:
+        """Drain queued prune passes and stop the worker (idempotent).
+
+        Called at the end of training for a deterministic flush. A weakref.finalize
+        safety net (registered when the worker starts) runs the same drain at
+        interpreter exit if close() is skipped (e.g. training raised), so the worker
+        is never leaked and pending deletions still complete.
+        """
+        if self._prune_worker is None:
+            return
+        self._finalizer.detach()
+        self._drain(self._prune_queue, self._prune_worker)
+        self._prune_worker = None
+
+    # --- load / discovery (delegate to the module-level free functions) ---
+
+    def latest_checkpoint(self) -> Tuple[Optional[str], int]:
+        """Latest checkpoint under this manager's model_dir."""
+        return latest_checkpoint(self._model_dir)
+
+    def best_checkpoint(self) -> Tuple[Optional[str], int]:
+        """Best checkpoint under model_dir per the configured export metric."""
+        return best_checkpoint(
+            self._model_dir, self._export_config, self._eval_result_filename
+        )
+
+    def restore(
+        self,
+        ckpt_path: str,
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer] = None,
+        ckpt_param_map_path: Optional[str] = None,
+    ) -> None:
+        """Restore model/optimizer state from a checkpoint dir."""
+        restore_model(ckpt_path, model, optimizer, ckpt_param_map_path)
+
+    def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, int]]:
+        """Restore dataloader state saved alongside a checkpoint."""
+        return restore_dataloader_state(ckpt_path)
+
+    @staticmethod
+    def _drain(prune_queue: "queue.Queue[object]", worker: threading.Thread) -> None:
+        """Stop the prune worker and wait for it to finish (no ``self`` ref).
+
+        Used by both ``close()`` and the weakref.finalize safety net. FIFO ensures
+        any pending prune request runs before the stop sentinel.
+        """
+        prune_queue.put(None)  # stop sentinel
+        worker.join()
+
+    def _ensure_prune_worker(self) -> None:
+        if self._prune_worker is None:
+            self._prune_worker = threading.Thread(
+                target=self._prune_worker_loop, name="ckpt-prune", daemon=True
+            )
+            self._prune_worker.start()
+            # Safety net: if close() is never reached (e.g. training raised), drain
+            # the worker at interpreter exit so it is not leaked. The callback must
+            # not reference self, or it would pin the manager.
+            self._finalizer = weakref.finalize(
+                self, self._drain, self._prune_queue, self._prune_worker
+            )
+
+    def _prune_worker_loop(self) -> None:
+        while True:
+            item = self._prune_queue.get()
+            try:
+                if item is None:  # stop sentinel
+                    return
+                # allow a fresh request to be enqueued while this pass runs.
+                with self._lock:
+                    self._prune_pending = False
+                try:
+                    self._run_prune()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"Checkpoint prune pass failed: {e}")
+            finally:
+                self._prune_queue.task_done()
+
+    def _run_prune(self) -> None:
+        """All filesystem work for one prune pass -- runs only on the worker."""
+        ckpt_metas = glob.glob(
+            os.path.join(self._model_dir, "model.ckpt-*" + os.path.sep)
+        )
+        ckpt_metas = [x.rstrip(os.path.sep) for x in ckpt_metas]
+        if len(ckpt_metas) <= self._keep_checkpoint_max:
+            return
+        ckpt_metas.sort(key=_get_checkpoint_step)
+        protected = set(ckpt_metas[-self._keep_checkpoint_max :])
+        if (
+            self._export_config is not None
+            and self._export_config.exporter_type == "best"
+        ):
+            best_ckpt_path, _ = best_checkpoint(
+                self._model_dir, self._export_config, self._eval_result_filename
+            )
+            if best_ckpt_path is not None:
+                protected.add(best_ckpt_path.rstrip(os.path.sep))
+        for ckpt_path in ckpt_metas:
+            if ckpt_path not in protected:
+                logger.info(f"Removing old checkpoint {ckpt_path}...")
+                try:
+                    shutil.rmtree(ckpt_path)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"Failed to remove checkpoint {ckpt_path}: {e}")
 
 
 _DISTCP_RANK_RE = re.compile(r"__(\d+)_\d+\.distcp$")

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -15,10 +15,12 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 import torch.distributed as dist
 import torchrec
+from parameterized import parameterized
 from torch import nn
 from torchrec import EmbeddingBagCollection
 from torchrec.distributed.model_parallel import (
@@ -215,6 +217,115 @@ class CheckpointUtilTest(unittest.TestCase):
         )
         self.assertEqual(ckpt_path, os.path.join(self.test_dir, "custom"))
         self.assertEqual(step, 0)
+
+    def _remaining_ckpt_steps(self):
+        return sorted(
+            int(p.rsplit("-", 1)[1])
+            for p in os.listdir(self.test_dir)
+            if p.startswith("model.ckpt-")
+        )
+
+    @parameterized.expand(
+        [
+            # name, keep_checkpoint_max, protect_best, expected remaining steps
+            ("keep_all", 0, False, [0, 10, 20, 30]),
+            ("recent_2", 2, False, [20, 30]),
+            ("protect_best", 2, True, [10, 20, 30]),
+            ("keep_ge_count", 10, False, [0, 10, 20, 30]),
+        ]
+    )
+    def test_checkpoint_manager_prune(
+        self, _name, keep_checkpoint_max, protect_best, expected_steps
+    ):
+        for step in [0, 10, 20, 30]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-{step}"))
+        export_config = None
+        if protect_best:
+            with open(
+                os.path.join(self.test_dir, TRAIN_EVAL_RESULT_FILENAME), "w"
+            ) as f:
+                f.write('{"global_step":0, "auc":0.50}\n')
+                f.write('{"global_step":10, "auc":0.99}\n')  # best, outside recent-2
+                f.write('{"global_step":20, "auc":0.60}\n')
+                f.write('{"global_step":30, "auc":0.70}\n')
+            export_config = ExportConfig(
+                exporter_type="best",
+                best_exporter_metric="auc",
+                metric_larger_is_better=True,
+            )
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir,
+            keep_checkpoint_max=keep_checkpoint_max,
+            export_config=export_config,
+        )
+        with mock.patch.dict(os.environ, {"RANK": "0"}):
+            manager.prune()
+            manager.close()  # drains the async worker -> deterministic
+        self.assertEqual(self._remaining_ckpt_steps(), expected_steps)
+
+    def test_checkpoint_manager_prune_non_rank_zero(self):
+        for step in [0, 10, 20, 30]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-{step}"))
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir, keep_checkpoint_max=2
+        )
+        with mock.patch.dict(os.environ, {"RANK": "1"}):
+            manager.prune()
+            manager.close()
+        self.assertEqual(self._remaining_ckpt_steps(), [0, 10, 20, 30])
+
+    def test_checkpoint_manager_prune_idempotent(self):
+        for step in [0, 10, 20, 30]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-{step}"))
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir, keep_checkpoint_max=2
+        )
+        with mock.patch.dict(os.environ, {"RANK": "0"}):
+            manager.prune()
+            manager.prune()  # coalesced; must not double-delete or error
+            manager.close()
+        self.assertEqual(self._remaining_ckpt_steps(), [20, 30])
+
+    def test_checkpoint_manager_finalizer_drains(self):
+        # Simulate the exception path: prune() runs but close() is never reached.
+        # The weakref.finalize safety net must drain the worker at interpreter exit.
+        for step in [0, 10, 20, 30]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-{step}"))
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir, keep_checkpoint_max=2
+        )
+        with mock.patch.dict(os.environ, {"RANK": "0"}):
+            manager.prune()
+        self.assertTrue(manager._finalizer.alive)
+        manager._finalizer()  # invoke directly to simulate at-exit
+        self.assertEqual(self._remaining_ckpt_steps(), [20, 30])
+        self.assertFalse(manager._prune_worker.is_alive())
+        self.assertFalse(manager._finalizer.alive)
+
+    def test_checkpoint_manager_discovery(self):
+        for step in [0, 10, 20]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-{step}"))
+        with open(os.path.join(self.test_dir, TRAIN_EVAL_RESULT_FILENAME), "w") as f:
+            f.write('{"global_step":0, "auc":0.6}\n')
+            f.write('{"global_step":10, "auc":0.7}\n')  # best
+            f.write('{"global_step":20, "auc":0.5}\n')
+        export_config = ExportConfig(
+            exporter_type="best",
+            best_exporter_metric="auc",
+            metric_larger_is_better=True,
+        )
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir, export_config=export_config
+        )
+        self.assertEqual(
+            manager.latest_checkpoint(),
+            checkpoint_util.latest_checkpoint(self.test_dir),
+        )
+        self.assertEqual(
+            manager.best_checkpoint(),
+            checkpoint_util.best_checkpoint(self.test_dir, export_config),
+        )
+        self.assertEqual(manager.best_checkpoint()[1], 10)
 
     def test_dist_save_restore_model(self):
         port = misc_util.get_free_port()

--- a/tzrec/utils/filesystem_util.py
+++ b/tzrec/utils/filesystem_util.py
@@ -27,6 +27,7 @@ _original_remove = os.remove
 _original_isdir = os.path.isdir
 _original_exists = os.path.exists
 _original_copy = shutil.copy
+_original_rmtree = shutil.rmtree
 _original_glob = glob_module.glob
 _original_getsize = os.path.getsize
 
@@ -109,6 +110,18 @@ def _patched_copy(src, dst, *args, **kwargs):
         return _original_copy(src, dst, *args, **kwargs)
 
 
+def _patched_rmtree(path, ignore_errors=False, *args, **kwargs):
+    fs, _ = url_to_fs(path)
+    if fs is not None:
+        try:
+            return fs.rm(path, recursive=True)
+        except Exception:
+            if not ignore_errors:
+                raise
+    else:
+        return _original_rmtree(path, ignore_errors, *args, **kwargs)
+
+
 def _patched_glob(pattern, *args, **kwargs):
     fs, _ = url_to_fs(pattern)
     if fs is not None:
@@ -134,6 +147,7 @@ def apply_monkeypatch():
     os.remove = _patched_remove
     os.path.exists = _patched_exists
     shutil.copy = _patched_copy
+    shutil.rmtree = _patched_rmtree
     glob_module.glob = _patched_glob
     os.path.getsize = _patch_get_size
 
@@ -147,6 +161,7 @@ def remove_monkeypatch():
     os.remove = _original_remove
     os.path.exists = _original_exists
     shutil.copy = _original_copy
+    shutil.rmtree = _original_rmtree
     glob_module.glob = _original_glob
     os.path.getsize = _original_getsize
 

--- a/tzrec/utils/filesystem_util_test.py
+++ b/tzrec/utils/filesystem_util_test.py
@@ -33,6 +33,21 @@ class FileSystemUtilTest(unittest.TestCase):
             if os.path.exists(self.test_dir):
                 shutil.rmtree(self.test_dir)
 
+    def test_rmtree_local_and_fsspec(self):
+        # local path -> delegates to the original rmtree
+        local_sub = os.path.join(self.test_dir, "local_sub")
+        os.makedirs(os.path.join(local_sub, "nested"))
+        shutil.rmtree(local_sub)
+        self.assertFalse(os.path.exists(local_sub))
+        # file:// path -> fsspec branch (recursive fs.rm)
+        fsspec_sub = os.path.join(self.test_dir, "fsspec_sub")
+        os.makedirs(os.path.join(fsspec_sub, "nested"))
+        shutil.rmtree(f"file://{fsspec_sub}")
+        self.assertFalse(os.path.exists(fsspec_sub))
+        # ignore_errors swallows a missing path on the fsspec branch
+        shutil.rmtree(f"file://{fsspec_sub}", ignore_errors=True)
+        self.success = True
+
     def test_local_fsspec_train_eval_export(self):
         self.success = utils.test_train_eval(
             "tzrec/tests/configs/multi_tower_din_fg_mock.config",

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.14"
+__version__ = "1.2.15"


### PR DESCRIPTION
## What

Adds a `keep_checkpoint_max` training option that caps the number of retained `model.ckpt-<step>` directories. On long runs checkpoints currently accumulate without bound and can fill the disk; this lets users keep only the most recent N.

- `TrainConfig.keep_checkpoint_max` (default `0` = keep all → fully backward compatible; pruning is opt-in).
- Pruning is fully **asynchronous**: the training thread only enqueues a coalesced request; a single daemon worker does all filesystem work (directory `glob`, best-checkpoint lookup, recursive delete), so the loop never blocks on `model_dir` I/O — important for slow OSS-backed dirs.
- When `export_config.exporter_type == "best"`, the current best-by-metric checkpoint is always retained even if it falls outside the recent-N window, so best-exporter export never breaks (effective retained count can be N+1).

## Design

Checkpoint IO is consolidated into a new `CheckpointManager` (in `checkpoint_util.py`) rooted at `model_dir`, used for both save and load across train/eval/export/predict:

- `save()` writes the checkpoint then requests an async prune; `close()` (called at the end of training) drains pending deletions so the on-disk state is settled before export reads `model_dir`.
- Only rank 0 deletes. The queue is bounded by a `_prune_pending` coalescing flag (at most one in-flight + one pending pass). Deletions are filesystem-agnostic (local `shutil.rmtree` / fsspec `fs.rm(recursive=True)`).
- `glob` of `model_dir` is the source of truth every pass (no in-memory registry), so it stays correct under `--continue_train`.
- Load/discovery methods (`latest_checkpoint`, `best_checkpoint`, `restore`, `restore_dataloader_state`) delegate to the existing free functions, which remain canonical. `fine_tune_checkpoint` discovery stays a free-function call since it resolves a dir outside `model_dir`.

A partially-written trailing line in the eval-result file (concurrently appended by eval) can make a prune pass raise; this is caught and logged, and the next pass self-heals — no crash, no spurious deletions.

## Testing

`checkpoint_util_test.py`: parameterized prune cases (keep-all / recent-N / protect-best / keep≥count), non-rank-0 no-op, coalesced-idempotent prune, and discovery-delegation. All green; `pre-commit run -a` clean on changed files.