### PR TITLE
[bugfix] ODPS reader: pin pyodps==0.12.5.1 (retry connection resets) + log session/table context on errors

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -15,7 +15,7 @@ psutil
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
-pyodps>=0.12.4
+pyodps==0.12.5.1
 safetensors
 scikit-learn
 tensorboard

--- a/tzrec/datasets/odps_dataset.py
+++ b/tzrec/datasets/odps_dataset.py
@@ -206,21 +206,50 @@ def _parse_table_path(
     return str_list[2], table_name, table_partitions, schema
 
 
+def _storage_debug_info(client: StorageApiArrowClient, **req_fields: Any) -> str:
+    """Format MaxCompute storage-api context for error logging."""
+    parts = {
+        "table": getattr(client, "_table", None),
+        "quota": getattr(client, "_quota_name", None),
+        "endpoint": getattr(client, "_rest_endpoint", None),
+        **req_fields,
+    }
+    return ", ".join(f"{k}={v}" for k, v in parts.items())
+
+
 def _read_rows_arrow_with_retry(
     client: StorageApiArrowClient,
     read_req: ReadRowsRequest,
 ) -> ArrowReader:
     max_retry_count = 3
     retry_cnt = 0
+    debug_info = _storage_debug_info(
+        client,
+        session_id=read_req.session_id,
+        row_index=read_req.row_index,
+        row_count=read_req.row_count,
+        max_batch_rows=read_req.max_batch_rows,
+    )
     while True:
         try:
             reader = client.read_rows_arrow(read_req)
         except ODPSError as e:
             if retry_cnt >= max_retry_count:
+                logger.error(
+                    f"read_rows_arrow failed after {retry_cnt} retries "
+                    f"({debug_info}): {e!r}"
+                )
                 raise e
             retry_cnt += 1
+            logger.warning(
+                f"read_rows_arrow retry {retry_cnt}/{max_retry_count} "
+                f"({debug_info}): {e!r}"
+            )
             time.sleep(random.choice([5, 9, 12]))
             continue
+        except Exception as e:
+            logger.error(f"read_rows_arrow failed ({debug_info}): {e!r}")
+            raise
         break
     return reader
 
@@ -230,8 +259,13 @@ def _get_session_record_count(
     sess_req: SessionRequest,
 ) -> int:
     """Get record count from a session, waiting until ready."""
+    debug_info = _storage_debug_info(client, session_id=sess_req.session_id)
     while True:
-        scan_resp = client.get_read_session(sess_req)
+        try:
+            scan_resp = client.get_read_session(sess_req)
+        except Exception as e:
+            logger.error(f"get_read_session failed ({debug_info}): {e!r}")
+            raise
         if scan_resp.session_status == SessionStatus.INIT:
             time.sleep(1)
             continue

--- a/tzrec/datasets/odps_dataset.py
+++ b/tzrec/datasets/odps_dataset.py
@@ -222,15 +222,17 @@ def _read_rows_arrow_with_retry(
     client: StorageApiArrowClient,
     read_req: ReadRowsRequest,
 ) -> ArrowReader:
+    def debug_info() -> str:
+        return _storage_debug_info(
+            client,
+            session_id=read_req.session_id,
+            row_index=read_req.row_index,
+            row_count=read_req.row_count,
+            max_batch_rows=read_req.max_batch_rows,
+        )
+
     max_retry_count = 3
     retry_cnt = 0
-    debug_info = _storage_debug_info(
-        client,
-        session_id=read_req.session_id,
-        row_index=read_req.row_index,
-        row_count=read_req.row_count,
-        max_batch_rows=read_req.max_batch_rows,
-    )
     while True:
         try:
             reader = client.read_rows_arrow(read_req)
@@ -238,18 +240,18 @@ def _read_rows_arrow_with_retry(
             if retry_cnt >= max_retry_count:
                 logger.error(
                     f"read_rows_arrow failed after {retry_cnt} retries "
-                    f"({debug_info}): {e!r}"
+                    f"({debug_info()}): {e!r}"
                 )
                 raise e
             retry_cnt += 1
             logger.warning(
                 f"read_rows_arrow retry {retry_cnt}/{max_retry_count} "
-                f"({debug_info}): {e!r}"
+                f"({debug_info()}): {e!r}"
             )
             time.sleep(random.choice([5, 9, 12]))
             continue
         except Exception as e:
-            logger.error(f"read_rows_arrow failed ({debug_info}): {e!r}")
+            logger.error(f"read_rows_arrow failed ({debug_info()}): {e!r}")
             raise
         break
     return reader
@@ -260,11 +262,11 @@ def _get_session_record_count(
     sess_req: SessionRequest,
 ) -> int:
     """Get record count from a session, waiting until ready."""
-    debug_info = _storage_debug_info(client, session_id=sess_req.session_id)
     while True:
         try:
             scan_resp = client.get_read_session(sess_req)
         except Exception as e:
+            debug_info = _storage_debug_info(client, session_id=sess_req.session_id)
             logger.error(f"get_read_session failed ({debug_info}): {e!r}")
             raise
         if scan_resp.session_status == SessionStatus.INIT:

--- a/tzrec/datasets/odps_dataset.py
+++ b/tzrec/datasets/odps_dataset.py
@@ -208,10 +208,11 @@ def _parse_table_path(
 
 def _storage_debug_info(client: StorageApiArrowClient, **req_fields: Any) -> str:
     """Format MaxCompute storage-api context for error logging."""
+    # client.table is a pyodps Table whose str() dumps the full schema; log its name.
     parts = {
-        "table": getattr(client, "_table", None),
-        "quota": getattr(client, "_quota_name", None),
-        "endpoint": getattr(client, "_rest_endpoint", None),
+        "table": client.table.full_table_name,
+        "quota": client._quota_name,
+        "endpoint": client._rest_endpoint,
         **req_fields,
     }
     return ", ".join(f"{k}={v}" for k, v in parts.items())

--- a/tzrec/datasets/odps_dataset.py
+++ b/tzrec/datasets/odps_dataset.py
@@ -208,11 +208,10 @@ def _parse_table_path(
 
 def _storage_debug_info(client: StorageApiArrowClient, **req_fields: Any) -> str:
     """Format MaxCompute storage-api context for error logging."""
-    # client.table is a pyodps Table whose str() dumps the full schema; log its name.
     parts = {
         "table": client.table.full_table_name,
-        "quota": client._quota_name,
-        "endpoint": client._rest_endpoint,
+        "quota": getattr(client, "_quota_name", None),
+        "endpoint": getattr(client, "_rest_endpoint", None),
         **req_fields,
     }
     return ", ".join(f"{k}={v}" for k, v in parts.items())

--- a/tzrec/datasets/odps_dataset_test.py
+++ b/tzrec/datasets/odps_dataset_test.py
@@ -696,7 +696,7 @@ class OdpsWriterTest(unittest.TestCase):
 class _FailingStorageClient:
     """Stub storage-api client whose calls raise a connection-reset error."""
 
-    _table = "test_project.test_table"
+    table = SimpleNamespace(full_table_name="test_project.test_table")
     _quota_name = "test_quota"
     _rest_endpoint = "http://service.odps.test"
 

--- a/tzrec/datasets/odps_dataset_test.py
+++ b/tzrec/datasets/odps_dataset_test.py
@@ -14,14 +14,18 @@ import multiprocessing as mp
 import os
 import time
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import numpy as np
 import pyarrow as pa
+import requests
 from odps import ODPS
 from parameterized import parameterized
 from torch import distributed as dist
 from torch.utils.data import DataLoader
 
+from tzrec.datasets import odps_dataset
 from tzrec.datasets.odps_dataset import OdpsDataset, OdpsWriter, _create_odps_account
 from tzrec.features.feature import FgMode, create_features
 from tzrec.protos import data_pb2, feature_pb2, sampler_pb2
@@ -687,6 +691,54 @@ class OdpsWriterTest(unittest.TestCase):
             partition = None
         with t.open_reader(partition=partition) as reader:
             self.assertEqual(reader.count, 1280)
+
+
+class _FailingStorageClient:
+    """Stub storage-api client whose calls raise a connection-reset error."""
+
+    _table = "test_project.test_table"
+    _quota_name = "test_quota"
+    _rest_endpoint = "http://service.odps.test"
+
+    def _raise(self):
+        raise requests.exceptions.ConnectionError(
+            "Connection aborted.",
+            ConnectionResetError(104, "Connection reset by peer"),
+        )
+
+    def read_rows_arrow(self, read_req):
+        self._raise()
+
+    def get_read_session(self, sess_req):
+        self._raise()
+
+
+class OdpsStorageErrorLogTest(unittest.TestCase):
+    def test_read_rows_arrow_logs_session_and_reraises(self):
+        client = _FailingStorageClient()
+        read_req = SimpleNamespace(
+            session_id="sess-read-123",
+            row_index=0,
+            row_count=10,
+            max_batch_rows=100,
+        )
+        with mock.patch.object(odps_dataset, "logger") as m_logger:
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                odps_dataset._read_rows_arrow_with_retry(client, read_req)
+        m_logger.error.assert_called_once()
+        logged = m_logger.error.call_args[0][0]
+        self.assertIn("sess-read-123", logged)
+        self.assertIn("test_project.test_table", logged)
+
+    def test_get_read_session_logs_session_and_reraises(self):
+        client = _FailingStorageClient()
+        sess_req = SimpleNamespace(session_id="sess-scan-456")
+        with mock.patch.object(odps_dataset, "logger") as m_logger:
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                odps_dataset._get_session_record_count(client, sess_req)
+        m_logger.error.assert_called_once()
+        logged = m_logger.error.call_args[0][0]
+        self.assertIn("sess-scan-456", logged)
 
 
 if __name__ == "__main__":

--- a/tzrec/datasets/odps_dataset_test.py
+++ b/tzrec/datasets/odps_dataset_test.py
@@ -21,6 +21,7 @@ import numpy as np
 import pyarrow as pa
 import requests
 from odps import ODPS
+from odps.errors import ODPSError
 from parameterized import parameterized
 from torch import distributed as dist
 from torch.utils.data import DataLoader
@@ -713,6 +714,25 @@ class _FailingStorageClient:
         self._raise()
 
 
+class _RetryingStorageClient:
+    """Stub whose read_rows_arrow raises ODPSError `fail_times` times, then succeeds."""
+
+    table = SimpleNamespace(full_table_name="test_project.test_table")
+    _quota_name = "test_quota"
+    _rest_endpoint = "http://service.odps.test"
+
+    def __init__(self, fail_times):
+        self._fail_times = fail_times
+        self.calls = 0
+        self.sentinel = object()
+
+    def read_rows_arrow(self, read_req):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise ODPSError("synthetic ODPS error", request_id="REQ-XYZ")
+        return self.sentinel
+
+
 class OdpsStorageErrorLogTest(unittest.TestCase):
     def test_read_rows_arrow_logs_session_and_reraises(self):
         client = _FailingStorageClient()
@@ -739,6 +759,41 @@ class OdpsStorageErrorLogTest(unittest.TestCase):
         m_logger.error.assert_called_once()
         logged = m_logger.error.call_args[0][0]
         self.assertIn("sess-scan-456", logged)
+
+    def test_read_rows_arrow_retries_odps_error_then_succeeds(self):
+        client = _RetryingStorageClient(fail_times=2)
+        read_req = SimpleNamespace(
+            session_id="sess-retry-1",
+            row_index=0,
+            row_count=10,
+            max_batch_rows=100,
+        )
+        with mock.patch.object(odps_dataset.time, "sleep"):
+            with mock.patch.object(odps_dataset, "logger") as m_logger:
+                reader = odps_dataset._read_rows_arrow_with_retry(client, read_req)
+        self.assertIs(reader, client.sentinel)
+        self.assertEqual(client.calls, 3)  # 2 failures + 1 success
+        self.assertEqual(m_logger.warning.call_count, 2)
+        m_logger.error.assert_not_called()
+
+    def test_read_rows_arrow_odps_error_exhausts_retries_and_raises(self):
+        client = _RetryingStorageClient(fail_times=99)
+        read_req = SimpleNamespace(
+            session_id="sess-retry-2",
+            row_index=5,
+            row_count=10,
+            max_batch_rows=100,
+        )
+        with mock.patch.object(odps_dataset.time, "sleep"):
+            with mock.patch.object(odps_dataset, "logger") as m_logger:
+                with self.assertRaises(ODPSError):
+                    odps_dataset._read_rows_arrow_with_retry(client, read_req)
+        self.assertEqual(client.calls, 4)  # initial + 3 retries
+        self.assertEqual(m_logger.warning.call_count, 3)
+        m_logger.error.assert_called_once()
+        logged = m_logger.error.call_args[0][0]
+        self.assertIn("after 3 retries", logged)
+        self.assertIn("sess-retry-2", logged)
 
 
 if __name__ == "__main__":

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.19"
+__version__ = "1.2.20"


### PR DESCRIPTION
## Problem

MaxCompute (ODPS) training jobs intermittently crash with a transient network drop during a storage-api read:

```
requests.exceptions.ConnectionError:
  ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

The exception escapes the DataLoader worker and tears down the whole distributed job, leaving only a raw stack trace — no session id, table, or row range to tell *which* read failed.

## Root cause

pyodps **stopped retrying connection resets in 0.12.6**. Up to **0.12.5.1**, the storage-api HTTP adapter mounted a urllib3 `Retry(total=retry_times, allowed_methods={GET,HEAD,DELETE}, status_forcelist=[502,503,504])`. A connection reset surfaces inside urllib3 as a `ProtocolError`, which `Retry` classifies as a retryable *read error* for idempotent methods — so it was retried up to `retry_times` times. 0.12.6 (and 0.13.0) dropped that adapter-level retry and moved retry into a Python filter that only retries `ODPSError` with status 502/503/504; a `requests.ConnectionError` is neither, so it is re-raised on the first attempt. Upgrading past 0.12.5.1 silently removed connection-reset resilience.

On the tzrec side, `tzrec/datasets/odps_dataset.py` also had two gaps: `_read_rows_arrow_with_retry` only caught `ODPSError` (and retried silently), and `_get_session_record_count` had no error handling at all — so an escaped reset died without any context.

## Change

- **Pin `pyodps==0.12.5.1`** (`requirements/runtime.txt`) to restore the transport-level urllib3 retry of connection resets.
- **Log storage-api context before re-raising** (diagnostics only — no new tzrec-side retry): `_storage_debug_info` formats session id / row range / table / quota / endpoint, and both call sites log it plus the exception `repr` (which carries the ODPS `RequestId` when present). The existing `ODPSError` retry path is made non-silent — `warning` per attempt, `error` on exhaustion.
- **Log `client.table.full_table_name`, not the `Table` object** — `str(Table)` dumps the entire column schema (hundreds of lines for wide feature tables) and touches lazily-loaded fields, which could fire a metadata reload inside the `except` block exactly when the connection is already broken.

## Test

Ungated `OdpsStorageErrorLogTest` (no credentials/network) drives a stub client that raises `ConnectionError` and asserts both functions re-raise and log the session id / table:

```
python -m tzrec.datasets.odps_dataset_test OdpsStorageErrorLogTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
