### PR TITLE
[fix] H20 CI: cutlass WGMMA bwd + unified-AOT int_array races; add test-skip infra

### DIFF
--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
           EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
-          docker run --rm \
+          docker run --rm --name "h20-ci-${{ github.run_id }}" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --gpus all --shm-size=512g --ulimit memlock=-1 \
             -e HOME=/github/home \
@@ -42,3 +42,8 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2 \
             bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
+      - name: StopDockerContainer
+        if: always()
+        run: |
+          docker stop --timeout=30 "h20-ci-${{ github.run_id }}" 2>/dev/null || true
+          docker rm -f "h20-ci-${{ github.run_id }}" 2>/dev/null || true

--- a/tzrec/acc/aot_utils.py
+++ b/tzrec/acc/aot_utils.py
@@ -491,6 +491,7 @@ def export_unified_model_aot(
 
     # Compile with AOTI
     logger.info("compiling unified model with AOTI...")
+    _backport_pt178147_int_array_dedup()
     with torch._inductor.config.patch(_aoti_compile_cfg()):
         aoti_dir = os.path.join(save_dir, "aoti")
         os.makedirs(aoti_dir, exist_ok=True)

--- a/tzrec/ops/hstu_attention_test.py
+++ b/tzrec/ops/hstu_attention_test.py
@@ -24,6 +24,7 @@ from tzrec.ops import (
 )
 from tzrec.ops.utils import clear_triton_caches
 from tzrec.utils.test_util import (
+    cutlass_hstu_unavailable,
     generate_sparse_seq_len,
     get_test_dtypes,
     get_test_enable_tma,
@@ -543,6 +544,7 @@ class HSTUAttentionTest(unittest.TestCase):
                 real_delta_out,
             )
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore
     @given(
@@ -586,6 +588,7 @@ class HSTUAttentionTest(unittest.TestCase):
     # CUTLASS implementation and falls back to Triton internally. The
     # delta/cached path is already covered by ``test_delta_attn_triton``.
 
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     @given(
         batch_size=st.sampled_from([1, 4]),

--- a/tzrec/ops/hstu_attention_test.py
+++ b/tzrec/ops/hstu_attention_test.py
@@ -566,15 +566,21 @@ class HSTUAttentionTest(unittest.TestCase):
     # pyre-ignore[2]
     def test_attn_cutlass(self, *args, **kwargs) -> None:
         hidden_dim = kwargs.pop("attn_dim")
-        test_attn(
-            *args,
-            **kwargs,
-            attn_dim=hidden_dim,
-            hidden_dim=hidden_dim,
-            test_backward=True,
-            ref_kernel=Kernel.PYTORCH,
-            real_kernel=Kernel.CUTLASS,
-        )
+        # CUTLASS silently falls back to Triton when max_attn_len>0 combines
+        # with target/contextual masking (hstu_attention.py
+        # _warn_cutlass_fallback_local_target); _force_mma_v2 sidesteps the
+        # Triton 3.6 sm_90 WGMMA bwd race (FAQ Q15) on those fallback shapes.
+        # No-op for the pure-CUTLASS path (env var only affects Triton).
+        with _force_mma_v2():
+            test_attn(
+                *args,
+                **kwargs,
+                attn_dim=hidden_dim,
+                hidden_dim=hidden_dim,
+                test_backward=True,
+                ref_kernel=Kernel.PYTORCH,
+                real_kernel=Kernel.CUTLASS,
+            )
 
     # NOTE: no ``test_delta_attn_cutlass`` — ``delta_hstu_mha`` has no
     # CUTLASS implementation and falls back to Triton internally. The
@@ -615,15 +621,18 @@ class HSTUAttentionTest(unittest.TestCase):
         if sla_k1 == 0 and sla_k2 == 0:
             return
         hidden_dim = kwargs.pop("attn_dim")
-        test_sla_attn(
-            *args,
-            **kwargs,
-            attn_dim=hidden_dim,
-            sla_k1=sla_k1,
-            sla_k2=sla_k2,
-            test_backward=True,
-            real_kernel=Kernel.CUTLASS,
-        )
+        # Same WGMMA-bwd workaround as test_attn_cutlass; harmless on the
+        # pure-CUTLASS NFUNC path (no Triton kernel runs).
+        with _force_mma_v2():
+            test_sla_attn(
+                *args,
+                **kwargs,
+                attn_dim=hidden_dim,
+                sla_k1=sla_k1,
+                sla_k2=sla_k2,
+                test_backward=True,
+                real_kernel=Kernel.CUTLASS,
+            )
 
     def test_sla_matches_fixed_causal_when_k1_spans_full_window(self) -> None:
         """CPU coverage of ``pytorch_hstu_mha(attn_func=...)``.

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -24,7 +24,13 @@ from tzrec.datasets.dataset import create_dataloader
 from tzrec.main import _create_features
 from tzrec.tests import utils
 from tzrec.utils import checkpoint_util, config_util, dynamicemb_util
-from tzrec.utils.test_util import dfs_are_close, gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import (
+    cutlass_hstu_unavailable,
+    dfs_are_close,
+    gpu_unavailable,
+    mark_ci_scope,
+    torch_fx_tool_unavailable,
+)
 
 
 class RankIntegrationTest(unittest.TestCase):
@@ -1059,6 +1065,7 @@ class RankIntegrationTest(unittest.TestCase):
             self.assertEqual(acc_cfg.get("MAX_EXPORT_BATCH_SIZE"), "2")
 
     @mark_ci_scope("h20")
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_cutlass_train_eval_export(self):
         self.success = utils.test_train_eval(
@@ -1088,6 +1095,7 @@ class RankIntegrationTest(unittest.TestCase):
         self.assertTrue(self.success)
 
     @mark_ci_scope("h20")
+    @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_ultra_hstu_cutlass_train_eval_export(self):
         self.success = utils.test_train_eval(
@@ -1156,6 +1164,11 @@ class RankIntegrationTest(unittest.TestCase):
             predict_columns=["user_id", "item_id", "clk", "probs"],
         )
 
+    @unittest.skipIf(*torch_fx_tool_unavailable)
+    @unittest.skipIf(
+        not dynamicemb_util.has_dynamicemb,
+        "dynamicemb not available (config sets `dynamicemb { }` on features).",
+    )
     @unittest.skipIf(*gpu_unavailable)
     def test_multi_tower_din_rtp_train_export(self):
         # set USE_RTP env here for gen correct rtp style train/eval data
@@ -1189,6 +1202,7 @@ class RankIntegrationTest(unittest.TestCase):
         )
 
     @mark_ci_scope("h20")
+    @unittest.skipIf(*torch_fx_tool_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_dlrm_hstu_rtp_train_export(self):
         self.success = utils.test_train_eval(

--- a/tzrec/utils/dynamicemb_util.py
+++ b/tzrec/utils/dynamicemb_util.py
@@ -217,6 +217,11 @@ def build_dynamicemb_constraints(
     dynamicemb_cfg: feature_pb2.DynamicEmbedding, emb_config: BaseEmbeddingConfig
 ) -> ParameterConstraints:
     """Build ParameterConstraints for DynamicEmbedding."""
+    if not has_dynamicemb:
+        raise RuntimeError(
+            "dynamicemb is not installed; required by features with "
+            "`dynamicemb { }` set."
+        )
     embedding_dim = emb_config.embedding_dim
     num_embeddings = emb_config.num_embeddings
 

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import os
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -37,6 +38,18 @@ amd_gpu_unavailable: Tuple[bool, str] = (
 gpu_unavailable: Tuple[bool, str] = (
     nv_gpu_unavailable[0] and amd_gpu_unavailable[0],
     "CUDA/HIP is not available or no GPUs detected",
+)
+
+# Optional-wheel probes via find_spec so importing test_util does NOT
+# eagerly load the wheel (or its CUDA/inductor/dynamo side effects) into
+# every test process.
+cutlass_hstu_unavailable: Tuple[bool, str] = (
+    importlib.util.find_spec("hstu") is None,
+    "fbgemm_gpu_hstu wheel is not installed",
+)
+torch_fx_tool_unavailable: Tuple[bool, str] = (
+    importlib.util.find_spec("torch_fx_tool") is None,
+    "torch_fx_tool wheel is not installed (required for RTP export)",
 )
 
 _settings.register_profile(


### PR DESCRIPTION
## What

Two intermittent races that have been silently exposing H20 CI to flaky-fail, plus test-skip plumbing that's useful regardless.

### 1. CUTLASS HSTU tests hit the Triton WGMMA bwd race (FAQ Q15)

`test_attn_cutlass` / `test_sla_attn_cutlass` pass `Kernel.CUTLASS`, but `tzrec/ops/hstu_attention.py` silently falls back to `Kernel.TRITON` when an input combines a local window (`max_attn_len > 0`) with target/contextual masking — the CUTLASS `Is_local` kernel doesn't compose with those. On Hopper / H20, Triton's `_hstu_attn_bwd` autotune then trips the v3 WGMMA shmem-OOB race documented in FAQ Q15 (and already worked around in `test_attn_triton_long_seqs` / `test_cache` via the existing `_force_mma_v2()` context manager).

Diagnosed end-to-end on ty_rec_h20_gitlab: the failure was deterministically reproducible cold-cache because hypothesis's `function_digest` is computed from `inspect.getsource`, which includes decorator source lines — adding a `@skipIf` decorator shifts the derandomize seed onto a different example sequence, and that sequence happened to land on a fallback-triggering shape. Wrap both cutlass tests in `_force_mma_v2()` so any silent Triton fallback compiles with v2 MMA. No-op for the pure-CUTLASS path (the env var only affects Triton compilation).

### 2. Unified-AOT export still races on `int_array_NN not declared`

PR #512 backported pytorch/pytorch#178147 (int_array dedup cache wrongly keyed on the bound method's `id()`, which CPython recycles for transient objects) as a runtime monkeypatch — but only installed it inside `export_model_aot` (legacy two-stage path, `ENABLE_AOT=1`). The unified path `export_unified_model_aot` (`ENABLE_AOT=2`), added later, never picked up the call site, so `test_rank_dlrm_hstu_train_eval_export_unified_aot` continues to intermittently fail with `wrapper.cpp:NNNN: 'int_array_NN' was not declared in this scope; did you mean 'int_array_MM'?` (verbatim failure mode from run 26554473082 on this PR). Install the same idempotent backport at the second call site.

### 3. Test-skip helpers + fail-loud `has_dynamicemb` guard

`cutlass_hstu_unavailable` and `torch_fx_tool_unavailable` in `tzrec/utils/test_util.py`, probed via `importlib.util.find_spec` so importing `test_util` does *not* eagerly load the wheel — a plain `try: import torch_fx_tool` would drag `triton`, `torch._inductor`, `torch._dynamo`, `fbgemm_gpu`, `torchrec`, `functorch` into every test process at collection time. Plus a `RuntimeError` at the top of `build_dynamicemb_constraints` so a feature config with `dynamicemb { }` set on an image without the wheel surfaces clearly. Apply `@unittest.skipIf` decorators on the HSTU cutlass tests and the four `rank_integration_test` methods they fit. All no-ops on the `tzrec-devel:1.2` H20 image; useful for ad-hoc local runs and the PPU CI lane.

### 4. H20 workflow container hygiene

`docker run --name "h20-ci-…"` + `if: always()` `StopDockerContainer` step on `unittest_h20_ci.yml`, mirroring the PPU workflow. Prevents container leakage on cancelled / failed jobs on the self-hosted `tzrec-h20-runner` pool.

## Verification

End-to-end on `ty_rec_h20_gitlab` (same pool that crashed 3/3 cold-cache on #529 and tripped the int_array race on the prior run of this PR): cold-cache `test_attn_cutlass` 3/3 OK; `function_digest(test_attn_cutlass)` matches master's. The H20 CI lane on this PR exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)