### PR TITLE
[bugfix] fix flaky TRT test: align engine TF32 with baseline, run strict FP32

### DIFF
--- a/tzrec/acc/trt_utils.py
+++ b/tzrec/acc/trt_utils.py
@@ -49,6 +49,9 @@ def trt_convert(
     torch_tensorrt.runtime.set_multi_device_safe_mode(True)
     enabled_precisions = {torch.float32}
 
+    # match TRT engine precision to the configured cuBLAS matmul tf32 mode
+    disable_tf32 = not torch.backends.cuda.matmul.allow_tf32
+
     # Workspace size for TensorRT
     workspace_size = 2 << 30
 
@@ -64,6 +67,7 @@ def trt_convert(
                 inputs,
                 # pyre-ignore [6]
                 enabled_precisions=enabled_precisions,
+                disable_tf32=disable_tf32,
                 workspace_size=workspace_size,
                 min_block_size=min_block_size,
                 hardware_compatible=True,
@@ -78,6 +82,7 @@ def trt_convert(
             inputs,
             # pyre-ignore [6]
             enabled_precisions=enabled_precisions,
+            disable_tf32=disable_tf32,
             workspace_size=workspace_size,
             min_block_size=min_block_size,
             hardware_compatible=True,

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -543,11 +543,12 @@ class RankIntegrationTest(unittest.TestCase):
             os.path.exists(os.path.join(self.test_dir, "train/eval_result.txt"))
         )
 
-        # set tf32 config for consistent TRT comparison
+        # disable tf32 so baseline and TRT engine both run strict fp32; export_config
+        # is the export/predict authority in allow_tf32_for_export
         test_config_path = os.path.join(self.test_dir, "pipeline.config")
         pipeline_config = config_util.load_pipeline_config(test_config_path)
-        pipeline_config.train_config.cudnn_allow_tf32 = True
-        pipeline_config.train_config.cuda_matmul_allow_tf32 = True
+        pipeline_config.export_config.cudnn_allow_tf32 = False
+        pipeline_config.export_config.cuda_matmul_allow_tf32 = False
         config_util.save_message(pipeline_config, test_config_path)
 
         trt_dir = os.path.join(self.test_dir, "trt")


### PR DESCRIPTION
## What

Fixes the flaky TensorRT consistency test `test_multi_tower_with_fg_train_eval_export_trt`
(and its ZCH sibling). CI intermittently failed the plain-TRT comparison:

```
rank_integration_test.py:603  self.assertTrue(dfs_are_close(df, df_t, 2e-5))
AssertionError: False is not true     # probs max abs_diff 2.67e-5 > 2e-5
```

## Root cause

The baseline and TRT paths ran at **different numeric precision**. The test enabled TF32
on the cuBLAS baseline (`train_config.cuda_matmul_allow_tf32 = True`), but `trt_convert`
never passed `disable_tf32`, so the TRT engine compiled with its **own** default-on TF32
GEMM kernels. cuBLAS-TF32 and TRT-TF32 are two independent implementations of the same
matmul and disagree at the TF32 mantissa floor. Through the dense head
`linear[256->1] -> sigmoid`, that surfaces as a ~3e-5 **logit** gap, which sigmoid
compresses to a "tiny" prob gap that grazes the 2e-5 tolerance and tips over it depending
on the (unseeded) mock training data.

Prior flaky-TRT fixes (`d9bf642`, `f19ce09`, `b6b583f`, `40b250a`) only ever toggled the
**baseline** TF32 and the tolerance — the **TRT-engine** TF32 was never controlled, so the
flake survived.

## Fix

- `trt_convert` mirrors `torch.backends.cuda.matmul.allow_tf32` into the engine via
  `disable_tf32`, so the engine and the cuBLAS baseline always run at the same precision.
  (This covers the plain + both input-tile TRT exports — all route through `trt_convert`.)
- The test disables TF32 on `export_config` so both sides run strict FP32.
  `export_config` is the export/predict authority in `allow_tf32_for_export` (applied
  last, and it overwrites train_config where set), so setting it there is sufficient and
  robust. The 2e-5 tolerance is kept; it is now physically meaningful.

## Evidence (A10, 8 exports, fixed weights; baseline-vs-TRT)

Reporting the **logit** diff alongside the prob diff is the point: sigmoid compression makes
the prob diff look like incidental noise, while the logit diff cleanly reads as the TF32
mantissa floor.

| precision (both sides) | prob max_abs_diff | logit max_abs_diff |
|---|---|---|
| TF32 (before) | 8.55e-6 | **3.42e-5** |
| FP32 (after)  | 1.19e-7 | **4.77e-7** |

Strict FP32 tightens the logit gap **~72x**, leaving ~70x margin under the 2e-5 tolerance.
TRT builds were bit-identical across repeats, so the run-to-run flake came from the training
data shifting the worst row, not TRT tactic nondeterminism.

## Verification

`test_multi_tower_with_fg_train_eval_export_trt` and
`test_multi_tower_zch_with_fg_train_eval_export_trt` pass locally (A10, torch 2.11+cu129,
torch-tensorrt 2.11), and the self-hosted Unit Test CI is green on this branch.

**50x local stress** (2 parallel workers, fresh unseeded train each run): the **plain-TRT
comparison (line 607) — the one this PR fixes — passed 50/50**, confirming the fix.

## Separate, pre-existing input-tile flake (NOT fixed here; follow-up)

The 50x stress also surfaced a **distinct** flake on the input-tile comparisons
(`INPUT_TILE=2/3`, lines 630/661), which this PR does not address because it has a different
root cause. Documenting the analysis so it can be tracked separately:

- **Pre-existing**: its tolerance was already loosened 1e-6 -> 2e-5 in the torchrec-1.4.0
  upgrade (`135c843`), and it has **never been observed failing in real (serial) CI** — only
  the plain line (607) has.
- **Signature**: bimodal — almost always ~1e-7, rarely ~2e-4 (a single row out of 131072;
  worst seen prob 2.1e-4 / logit 8.5e-4). Surfaced only at ~1/50 under heavy artificial GPU
  contention (2 full pipelines concurrent).
- **Root-caused as transient TRT runtime nondeterminism**, not a precision/compile/weight bug:
  - Re-exporting one fixed checkpoint 30x: **0/30 diverged**, bit-identical → not build/tactic
    nondeterminism.
  - Froze a checkpoint+engine that produced a bad value, then replayed `predict` on that
    **exact engine + same eval data 3x: all correct (diff 0.0)** → not an engine miscompile and
    not weight-dependent; the bad value occurred once at runtime and did not reproduce.
- **Recommendation**: track as a separate issue (TRT input-tile runtime nondeterminism under
  contention). It is out of scope for this precision fix and does not affect real CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
