### PR TITLE
[bugfix] RTP export: keep dense-embedding modules as FX leaves so AutoDis/MLP params restore

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -344,6 +344,26 @@ def _get_sharded_leaf_module_names(model: torch.nn.Module) -> List[str]:
     return list(leaf_module_names)
 
 
+def _get_dense_embedding_leaf_module_names(model: torch.nn.Module) -> List[str]:
+    """Get dense-embedding modules to keep as FX leaf modules during export.
+
+    ``AutoDisEmbedding`` / ``MLPEmbedding`` override ``state_dict`` /
+    ``_load_from_state_dict`` with split per-feature names. Tracing them as
+    leaves keeps the class so ``reset_parameters`` and the custom restore run
+    after the graph is flattened; otherwise their params stay uninitialized.
+    """
+    from tzrec.modules.dense_embedding_collection import (
+        AutoDisEmbedding,
+        MLPEmbedding,
+    )
+
+    names = []
+    for path, module in model.named_modules():
+        if isinstance(module, (AutoDisEmbedding, MLPEmbedding)):
+            names.append(path)
+    return names
+
+
 def _get_rtp_feature_to_embedding_info(
     model: nn.Module,
 ) -> Dict[str, BaseEmbeddingConfig]:
@@ -765,7 +785,10 @@ def export_rtp_model(
 
     # Trace Sharded Model
     unwrap_model = dmp_model.module
-    tracer = Tracer(leaf_modules=_get_sharded_leaf_module_names(unwrap_model))
+    tracer = Tracer(
+        leaf_modules=_get_sharded_leaf_module_names(unwrap_model)
+        + _get_dense_embedding_leaf_module_names(unwrap_model)
+    )
     full_graph = tracer.trace(unwrap_model)  # , concrete_args=concrete_args)
     if is_rank_zero:
         with open(os.path.join(graph_dir, "gm_full.graph"), "w") as f:

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+
+import torch
+from torchrec.distributed.train_pipeline.utils import Tracer
+
+from tzrec.modules.dense_embedding_collection import (
+    AutoDisEmbeddingConfig,
+    DenseEmbeddingCollection,
+    MLPDenseEmbeddingConfig,
+)
+from tzrec.utils.export_util import (
+    _get_dense_embedding_leaf_module_names,
+    _prune_unused_param_and_buffer,
+)
+
+
+class ExportUtilTest(unittest.TestCase):
+    def test_dense_embedding_restore_survives_fx_flatten(self) -> None:
+        """AutoDis/MLP params must restore after the RTP FX flatten.
+
+        Their split-name ``state_dict`` only round-trips if the module class
+        survives tracing as a leaf; otherwise restore skips them and leaves
+        uninitialized memory. See ``export_rtp_model``.
+        """
+        configs = [
+            AutoDisEmbeddingConfig(16, 3, 0.1, 0.8, ["dense_1", "dense_2"]),
+            MLPDenseEmbeddingConfig(8, ["dense_3"]),
+        ]
+        ec = DenseEmbeddingCollection(configs)
+        # state_dict returns parameter views; clone before mutating params.
+        ref_state_dict = {k: v.detach().clone() for k, v in ec.state_dict().items()}
+
+        leaf_names = _get_dense_embedding_leaf_module_names(ec)
+        self.assertEqual(len([n for n in leaf_names if n.startswith("dense_embs.")]), 2)
+
+        # Trace + flatten as export_rtp_model does.
+        tracer = Tracer(leaf_modules=leaf_names)
+        graph = tracer.trace(ec)
+        gm = torch.fx.GraphModule(ec, graph)
+        gm.graph.eliminate_dead_code()
+        gm = _prune_unused_param_and_buffer(gm)
+
+        # Garbage-fill to mimic init_parameters, then restore from checkpoint.
+        with torch.no_grad():
+            for param in gm.parameters():
+                param.fill_(float("nan"))
+        gm.load_state_dict(ref_state_dict)
+
+        restored = gm.state_dict()
+        self.assertEqual(sorted(restored.keys()), sorted(ref_state_dict.keys()))
+        for name, ref in ref_state_dict.items():
+            self.assertFalse(
+                torch.isnan(restored[name]).any(), f"{name} was not restored"
+            )
+            torch.testing.assert_close(restored[name], ref)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`test_multi_tower_din_rtp_train_export` intermittently fails on the H20 CI lane (e.g. run [26559247912](https://github.com/alibaba/TorchEasyRec/actions/runs/26559247912/job/78237987764) on #531) with:

```
File ".../torch_fx_tool/ExportTorchFxTool.py", line 313, in export_fx_model
    raise ValueError("export_fx_output is not equal to user_model_output!")
```

This is a real RTP-export correctness bug surfacing as a flake — **unrelated to #531's changes** (it exercises the RTP / `torch_fx_tool` path, not AOT/CUTLASS).

## Root cause

`export_rtp_model` FX-traces the model treating only `ShardedModule`s as leaf modules, so the dense-embedding modules `AutoDisEmbedding` / `MLPEmbedding` are **inlined**, and `_prune_unused_param_and_buffer` flattens their parameters onto a plain `nn.Module`, discarding the original class.

Those modules use a **custom `state_dict` / `_load_from_state_dict`** that splits each parameter under per-feature names (`meta_emb_<feat>.weight`, …) so shared-embedding models like dssm_v2 can export. After flattening:

1. `init_parameters` allocates the meta-device params with `torch.empty_like` (uninitialized) and skips `reset_parameters` — the plain parent module doesn't have one.
2. `restore_model`'s `PartialLoadPlanner` cannot match the flattened name `…meta_emb` against the checkpoint's split `…meta_emb_<feat>.weight`, so it logs `Skip restore state` and silently skips.

The exported model therefore carries **uninitialized garbage** in every AutoDis/MLP dense-embedding parameter. Most runs the garbage is finite (silently wrong output); ~1/6 of runs it is NaN, which fails the `torch_fx_tool` equivalence check (`torch.allclose(out, base, atol=1e-6)`, default `equal_nan=False`, so NaN≠NaN) — the flake.

The AOT / TRT / unified-AOT paths are **not** affected: `export_model` restores the model with intact modules (the custom load works) *before* `split_model` flattens.

## Fix

Keep `AutoDisEmbedding` / `MLPEmbedding` as FX **leaf modules** during the RTP trace (new `_get_dense_embedding_leaf_module_names`), so `_prune_unused_param_and_buffer` preserves the original class. `init_parameters` then runs their `reset_parameters`, and `restore_model` runs their custom split-name `_load_from_state_dict` — the params restore correctly.

## Verification

- New deterministic regression test `tzrec/utils/export_util_test.py`: FX-flatten → restore round-trip on AutoDis + MLP. Asserts the restored params equal the checkpoint values. Fails on master (params stay NaN, never restored), passes with this fix.
- Reproduced the original flake locally on A10 (~1/7, matching CI's ~1/6). Instrumentation confirmed the eager `gm` and `symbolic_trace(gm)` are bit-identical (diff exactly 0) and the failure is purely all-NaN output from unrestored AutoDis params — landing on a *different* small param each time, the signature of uninitialized memory. A restore probe showed `changed_by_restore=False` for all AutoDis params before the fix, `True` after.
- With the fix: **120/120** consecutive `test_multi_tower_din_rtp_train_export` runs pass (0 failures), vs ~1/7 failing before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)