### PR TITLE
[bugfix] DlrmHSTU predict: keep candidate split key in original order for descending timestamps

### DIFF
--- a/tzrec/models/dlrm_hstu.py
+++ b/tzrec/models/dlrm_hstu.py
@@ -201,6 +201,10 @@ class DlrmHSTU(RankModel):
         with record_function("## preprocess ##"):
             grouped_features = self.build_input(batch)
 
+        # Capture num_targets before the descending-timestamp flip below, so the
+        # output split key stays in the original (un-flipped) request order.
+        num_targets = grouped_features["candidate.sequence_length"]
+
         if not self._model_config.sequence_timestamp_is_ascending:
             # if timestamp of sequence is descending,
             # we should reverse all features
@@ -235,9 +239,7 @@ class DlrmHSTU(RankModel):
                         suffix=f"_{task_name}",
                     )
                 )
-        predictions[TARGET_REPEAT_INTERLEAVE_KEY] = grouped_features[
-            "candidate.sequence_length"
-        ]
+        predictions[TARGET_REPEAT_INTERLEAVE_KEY] = num_targets
 
         return predictions
 

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -24,6 +24,7 @@ from tzrec.datasets.utils import BASE_DATA_GROUP, Batch
 from tzrec.features.feature import create_features
 from tzrec.models.dlrm_hstu import DlrmHSTU
 from tzrec.models.model import TrainWrapper
+from tzrec.models.rank_model import TARGET_REPEAT_INTERLEAVE_KEY
 from tzrec.ops import Kernel
 from tzrec.protos import (
     feature_pb2,
@@ -444,6 +445,34 @@ class DlrmHSTUTest(unittest.TestCase):
         self.assertEqual(predictions["probs_is_like"].size(), (6,))
         self.assertEqual(predictions["logits_is_comment"].size(), (6,))
         self.assertEqual(predictions["probs_is_comment"].size(), (6,))
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dlrm_hstu_predict_num_targets_order(self) -> None:
+        """num_targets split key must stay in input order.
+
+        ``_write_predictions`` regroups predictions per request via
+        ``cumsum(predictions[TARGET_REPEAT_INTERLEAVE_KEY])``. With
+        ``sequence_timestamp_is_ascending=False``, ``predict()`` flips features
+        (reversing request order) and flips predictions back, so the key must
+        also be un-flipped; reading it from the still-flipped
+        ``candidate.sequence_length`` returns [4, 2] for the [2, 4] test batch,
+        misassigning whole-request blocks. ``size()`` (== 6) can't catch it.
+        """
+        device = torch.device("cuda")
+        # candidate (cand_seq) counts in _build_batch, in input order.
+        expected_num_targets = [2, 4]
+        for ascending in (True, False):
+            model = _build_model(
+                device=device, sequence_timestamp_is_ascending=ascending
+            )
+            batch = _build_batch(device=device)
+            with torch.no_grad():
+                predictions = model.predict(batch)
+            self.assertEqual(
+                predictions[TARGET_REPEAT_INTERLEAVE_KEY].cpu().tolist(),
+                expected_num_targets,
+                msg=f"num_targets order wrong for ascending={ascending}",
+            )
 
     @unittest.skipIf(*gpu_unavailable)
     def test_dlrm_hstu_task_weight(self) -> None:

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"


### PR DESCRIPTION
## Problem

`DlrmHSTU.predict` (inherited by `UltraHSTU`) can attach a request's predictions
to the **wrong output row** when running inference with `batch_size > 1` and
`sequence_timestamp_is_ascending = false`. The per-candidate values themselves
are correct, but whole-request prediction blocks get assigned to the wrong
`request_id`/reserved columns. `batch_size = 1` is always correct, which makes
the discrepancy look batch-size dependent.

## Root cause

In the descending-timestamp path, `predict()`:

1. flips every tensor in `grouped_features` along dim 0 (`_fx_flip_tensor_dict`),
   which reverses both the in-sequence token order **and the request order** in
   the batch;
2. runs the model and flips `mt_preds` **back** to the original request order;
3. but sets the per-request output-split key from the **still-flipped**
   `grouped_features["candidate.sequence_length"]`:

```python
predictions[TARGET_REPEAT_INTERLEAVE_KEY] = grouped_features["candidate.sequence_length"]
```

`_write_predictions` regroups the flat per-candidate predictions into per-request
rows via `cumsum(TARGET_REPEAT_INTERLEAVE_KEY)`. Because the predictions are in
original order but the split key is reversed, the cumulative boundaries diverge
whenever the per-request candidate count (`num_targets`) is not uniform across
the batch. Where all requests share the same candidate count,
`cumsum(reversed) == cumsum(original)` so nothing breaks — which is why only the
requests near a differing-length request are affected, and why `batch_size = 1`
(a single request flips to itself) is always correct. The misaligned span is
exactly the rows between a variable-length request's position and its flip-mirror
within the batch.

## Fix

Capture `candidate.sequence_length` **before** the flip and use that original-order
copy as the split key (the predictions are already flipped back to original
order, so the split key must match):

```python
grouped_features = self.build_input(batch)
num_targets = grouped_features["candidate.sequence_length"]  # original order
if not self._model_config.sequence_timestamp_is_ascending:
    grouped_features = _fx_flip_tensor_dict(grouped_features)
...
predictions[TARGET_REPEAT_INTERLEAVE_KEY] = num_targets
```

## Verification

Re-ran checkpoint prediction on a descending-timestamp DlrmHSTU model with
variable per-request candidate counts. Before the fix a subset of rows did not
match their own per-row reference scores and the affected count changed with
`num_workers` (which alters batch composition); after the fix every output row
matches its reference and the output is identical across `batch_size` and
`num_workers`. The bug also affects the exported/scripted serving graph (same
traced `predict()`), so a re-export is needed to propagate the fix to a deployed
artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
