### PR TITLE
[feat] Kafka: event-time driven checkpointing from message timestamp

### DIFF
--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -63,6 +63,9 @@ LR策略可以支持按epoch更新或者按step更新
 - num_epochs: 训练的epoch数
 - save_checkpoints_steps: 保存模型的步数间隔，保存模型后会做一次评估
 - save_checkpoints_epochs: 保存模型的Epoch数间隔，保存模型后会做一次评估，与save_checkpoints_steps不能同时设置
+- save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个按epoch对齐的间隔边界时保存一次，默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
+- save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的epoch时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
+- checkpoint_timestamp_reduce: 分布式训练下各rank消费的分区不同，事件时间也不同，在触发基于时间的checkpoint前如何对各rank的事件时间做归约，可选"min"（最慢rank越过边界后才保存，默认）或"max"（任一rank越过边界即保存）
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -63,9 +63,9 @@ LR策略可以支持按epoch更新或者按step更新
 - num_epochs: 训练的epoch数
 - save_checkpoints_steps: 保存模型的步数间隔，保存模型后会做一次评估
 - save_checkpoints_epochs: 保存模型的Epoch数间隔，保存模型后会做一次评估，与save_checkpoints_steps不能同时设置
-- save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个按epoch对齐的间隔边界时保存一次，默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
-- save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的epoch时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
-- checkpoint_timestamp_reduce: 分布式训练下各rank消费的分区不同，事件时间也不同，在触发基于时间的checkpoint前如何对各rank的事件时间做归约，可选"min"（最慢rank越过边界后才保存，默认）或"max"（任一rank越过边界即保存）
+- save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次；边界按 Unix 时间(epoch/墙钟)对齐，而非训练 epoch。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
+- save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的 Unix 时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
+- save_checkpoints_timestamp_quorum: 分布式训练下各rank消费的分区不同，事件时间也不同；当至少该比例（取值(0,1\]，默认0.5）的rank已消费越过边界/时间点时才触发保存。1.0表示所有rank都越过才保存（最保守），越小越激进（最小可仅需一个rank）；默认值对单个异常/超前的timestamp具有鲁棒性
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -334,15 +334,15 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 )
             )
 
-        # Extract transient event-time (Unix-epoch seconds) if present. Pop it
-        # unconditionally so it is never parsed as a feature; surface the max valid
-        # (>= 0) value on Batch.data_timestamp, else keep the -1.0 "unavailable"
-        # sentinel. The producer (e.g. KafkaReader) owns the unit; stays unit-agnostic.
+        # Pop the transient event-time column (Unix-epoch seconds) so it is never
+        # parsed as a feature, and surface its max on Batch.data_timestamp. The
+        # -1.0 "unavailable" sentinel sorts below any real time, so max yields the
+        # right value (a real time, or -1.0 when none). Producer owns the unit.
         data_timestamp = -1.0
         ts_col = input_data.pop(DATA_TIMESTAMP, None)
         if ts_col is not None and len(ts_col) > 0:
             max_ts = pc.max(ts_col).as_py()
-            if max_ts is not None and max_ts >= 0:
+            if max_ts is not None:
                 data_timestamp = max_ts
 
         use_sample_mask = self._mode == Mode.TRAIN and (

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -336,9 +336,9 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
 
         # Extract transient event-time (Unix-epoch seconds) if present. Pop it
         # unconditionally so it is never parsed as a feature; surface the max valid
-        # (>= 0; negative is the "unavailable" sentinel) value on Batch.data_timestamp.
-        # The producer (e.g. KafkaReader) owns the unit; this stays unit-agnostic.
-        data_timestamp = None
+        # (>= 0) value on Batch.data_timestamp, else keep the -1.0 "unavailable"
+        # sentinel. The producer (e.g. KafkaReader) owns the unit; stays unit-agnostic.
+        data_timestamp = -1.0
         ts_col = input_data.pop(DATA_TIMESTAMP, None)
         if ts_col is not None and len(ts_col) > 0:
             max_ts = pc.max(ts_col).as_py()

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -334,16 +334,16 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 )
             )
 
-        # Extract transient event-time (raw kafka message timestamp, ms) if present.
-        # Pop unconditionally so it is never parsed as a feature; the max valid
-        # (>= 0) timestamp is normalized to Unix-epoch seconds and surfaced on
-        # Batch.data_timestamp (the unit used by config, watermark and triggers).
+        # Extract transient event-time (Unix-epoch seconds) if present. Pop it
+        # unconditionally so it is never parsed as a feature; surface the max valid
+        # (>= 0; negative is the "unavailable" sentinel) value on Batch.data_timestamp.
+        # The producer (e.g. KafkaReader) owns the unit; this stays unit-agnostic.
         data_timestamp = None
         ts_col = input_data.pop(DATA_TIMESTAMP, None)
         if ts_col is not None and len(ts_col) > 0:
             max_ts = pc.max(ts_col).as_py()
             if max_ts is not None and max_ts >= 0:
-                data_timestamp = max_ts / 1000.0
+                data_timestamp = max_ts
 
         use_sample_mask = self._mode == Mode.TRAIN and (
             self._data_config.negative_sample_mask_prob > 0

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -30,6 +30,7 @@ from tzrec.datasets.utils import (
     CAND_POS_LENGTHS,
     CKPT_ROW_IDX,
     CKPT_SOURCE_ID,
+    DATA_TIMESTAMP,
     HARD_NEG_INDICES,
     Batch,
     RecordBatchTensor,
@@ -333,6 +334,16 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 )
             )
 
+        # Extract transient event-time (kafka message timestamp, ms) if present.
+        # Pop unconditionally so it is never parsed as a feature; the max valid
+        # (>= 0) timestamp in the batch is surfaced on Batch.data_timestamp.
+        data_timestamp = None
+        ts_col = input_data.pop(DATA_TIMESTAMP, None)
+        if ts_col is not None and len(ts_col) > 0:
+            max_ts = pc.max(ts_col).as_py()
+            if max_ts is not None and max_ts >= 0:
+                data_timestamp = max_ts
+
         use_sample_mask = self._mode == Mode.TRAIN and (
             self._data_config.negative_sample_mask_prob > 0
             or self._data_config.sample_mask_prob > 0
@@ -372,6 +383,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
 
         # Set checkpoint info on batch
         batch.checkpoint_info = checkpoint_info
+        batch.data_timestamp = data_timestamp
         return batch
 
     def _apply_negative_sampler(

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -334,15 +334,16 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 )
             )
 
-        # Extract transient event-time (kafka message timestamp, ms) if present.
+        # Extract transient event-time (raw kafka message timestamp, ms) if present.
         # Pop unconditionally so it is never parsed as a feature; the max valid
-        # (>= 0) timestamp in the batch is surfaced on Batch.data_timestamp.
+        # (>= 0) timestamp is normalized to Unix-epoch seconds and surfaced on
+        # Batch.data_timestamp (the unit used by config, watermark and triggers).
         data_timestamp = None
         ts_col = input_data.pop(DATA_TIMESTAMP, None)
         if ts_col is not None and len(ts_col) > 0:
             max_ts = pc.max(ts_col).as_py()
             if max_ts is not None and max_ts >= 0:
-                data_timestamp = max_ts
+                data_timestamp = max_ts / 1000.0
 
         use_sample_mask = self._mode == Mode.TRAIN and (
             self._data_config.negative_sample_mask_prob > 0

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -290,7 +290,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
 
         return rank * num_workers + worker_id, num_workers * world_size
 
-    def load_state_dict(self, state: Optional[Dict[str, int]]) -> None:
+    def load_state_dict(self, state: Optional[Dict[str, Any]]) -> None:
         """Set checkpoint state for resume.
 
         Args:
@@ -540,14 +540,14 @@ class BaseReader(metaclass=_reader_meta_cls):
         self._sample_cost_field = sample_cost_field
         self._batch_cost_size = batch_cost_size
         self._use_sample_cost = False
-        self._checkpoint_state: Optional[Dict[str, int]] = None
+        self._checkpoint_state: Optional[Dict[str, Any]] = None
         if self._batch_cost_size is not None and self._batch_cost_size > 0:
             assert (
                 self._sample_cost_field is not None and len(self._sample_cost_field) > 0
             ), "Should set data_config.sample_cost_field when use batch_cost_size"
             self._use_sample_cost = True
 
-    def load_state_dict(self, state: Optional[Dict[str, int]]) -> None:
+    def load_state_dict(self, state: Optional[Dict[str, Any]]) -> None:
         """Set checkpoint state for resume.
 
         Args:

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -334,10 +334,8 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
                 )
             )
 
-        # Pop the transient event-time column (Unix-epoch seconds) so it is never
-        # parsed as a feature, and surface its max on Batch.data_timestamp. The
-        # -1.0 "unavailable" sentinel sorts below any real time, so max yields the
-        # right value (a real time, or -1.0 when none). Producer owns the unit.
+        # Pop the event-time column (so it's not parsed as a feature) and surface
+        # its max; the -1.0 sentinel sorts below real times, so max is correct.
         data_timestamp = -1.0
         ts_col = input_data.pop(DATA_TIMESTAMP, None)
         if ts_col is not None and len(ts_col) > 0:

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import numpy as np
 import pyarrow as pa
+import torch
 from graphlearn.python.nn.pytorch.data import utils
 from parameterized import parameterized
 from torch.utils.data import DataLoader
@@ -28,8 +29,10 @@ from tzrec.datasets.dataset import BaseDataset, BaseReader
 from tzrec.datasets.utils import (
     BASE_DATA_GROUP,
     CAND_POS_LENGTHS,
+    DATA_TIMESTAMP,
     HARD_NEG_INDICES,
     NEG_DATA_GROUP,
+    Batch,
 )
 from tzrec.features.feature import BaseFeature, create_features
 from tzrec.protos import data_pb2, feature_pb2, sampler_pb2
@@ -222,6 +225,68 @@ class DatasetTest(unittest.TestCase):
         self.assertEqual(batch.sparse_features[BASE_DATA_GROUP].values().size(), (8,))
         self.assertEqual(batch.sparse_features[BASE_DATA_GROUP].lengths().size(), (8,))
         self.assertEqual(batch.labels["label"].size(), (4,))
+
+    def _build_batch_with_columns(self, extra_columns):
+        input_fields = [
+            pa.field(name="int_a", type=pa.int64()),
+            pa.field(name="float_b", type=pa.float64()),
+            pa.field(name="label", type=pa.int32()),
+        ]
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(feature_name="int_a")
+            ),
+            feature_pb2.FeatureConfig(
+                raw_feature=feature_pb2.RawFeature(feature_name="float_b")
+            ),
+        ]
+        dataset = _TestDataset(
+            data_config=data_pb2.DataConfig(
+                batch_size=4,
+                dataset_type=data_pb2.DatasetType.OdpsDataset,
+                fg_mode=data_pb2.FgMode.FG_NONE,
+                label_fields=["label"],
+            ),
+            features=create_features(feature_cfgs),
+            input_path="",
+            input_fields=input_fields,
+            mode=Mode.TRAIN,
+        )
+        input_data = OrderedDict(
+            [
+                ("int_a", pa.array([1, 2, 3, 4], type=pa.int64())),
+                ("float_b", pa.array([1.0, 2.0, 3.0, 4.0], type=pa.float64())),
+                ("label", pa.array([0, 1, 0, 1], type=pa.int32())),
+            ]
+        )
+        input_data.update(extra_columns)
+        return dataset._build_batch(input_data)
+
+    def test_build_batch_data_timestamp(self):
+        # max of the valid (>= 0) event-times; the -1 "no timestamp" is ignored
+        batch = self._build_batch_with_columns(
+            {DATA_TIMESTAMP: pa.array([100, 200, -1, 150], type=pa.int64())}
+        )
+        self.assertEqual(batch.data_timestamp, 200)
+
+    def test_build_batch_data_timestamp_absent(self):
+        # no __data_timestamp__ column (e.g. non-kafka source) -> None
+        batch = self._build_batch_with_columns({})
+        self.assertIsNone(batch.data_timestamp)
+
+    def test_build_batch_data_timestamp_all_invalid(self):
+        # all -1 (topic without timestamps) -> None
+        batch = self._build_batch_with_columns(
+            {DATA_TIMESTAMP: pa.array([-1, -1, -1, -1], type=pa.int64())}
+        )
+        self.assertIsNone(batch.data_timestamp)
+
+    def test_batch_to_and_pin_memory_preserve_data_timestamp(self):
+        # silent-failure guard: .to()/.pin_memory() must keep data_timestamp,
+        # otherwise event-time checkpointing becomes a no-op after the pipeline
+        batch = Batch(data_timestamp=1717000000456)
+        self.assertEqual(batch.to(torch.device("cpu")).data_timestamp, 1717000000456)
+        self.assertEqual(batch.pin_memory().data_timestamp, 1717000000456)
 
     @parameterized.expand(
         [

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -21,7 +21,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from graphlearn.python.nn.pytorch.data import utils
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torch.utils.data import DataLoader
 
 from tzrec.constant import Mode
@@ -262,37 +262,49 @@ class DatasetTest(unittest.TestCase):
         input_data.update(extra_columns)
         return dataset._build_batch(input_data)
 
-    def test_build_batch_data_timestamp(self):
-        # column is event-time in seconds (the reader normalizes); surface the max
-        # valid (>= 0) value, ignoring the -1 "no timestamp" sentinel.
-        batch = self._build_batch_with_columns(
-            {
-                DATA_TIMESTAMP: pa.array(
-                    [1717000000.0, 1717000002.0, -1.0, 1717000001.0],
-                    type=pa.float64(),
-                )
-            }
-        )
-        self.assertEqual(batch.data_timestamp, 1717000002.0)
+    @parameterized.expand(
+        [
+            # column is event-time in seconds (the reader normalizes); surface the
+            # max valid (>= 0) value, ignoring the -1 "no timestamp" sentinel
+            param(
+                "max_valid",
+                columns={
+                    DATA_TIMESTAMP: pa.array(
+                        [1717000000.0, 1717000002.0, -1.0, 1717000001.0],
+                        type=pa.float64(),
+                    )
+                },
+                expected=1717000002.0,
+            ),
+            # no __data_timestamp__ column (e.g. non-kafka source) -> None
+            param("absent", columns={}, expected=None),
+            # all -1 (topic without timestamps) -> None
+            param(
+                "all_invalid",
+                columns={
+                    DATA_TIMESTAMP: pa.array(
+                        [-1.0, -1.0, -1.0, -1.0], type=pa.float64()
+                    )
+                },
+                expected=None,
+            ),
+        ]
+    )
+    def test_build_batch_data_timestamp(self, _name, columns, expected):
+        batch = self._build_batch_with_columns(columns)
+        self.assertEqual(batch.data_timestamp, expected)
 
-    def test_build_batch_data_timestamp_absent(self):
-        # no __data_timestamp__ column (e.g. non-kafka source) -> None
-        batch = self._build_batch_with_columns({})
-        self.assertIsNone(batch.data_timestamp)
-
-    def test_build_batch_data_timestamp_all_invalid(self):
-        # all -1 (topic without timestamps) -> None
-        batch = self._build_batch_with_columns(
-            {DATA_TIMESTAMP: pa.array([-1.0, -1.0, -1.0, -1.0], type=pa.float64())}
-        )
-        self.assertIsNone(batch.data_timestamp)
-
-    def test_batch_to_and_pin_memory_preserve_data_timestamp(self):
-        # silent-failure guard: .to()/.pin_memory() must keep data_timestamp,
-        # otherwise event-time checkpointing becomes a no-op after the pipeline
+    @parameterized.expand(
+        [
+            param("to", apply=lambda b: b.to(torch.device("cpu"))),
+            param("pin_memory", apply=lambda b: b.pin_memory()),
+        ]
+    )
+    def test_batch_copy_preserves_data_timestamp(self, _name, apply):
+        # silent-failure guard: copy methods must keep data_timestamp, otherwise
+        # event-time checkpointing becomes a no-op after the pipeline
         batch = Batch(data_timestamp=1717000000.456)
-        self.assertEqual(batch.to(torch.device("cpu")).data_timestamp, 1717000000.456)
-        self.assertEqual(batch.pin_memory().data_timestamp, 1717000000.456)
+        self.assertEqual(apply(batch).data_timestamp, 1717000000.456)
 
     @parameterized.expand(
         [

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import numpy as np
 import pyarrow as pa
-import torch
 from graphlearn.python.nn.pytorch.data import utils
 from parameterized import param, parameterized
 from torch.utils.data import DataLoader
@@ -32,7 +31,6 @@ from tzrec.datasets.utils import (
     DATA_TIMESTAMP,
     HARD_NEG_INDICES,
     NEG_DATA_GROUP,
-    Batch,
 )
 from tzrec.features.feature import BaseFeature, create_features
 from tzrec.protos import data_pb2, feature_pb2, sampler_pb2
@@ -293,18 +291,6 @@ class DatasetTest(unittest.TestCase):
     def test_build_batch_data_timestamp(self, _name, columns, expected):
         batch = self._build_batch_with_columns(columns)
         self.assertEqual(batch.data_timestamp, expected)
-
-    @parameterized.expand(
-        [
-            param("to", apply=lambda b: b.to(torch.device("cpu"))),
-            param("pin_memory", apply=lambda b: b.pin_memory()),
-        ]
-    )
-    def test_batch_copy_preserves_data_timestamp(self, _name, apply):
-        # silent-failure guard: copy methods must keep data_timestamp, otherwise
-        # event-time checkpointing becomes a no-op after the pipeline
-        batch = Batch(data_timestamp=1717000000.456)
-        self.assertEqual(apply(batch).data_timestamp, 1717000000.456)
 
     @parameterized.expand(
         [

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -263,17 +263,17 @@ class DatasetTest(unittest.TestCase):
         return dataset._build_batch(input_data)
 
     def test_build_batch_data_timestamp(self):
-        # max of the valid (>= 0) raw-ms event-times, normalized to seconds; the
-        # -1 "no timestamp" is ignored. 1717000002000 ms -> 1717000002.0 s
+        # column is event-time in seconds (the reader normalizes); surface the max
+        # valid (>= 0) value, ignoring the -1 "no timestamp" sentinel.
         batch = self._build_batch_with_columns(
             {
                 DATA_TIMESTAMP: pa.array(
-                    [1717000000000, 1717000002000, -1, 1717000001000],
-                    type=pa.int64(),
+                    [1717000000.0, 1717000002.0, -1.0, 1717000001.0],
+                    type=pa.float64(),
                 )
             }
         )
-        self.assertAlmostEqual(batch.data_timestamp, 1717000002.0, places=3)
+        self.assertEqual(batch.data_timestamp, 1717000002.0)
 
     def test_build_batch_data_timestamp_absent(self):
         # no __data_timestamp__ column (e.g. non-kafka source) -> None
@@ -283,7 +283,7 @@ class DatasetTest(unittest.TestCase):
     def test_build_batch_data_timestamp_all_invalid(self):
         # all -1 (topic without timestamps) -> None
         batch = self._build_batch_with_columns(
-            {DATA_TIMESTAMP: pa.array([-1, -1, -1, -1], type=pa.int64())}
+            {DATA_TIMESTAMP: pa.array([-1.0, -1.0, -1.0, -1.0], type=pa.float64())}
         )
         self.assertIsNone(batch.data_timestamp)
 

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -276,9 +276,9 @@ class DatasetTest(unittest.TestCase):
                 },
                 expected=1717000002.0,
             ),
-            # no __data_timestamp__ column (e.g. non-kafka source) -> None
-            param("absent", columns={}, expected=None),
-            # all -1 (topic without timestamps) -> None
+            # no __data_timestamp__ column (e.g. non-kafka source) -> -1.0 sentinel
+            param("absent", columns={}, expected=-1.0),
+            # all -1 (topic without timestamps) -> -1.0 sentinel
             param(
                 "all_invalid",
                 columns={
@@ -286,7 +286,7 @@ class DatasetTest(unittest.TestCase):
                         [-1.0, -1.0, -1.0, -1.0], type=pa.float64()
                     )
                 },
-                expected=None,
+                expected=-1.0,
             ),
         ]
     )

--- a/tzrec/datasets/dataset_test.py
+++ b/tzrec/datasets/dataset_test.py
@@ -263,11 +263,17 @@ class DatasetTest(unittest.TestCase):
         return dataset._build_batch(input_data)
 
     def test_build_batch_data_timestamp(self):
-        # max of the valid (>= 0) event-times; the -1 "no timestamp" is ignored
+        # max of the valid (>= 0) raw-ms event-times, normalized to seconds; the
+        # -1 "no timestamp" is ignored. 1717000002000 ms -> 1717000002.0 s
         batch = self._build_batch_with_columns(
-            {DATA_TIMESTAMP: pa.array([100, 200, -1, 150], type=pa.int64())}
+            {
+                DATA_TIMESTAMP: pa.array(
+                    [1717000000000, 1717000002000, -1, 1717000001000],
+                    type=pa.int64(),
+                )
+            }
         )
-        self.assertEqual(batch.data_timestamp, 200)
+        self.assertAlmostEqual(batch.data_timestamp, 1717000002.0, places=3)
 
     def test_build_batch_data_timestamp_absent(self):
         # no __data_timestamp__ column (e.g. non-kafka source) -> None
@@ -284,9 +290,9 @@ class DatasetTest(unittest.TestCase):
     def test_batch_to_and_pin_memory_preserve_data_timestamp(self):
         # silent-failure guard: .to()/.pin_memory() must keep data_timestamp,
         # otherwise event-time checkpointing becomes a no-op after the pipeline
-        batch = Batch(data_timestamp=1717000000456)
-        self.assertEqual(batch.to(torch.device("cpu")).data_timestamp, 1717000000456)
-        self.assertEqual(batch.pin_memory().data_timestamp, 1717000000456)
+        batch = Batch(data_timestamp=1717000000.456)
+        self.assertEqual(batch.to(torch.device("cpu")).data_timestamp, 1717000000.456)
+        self.assertEqual(batch.pin_memory().data_timestamp, 1717000000.456)
 
     @parameterized.expand(
         [

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -413,9 +413,8 @@ class KafkaReader(BaseReader):
                     source_ids.extend([source_id] * batch_len)
                     # Use offset as the row index (each message has one offset)
                     row_indices.extend([offset] * batch_len)
-                    # msg.timestamp() -> (type, ms); ms is -1 when unavailable.
-                    # Normalize to Unix-epoch seconds (the unit used downstream),
-                    # keeping -1 as the "unavailable" sentinel.
+                    # msg.timestamp() -> (type, ms), -1 when unavailable; use
+                    # Unix-epoch seconds and keep -1 as the sentinel.
                     ts_ms = msg.timestamp()[1]
                     ts_s = ts_ms / 1000.0 if ts_ms >= 0 else -1.0
                     timestamps.extend([ts_s] * batch_len)

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -413,11 +413,9 @@ class KafkaReader(BaseReader):
                     source_ids.extend([source_id] * batch_len)
                     # Use offset as the row index (each message has one offset)
                     row_indices.extend([offset] * batch_len)
-                    # msg.timestamp() -> (timestamp_type, timestamp_ms); the value
-                    # is -1 when the topic has no timestamps
-                    # (TIMESTAMP_NOT_AVAILABLE). Normalize ms -> Unix-epoch seconds
-                    # here (the unit used by Batch.data_timestamp / config / the
-                    # save triggers); keep -1 as the "unavailable" sentinel.
+                    # msg.timestamp() -> (type, ms); ms is -1 when unavailable.
+                    # Normalize to Unix-epoch seconds (the unit used downstream),
+                    # keeping -1 as the "unavailable" sentinel.
                     ts_ms = msg.timestamp()[1]
                     ts_s = ts_ms / 1000.0 if ts_ms >= 0 else -1.0
                     timestamps.extend([ts_s] * batch_len)
@@ -448,8 +446,7 @@ class KafkaReader(BaseReader):
                 t = t.append_column(
                     CKPT_ROW_IDX, pa.array(row_indices, type=pa.int64())
                 )
-                # Add transient event-time column in seconds (consumed in
-                # _build_batch to set Batch.data_timestamp; not checkpoint state).
+                # transient event-time column (seconds), read in _build_batch
                 t = t.append_column(
                     DATA_TIMESTAMP, pa.array(timestamps, type=pa.float64())
                 )

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -24,6 +24,7 @@ from tzrec.datasets.dataset import BaseDataset, BaseReader
 from tzrec.datasets.utils import (
     CKPT_ROW_IDX,
     CKPT_SOURCE_ID,
+    DATA_TIMESTAMP,
     FIELD_TYPE_TO_PA,
     get_input_fields_proto,
 )
@@ -376,6 +377,8 @@ class KafkaReader(BaseReader):
                 # Track checkpoint metadata for each message
                 source_ids = []
                 row_indices = []
+                # Track event-time (kafka message timestamp, ms) for each message
+                timestamps = []
 
                 for msg in messages:
                     msg_error = msg.error()
@@ -410,6 +413,10 @@ class KafkaReader(BaseReader):
                     source_ids.extend([source_id] * batch_len)
                     # Use offset as the row index (each message has one offset)
                     row_indices.extend([offset] * batch_len)
+                    # msg.timestamp() -> (timestamp_type, timestamp_ms); the value is
+                    # -1 when the topic has no timestamps (TIMESTAMP_NOT_AVAILABLE).
+                    ts_ms = msg.timestamp()[1]
+                    timestamps.extend([ts_ms] * batch_len)
 
                 if not record_batchs:
                     continue
@@ -436,6 +443,11 @@ class KafkaReader(BaseReader):
                 )
                 t = t.append_column(
                     CKPT_ROW_IDX, pa.array(row_indices, type=pa.int64())
+                )
+                # Add transient event-time column (consumed downstream in _build_batch
+                # to set Batch.data_timestamp; not part of the checkpoint state).
+                t = t.append_column(
+                    DATA_TIMESTAMP, pa.array(timestamps, type=pa.int64())
                 )
 
                 for batch in t.to_batches():

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -377,7 +377,7 @@ class KafkaReader(BaseReader):
                 # Track checkpoint metadata for each message
                 source_ids = []
                 row_indices = []
-                # Track event-time (kafka message timestamp, ms) for each message
+                # Track event-time (Unix-epoch seconds) for each message
                 timestamps = []
 
                 for msg in messages:
@@ -413,10 +413,14 @@ class KafkaReader(BaseReader):
                     source_ids.extend([source_id] * batch_len)
                     # Use offset as the row index (each message has one offset)
                     row_indices.extend([offset] * batch_len)
-                    # msg.timestamp() -> (timestamp_type, timestamp_ms); the value is
-                    # -1 when the topic has no timestamps (TIMESTAMP_NOT_AVAILABLE).
+                    # msg.timestamp() -> (timestamp_type, timestamp_ms); the value
+                    # is -1 when the topic has no timestamps
+                    # (TIMESTAMP_NOT_AVAILABLE). Normalize ms -> Unix-epoch seconds
+                    # here (the unit used by Batch.data_timestamp / config / the
+                    # save triggers); keep -1 as the "unavailable" sentinel.
                     ts_ms = msg.timestamp()[1]
-                    timestamps.extend([ts_ms] * batch_len)
+                    ts_s = ts_ms / 1000.0 if ts_ms >= 0 else -1.0
+                    timestamps.extend([ts_s] * batch_len)
 
                 if not record_batchs:
                     continue
@@ -444,10 +448,10 @@ class KafkaReader(BaseReader):
                 t = t.append_column(
                     CKPT_ROW_IDX, pa.array(row_indices, type=pa.int64())
                 )
-                # Add transient event-time column (consumed downstream in _build_batch
-                # to set Batch.data_timestamp; not part of the checkpoint state).
+                # Add transient event-time column in seconds (consumed in
+                # _build_batch to set Batch.data_timestamp; not checkpoint state).
                 t = t.append_column(
-                    DATA_TIMESTAMP, pa.array(timestamps, type=pa.int64())
+                    DATA_TIMESTAMP, pa.array(timestamps, type=pa.float64())
                 )
 
                 for batch in t.to_batches():

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -307,9 +307,7 @@ class KafkaDatasetTest(unittest.TestCase):
             self.assertIsInstance(value, int)
             self.assertGreaterEqual(value, 0)
 
-        # Event-time should be surfaced from the kafka message timestamps (the
-        # producer stamps create-time), as positive Unix-epoch seconds (float;
-        # -1.0 only when the topic has no timestamps).
+        # event-time in positive Unix-epoch seconds (-1.0 only without timestamps)
         self.assertIsInstance(batch.data_timestamp, float)
         self.assertGreater(batch.data_timestamp, 0)
 

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -308,8 +308,8 @@ class KafkaDatasetTest(unittest.TestCase):
             self.assertGreaterEqual(value, 0)
 
         # Event-time should be surfaced from the kafka message timestamps (the
-        # producer stamps create-time), as positive Unix-epoch seconds (float).
-        self.assertIsNotNone(batch.data_timestamp)
+        # producer stamps create-time), as positive Unix-epoch seconds (float;
+        # -1.0 only when the topic has no timestamps).
         self.assertIsInstance(batch.data_timestamp, float)
         self.assertGreater(batch.data_timestamp, 0)
 

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -307,6 +307,12 @@ class KafkaDatasetTest(unittest.TestCase):
             self.assertIsInstance(value, int)
             self.assertGreaterEqual(value, 0)
 
+        # Event-time should be surfaced from the kafka message timestamps (the
+        # producer stamps create-time), as a positive epoch-ms integer.
+        self.assertIsNotNone(batch.data_timestamp)
+        self.assertIsInstance(batch.data_timestamp, int)
+        self.assertGreater(batch.data_timestamp, 0)
+
     @unittest.skipIf(
         os.environ.get("CI_ALIKAFKA_INSTANCE_ID", "") == "", "ci kafka is not exists."
     )

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -308,9 +308,9 @@ class KafkaDatasetTest(unittest.TestCase):
             self.assertGreaterEqual(value, 0)
 
         # Event-time should be surfaced from the kafka message timestamps (the
-        # producer stamps create-time), as a positive epoch-ms integer.
+        # producer stamps create-time), as positive Unix-epoch seconds (float).
         self.assertIsNotNone(batch.data_timestamp)
-        self.assertIsInstance(batch.data_timestamp, int)
+        self.assertIsInstance(batch.data_timestamp, float)
         self.assertGreater(batch.data_timestamp, 0)
 
     @unittest.skipIf(

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -38,9 +38,8 @@ CAND_POS_LENGTHS = "cand_pos_lengths"
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
 CKPT_ROW_IDX = "__ckpt_row_idx__"  # int64 column for absolute row index
-# Transient per-row event-time column in Unix-epoch seconds (-1 when unavailable),
-# produced by the source reader (e.g. KafkaReader normalizes its ms timestamp).
-# Surfaced as the per-batch max on Batch.data_timestamp; not persisted.
+# Transient event-time column (Unix-epoch seconds, -1 when unavailable) set by the
+# source reader; surfaced as the per-batch max on Batch.data_timestamp, not persisted.
 DATA_TIMESTAMP = "__data_timestamp__"  # float64 column, event-time (seconds)
 
 
@@ -339,9 +338,8 @@ class Batch(Pipelineable):
     dummy: bool = field(default=False)
     # checkpoint info: {source_key: max_abs_row}
     checkpoint_info: Optional[Dict[str, int]] = field(default=None)
-    # max event-time (Unix-epoch seconds) consumed in this batch, or -1.0 when the
-    # source has no timestamps (e.g. non-kafka datasets). normalized from the raw
-    # kafka message timestamp (ms) in BaseDataset._build_batch.
+    # max event-time (Unix-epoch seconds) consumed in this batch, -1.0 when the
+    # source has no timestamps (e.g. non-kafka datasets)
     data_timestamp: float = field(default=-1.0)
 
     def to(self, device: torch.device, non_blocking: bool = False) -> "Batch":

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -339,10 +339,10 @@ class Batch(Pipelineable):
     dummy: bool = field(default=False)
     # checkpoint info: {source_key: max_abs_row}
     checkpoint_info: Optional[Dict[str, int]] = field(default=None)
-    # max event-time (Unix-epoch seconds) consumed in this batch, or None when the
+    # max event-time (Unix-epoch seconds) consumed in this batch, or -1.0 when the
     # source has no timestamps (e.g. non-kafka datasets). normalized from the raw
     # kafka message timestamp (ms) in BaseDataset._build_batch.
-    data_timestamp: Optional[float] = field(default=None)
+    data_timestamp: float = field(default=-1.0)
 
     def to(self, device: torch.device, non_blocking: bool = False) -> "Batch":
         """Copy to specified device."""

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -38,8 +38,8 @@ CAND_POS_LENGTHS = "cand_pos_lengths"
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
 CKPT_ROW_IDX = "__ckpt_row_idx__"  # int64 column for absolute row index
-# Transient event-time column (Unix-epoch seconds, -1 when unavailable) set by the
-# source reader; surfaced as the per-batch max on Batch.data_timestamp, not persisted.
+# transient event-time column (Unix-epoch seconds, -1 when unavailable); its
+# per-batch max is surfaced on Batch.data_timestamp.
 DATA_TIMESTAMP = "__data_timestamp__"  # float64 column, event-time (seconds)
 
 
@@ -338,8 +338,7 @@ class Batch(Pipelineable):
     dummy: bool = field(default=False)
     # checkpoint info: {source_key: max_abs_row}
     checkpoint_info: Optional[Dict[str, int]] = field(default=None)
-    # max event-time (Unix-epoch seconds) consumed in this batch, -1.0 when the
-    # source has no timestamps (e.g. non-kafka datasets)
+    # max event-time (Unix-epoch seconds) in this batch, -1.0 when unavailable
     data_timestamp: float = field(default=-1.0)
 
     def to(self, device: torch.device, non_blocking: bool = False) -> "Batch":

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -38,10 +38,10 @@ CAND_POS_LENGTHS = "cand_pos_lengths"
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
 CKPT_ROW_IDX = "__ckpt_row_idx__"  # int64 column for absolute row index
-# Transient per-row event-time column carrying the RAW kafka message timestamp in
-# ms (-1 when unavailable). Normalized to Unix-epoch seconds on Batch.data_timestamp
-# in _build_batch; not persisted into the checkpoint state.
-DATA_TIMESTAMP = "__data_timestamp__"  # int64 column, raw event-time (ms)
+# Transient per-row event-time column in Unix-epoch seconds (-1 when unavailable),
+# produced by the source reader (e.g. KafkaReader normalizes its ms timestamp).
+# Surfaced as the per-batch max on Batch.data_timestamp; not persisted.
+DATA_TIMESTAMP = "__data_timestamp__"  # float64 column, event-time (seconds)
 
 
 def inject_checkpoint_metadata(

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -38,10 +38,10 @@ CAND_POS_LENGTHS = "cand_pos_lengths"
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
 CKPT_ROW_IDX = "__ckpt_row_idx__"  # int64 column for absolute row index
-# Transient per-row event-time (kafka message timestamp, ms since epoch); -1 when
-# unavailable. Not persisted into the checkpoint state, only surfaced on
-# Batch.data_timestamp.
-DATA_TIMESTAMP = "__data_timestamp__"  # int64 column for event-time (ms)
+# Transient per-row event-time column carrying the RAW kafka message timestamp in
+# ms (-1 when unavailable). Normalized to Unix-epoch seconds on Batch.data_timestamp
+# in _build_batch; not persisted into the checkpoint state.
+DATA_TIMESTAMP = "__data_timestamp__"  # int64 column, raw event-time (ms)
 
 
 def inject_checkpoint_metadata(
@@ -339,9 +339,10 @@ class Batch(Pipelineable):
     dummy: bool = field(default=False)
     # checkpoint info: {source_key: max_abs_row}
     checkpoint_info: Optional[Dict[str, int]] = field(default=None)
-    # max event-time (kafka message timestamp, ms since epoch) consumed in this batch,
-    # or None when the source has no timestamps (e.g. non-kafka datasets)
-    data_timestamp: Optional[int] = field(default=None)
+    # max event-time (Unix-epoch seconds) consumed in this batch, or None when the
+    # source has no timestamps (e.g. non-kafka datasets). normalized from the raw
+    # kafka message timestamp (ms) in BaseDataset._build_batch.
+    data_timestamp: Optional[float] = field(default=None)
 
     def to(self, device: torch.device, non_blocking: bool = False) -> "Batch":
         """Copy to specified device."""

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -38,6 +38,10 @@ CAND_POS_LENGTHS = "cand_pos_lengths"
 # Checkpoint metadata column names injected into RecordBatch
 CKPT_SOURCE_ID = "__ckpt_source_id__"  # string column for checkpoint source identifier
 CKPT_ROW_IDX = "__ckpt_row_idx__"  # int64 column for absolute row index
+# Transient per-row event-time (kafka message timestamp, ms since epoch); -1 when
+# unavailable. Not persisted into the checkpoint state, only surfaced on
+# Batch.data_timestamp.
+DATA_TIMESTAMP = "__data_timestamp__"  # int64 column for event-time (ms)
 
 
 def inject_checkpoint_metadata(
@@ -335,6 +339,9 @@ class Batch(Pipelineable):
     dummy: bool = field(default=False)
     # checkpoint info: {source_key: max_abs_row}
     checkpoint_info: Optional[Dict[str, int]] = field(default=None)
+    # max event-time (kafka message timestamp, ms since epoch) consumed in this batch,
+    # or None when the source has no timestamps (e.g. non-kafka datasets)
+    data_timestamp: Optional[int] = field(default=None)
 
     def to(self, device: torch.device, non_blocking: bool = False) -> "Batch":
         """Copy to specified device."""
@@ -375,6 +382,7 @@ class Batch(Pipelineable):
             },
             dummy=self.dummy,
             checkpoint_info=self.checkpoint_info,
+            data_timestamp=self.data_timestamp,
         )
 
     def record_stream(self, stream: torch.Stream) -> None:
@@ -453,6 +461,7 @@ class Batch(Pipelineable):
             },
             dummy=self.dummy,
             checkpoint_info=self.checkpoint_info,
+            data_timestamp=self.data_timestamp,
         )
 
     def to_dict(

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -330,7 +330,7 @@ def _train_and_evaluate(
     eval_result_filename: str = TRAIN_EVAL_RESULT_FILENAME,
     check_all_workers_data_status: bool = False,
     ignore_restore_optimizer: bool = False,
-    dataloader_state: Optional[Dict[str, int]] = None,
+    dataloader_state: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Train and evaluate the model."""
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
@@ -367,7 +367,11 @@ def _train_and_evaluate(
         train_config.save_checkpoints_timestamp_quorum,
     )
     need_ts = ckpt_manager.needs_worker_timestamps()
-    ts_device = next(model.parameters()).device if need_ts else None
+    # dedicated CPU (gloo) group so the per-step event-time gather stays off the
+    # GPU and never forces a device sync that would stall the prefetch pipeline.
+    ts_pg = (
+        dist.new_group(backend="gloo") if need_ts and dist.is_initialized() else None
+    )
 
     plogger = None
     summary_writer = None
@@ -491,9 +495,7 @@ def _train_and_evaluate(
             # in lockstep (same equal-step-count invariant the model's gradient
             # collectives already require).
             worker_ts = (
-                gather_float_scalar(batch.data_timestamp, ts_device)
-                if need_ts
-                else None
+                gather_float_scalar(batch.data_timestamp, ts_pg) if need_ts else None
             )
             # Single entry point for step / epoch / event-time saves + dedupe.
             if ckpt_manager.maybe_save(
@@ -638,7 +640,7 @@ def train_and_evaluate(
                 )
 
     # Restore dataloader checkpoint state
-    dataloader_state: Optional[Dict[str, int]] = None
+    dataloader_state: Optional[Dict[str, Any]] = None
     if ckpt_path and continue_train:
         dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
         if dataloader_state:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -356,6 +356,19 @@ def _train_and_evaluate(
     else:
         save_checkpoints_steps = train_config.save_checkpoints_steps
 
+    # Event-time (consumed data timestamp, e.g. kafka message timestamp) driven
+    # checkpointing. ts_trigger_active is config-derived so it is identical on all
+    # ranks, keeping the per-step cross-rank all-reduce below collective-safe.
+    ts_interval_s = train_config.save_checkpoints_timestamp_interval
+    ts_targets = list(train_config.save_checkpoints_timestamps)
+    ts_reduce = train_config.checkpoint_timestamp_reduce or "min"
+    if ts_reduce not in ("min", "max"):
+        raise ValueError(
+            "train_config.checkpoint_timestamp_reduce must be 'min' or 'max', "
+            f"got {ts_reduce!r}."
+        )
+    ts_trigger_active = ts_interval_s > 0 or len(ts_targets) > 0
+
     plogger = None
     summary_writer = None
     eval_summary_writer = None
@@ -396,9 +409,34 @@ def _train_and_evaluate(
         prof.start()
 
     last_ckpt_step = -1
+    # event-time at the last timestamp-triggered save (seconds since epoch); None
+    # until the first batch with a valid timestamp establishes the reference.
+    last_ckpt_data_ts_s: Optional[float] = None
+    ts_device = None
+    if ts_trigger_active:
+        ts_device = next(model.parameters()).device
     i_step = 0
     i_epoch = 0
     losses = {}
+
+    def do_checkpoint(step: int) -> None:
+        """Save a checkpoint (and run eval, if configured) at the given step."""
+        nonlocal last_ckpt_step
+        last_ckpt_step = step
+        ckpt_manager.save(step, model, optimizer, dataloader_state)
+        if eval_dataloader is not None:
+            _evaluate(
+                model,
+                eval_dataloader,
+                eval_config,
+                eval_result_filename=eval_result_filename,
+                global_step=step,
+                eval_summary_writer=eval_summary_writer,
+                global_epoch=i_epoch,
+                check_all_workers_data_status=check_all_workers_data_status,
+            )
+            model.train()
+
     for i_epoch in epoch_iter:
         pipeline = create_train_pipeline(
             model,
@@ -459,39 +497,63 @@ def _train_and_evaluate(
 
             if save_checkpoints_steps > 0 and i_step > 0:
                 if i_step % save_checkpoints_steps == 0:
-                    last_ckpt_step = i_step
-                    ckpt_manager.save(i_step, model, optimizer, dataloader_state)
-                    if eval_dataloader is not None:
-                        _evaluate(
-                            model,
-                            eval_dataloader,
-                            eval_config,
-                            eval_result_filename=eval_result_filename,
-                            global_step=i_step,
-                            eval_summary_writer=eval_summary_writer,
-                            global_epoch=i_epoch,
-                            check_all_workers_data_status=check_all_workers_data_status,
-                        )
-                        model.train()
+                    do_checkpoint(i_step)
+
+            if ts_trigger_active:
+                # Reconcile each rank's consumed event-time before deciding to save
+                # (the save below is collective). Ranks without a timestamp this step
+                # contribute a neutral sentinel so they neither skew nor skip the
+                # collective. The all-reduce is gated only by the config-derived
+                # ts_trigger_active, so every rank participates.
+                if ts_reduce == "min":
+                    reduce_op = dist.ReduceOp.MIN
+                    local_ts_s = (
+                        batch.data_timestamp / 1000.0
+                        if batch.data_timestamp is not None
+                        else float("inf")
+                    )
+                else:
+                    reduce_op = dist.ReduceOp.MAX
+                    local_ts_s = (
+                        batch.data_timestamp / 1000.0
+                        if batch.data_timestamp is not None
+                        else float("-inf")
+                    )
+                if dist.is_initialized():
+                    ts_tensor = torch.tensor(
+                        [local_ts_s], dtype=torch.float64, device=ts_device
+                    )
+                    dist.all_reduce(ts_tensor, op=reduce_op)
+                    global_ts_s = ts_tensor.item()
+                else:
+                    global_ts_s = local_ts_s
+                # global_ts_s stays at the sentinel only when no rank had a valid
+                # timestamp this step; skip those steps.
+                if global_ts_s not in (float("inf"), float("-inf")):
+                    if last_ckpt_data_ts_s is None:
+                        # First observed event-time: set the reference, do not save.
+                        last_ckpt_data_ts_s = global_ts_s
+                    elif checkpoint_util.should_save_on_timestamp(
+                        global_ts_s,
+                        last_ckpt_data_ts_s,
+                        ts_interval_s,
+                        ts_targets,
+                    ):
+                        last_ckpt_data_ts_s = global_ts_s
+                        # Avoid double-saving when a step trigger already fired here.
+                        if i_step != last_ckpt_step:
+                            logger.info(
+                                f"saving checkpoint at step {i_step}, triggered by "
+                                f"consumed event-time {global_ts_s:.0f}s "
+                                f"(reduce={ts_reduce})"
+                            )
+                            do_checkpoint(i_step)
             if train_config.is_profiling:
                 prof.step()
 
         if save_checkpoints_epochs > 0 and i_step > 0:
             if (i_epoch + 1) % save_checkpoints_epochs == 0:
-                last_ckpt_step = i_step
-                ckpt_manager.save(i_step, model, optimizer, dataloader_state)
-                if eval_dataloader is not None:
-                    _evaluate(
-                        model,
-                        eval_dataloader,
-                        eval_config,
-                        eval_result_filename=eval_result_filename,
-                        global_step=i_step,
-                        eval_summary_writer=eval_summary_writer,
-                        global_epoch=i_epoch,
-                        check_all_workers_data_status=check_all_workers_data_status,
-                    )
-                    model.train()
+                do_checkpoint(i_step)
 
         if use_step and i_step >= train_config.num_steps - 1:
             break
@@ -514,19 +576,7 @@ def _train_and_evaluate(
     if train_config.is_profiling:
         prof.stop()
     if last_ckpt_step != i_step:
-        ckpt_manager.save(i_step, model, optimizer, dataloader_state)
-        if eval_dataloader is not None:
-            _evaluate(
-                model,
-                eval_dataloader,
-                eval_config,
-                eval_result_filename=eval_result_filename,
-                global_step=i_step,
-                eval_summary_writer=eval_summary_writer,
-                global_epoch=i_epoch,
-                check_all_workers_data_status=check_all_workers_data_status,
-            )
-            model.train()
+        do_checkpoint(i_step)
     ckpt_manager.close()
 
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -82,6 +82,7 @@ from tzrec.utils.dist_util import (
     DistributedModelParallel,
     PredictPipelineSparseDist,
     create_train_pipeline,
+    gather_float_scalar,
     init_process_group,
 )
 from tzrec.utils.export_util import export_model
@@ -314,23 +315,6 @@ def _log_train(
                 summary_writer.add_scalar(f"metric/{k}", v, step)
 
 
-def _gather_worker_event_times(
-    data_timestamp_s: float, device: Optional[torch.device]
-) -> List[float]:
-    """All-gather each rank's consumed event-time (seconds) for the save quorum.
-
-    Ranks without a timestamp this step carry the -1.0 sentinel, which is filtered
-    out so the returned list holds only the valid per-worker event-times.
-    """
-    if dist.is_initialized():
-        world_size = dist.get_world_size()
-        local_t = torch.tensor([data_timestamp_s], dtype=torch.float64, device=device)
-        gathered = torch.empty(world_size, dtype=torch.float64, device=device)
-        dist.all_gather_into_tensor(gathered, local_t)
-        return [v for v in gathered.tolist() if v >= 0]
-    return [data_timestamp_s] if data_timestamp_s >= 0 else []
-
-
 def _train_and_evaluate(
     model: nn.Module,
     optimizer: optim.Optimizer,
@@ -373,8 +357,7 @@ def _train_and_evaluate(
     else:
         save_checkpoints_steps = train_config.save_checkpoints_steps
 
-    # Centralize the save cadence (step / epoch / consumed-event-time) in the
-    # CheckpointManager. It owns the dedupe and the event-time watermark; the loop
+    # The CheckpointManager owns the save cadence + dedupe + watermark; the loop
     # only gathers per-worker event-times and runs eval after a save.
     ckpt_manager.set_save_policy(
         save_checkpoints_steps,
@@ -504,13 +487,11 @@ def _train_and_evaluate(
                 i_step -= 1
                 break
 
-            # Gather each rank's consumed event-time for the timestamp trigger.
-            # Done in lockstep across ranks under the same equal-step-count
-            # invariant the model's own gradient collectives already require: a
-            # rank that drains first hangs at the gradient all-reduce inside
-            # pipeline.progress before ever reaching here.
+            # Gather each rank's consumed event-time for the timestamp trigger,
+            # in lockstep (same equal-step-count invariant the model's gradient
+            # collectives already require).
             worker_ts = (
-                _gather_worker_event_times(batch.data_timestamp, ts_device)
+                gather_float_scalar(batch.data_timestamp, ts_device)
                 if need_ts
                 else None
             )

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -82,7 +82,6 @@ from tzrec.utils.dist_util import (
     DistributedModelParallel,
     PredictPipelineSparseDist,
     create_train_pipeline,
-    gather_float_scalar,
     init_process_group,
 )
 from tzrec.utils.export_util import export_model
@@ -366,12 +365,6 @@ def _train_and_evaluate(
         list(train_config.save_checkpoints_timestamps),
         train_config.save_checkpoints_timestamp_quorum,
     )
-    need_ts = ckpt_manager.needs_worker_timestamps()
-    # dedicated CPU (gloo) group so the per-step event-time gather stays off the
-    # GPU and never forces a device sync that would stall the prefetch pipeline.
-    ts_pg = (
-        dist.new_group(backend="gloo") if need_ts and dist.is_initialized() else None
-    )
 
     plogger = None
     summary_writer = None
@@ -431,8 +424,8 @@ def _train_and_evaluate(
             )
             model.train()
 
-    # last gathered per-worker event-times, reused by the epoch / final saves
-    worker_ts: Optional[List[float]] = None
+    # this rank's last consumed event-time, reused by the epoch / final saves
+    data_timestamp = -1.0
     for i_epoch in epoch_iter:
         pipeline = create_train_pipeline(
             model,
@@ -491,15 +484,15 @@ def _train_and_evaluate(
                 i_step -= 1
                 break
 
-            # Gather each rank's consumed event-time for the timestamp trigger,
-            # in lockstep (same equal-step-count invariant the model's gradient
-            # collectives already require).
-            worker_ts = (
-                gather_float_scalar(batch.data_timestamp, ts_pg) if need_ts else None
-            )
-            # Single entry point for step / epoch / event-time saves + dedupe.
+            # Single entry point for step / epoch / event-time saves + dedupe;
+            # maybe_save reconciles this rank's event-time across ranks in lockstep.
+            data_timestamp = batch.data_timestamp
             if ckpt_manager.maybe_save(
-                i_step, model, optimizer, dataloader_state, worker_ts_list=worker_ts
+                i_step,
+                model,
+                optimizer,
+                dataloader_state,
+                data_timestamp=data_timestamp,
             ):
                 run_eval(i_step, i_epoch)
             if train_config.is_profiling:
@@ -511,7 +504,7 @@ def _train_and_evaluate(
             optimizer,
             dataloader_state,
             epoch=i_epoch,
-            worker_ts_list=worker_ts,
+            data_timestamp=data_timestamp,
         ):
             run_eval(i_step, i_epoch)
 
@@ -536,7 +529,12 @@ def _train_and_evaluate(
     if train_config.is_profiling:
         prof.stop()
     if ckpt_manager.maybe_save(
-        i_step, model, optimizer, dataloader_state, worker_ts_list=worker_ts, final=True
+        i_step,
+        model,
+        optimizer,
+        dataloader_state,
+        data_timestamp=data_timestamp,
+        final=True,
     ):
         run_eval(i_step, i_epoch)
     ckpt_manager.close()

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -316,7 +316,7 @@ def _log_train(
 
 
 def _gather_worker_event_times(
-    data_timestamp_ms: Optional[int], device: Optional[torch.device]
+    data_timestamp_s: Optional[float], device: Optional[torch.device]
 ) -> List[float]:
     """All-gather each rank's consumed event-time (seconds) for the save quorum.
 
@@ -324,9 +324,7 @@ def _gather_worker_event_times(
     the returned list holds only the valid per-worker event-times. all_gather
     (not all_reduce) is used so a NaN never poisons the others.
     """
-    local = (
-        data_timestamp_ms / 1000.0 if data_timestamp_ms is not None else float("nan")
-    )
+    local = data_timestamp_s if data_timestamp_s is not None else float("nan")
     if dist.is_initialized():
         world_size = dist.get_world_size()
         local_t = torch.tensor([local], dtype=torch.float64, device=device)

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -12,6 +12,7 @@
 import copy
 import itertools
 import json
+import math
 import os
 from collections import OrderedDict
 from queue import Queue
@@ -314,6 +315,27 @@ def _log_train(
                 summary_writer.add_scalar(f"metric/{k}", v, step)
 
 
+def _gather_worker_event_times(
+    data_timestamp_ms: Optional[int], device: Optional[torch.device]
+) -> List[float]:
+    """All-gather each rank's consumed event-time (seconds) for the save quorum.
+
+    Ranks without a timestamp this step contribute a NaN that is filtered out, so
+    the returned list holds only the valid per-worker event-times. all_gather
+    (not all_reduce) is used so a NaN never poisons the others.
+    """
+    local = (
+        data_timestamp_ms / 1000.0 if data_timestamp_ms is not None else float("nan")
+    )
+    if dist.is_initialized():
+        world_size = dist.get_world_size()
+        local_t = torch.tensor([local], dtype=torch.float64, device=device)
+        gathered = torch.empty(world_size, dtype=torch.float64, device=device)
+        dist.all_gather_into_tensor(gathered, local_t)
+        return [v for v in gathered.tolist() if not math.isnan(v)]
+    return [] if math.isnan(local) else [local]
+
+
 def _train_and_evaluate(
     model: nn.Module,
     optimizer: optim.Optimizer,
@@ -356,18 +378,18 @@ def _train_and_evaluate(
     else:
         save_checkpoints_steps = train_config.save_checkpoints_steps
 
-    # Event-time (consumed data timestamp, e.g. kafka message timestamp) driven
-    # checkpointing. ts_trigger_active is config-derived so it is identical on all
-    # ranks, keeping the per-step cross-rank all-reduce below collective-safe.
-    ts_interval_s = train_config.save_checkpoints_timestamp_interval
-    ts_targets = list(train_config.save_checkpoints_timestamps)
-    ts_reduce = train_config.checkpoint_timestamp_reduce or "min"
-    if ts_reduce not in ("min", "max"):
-        raise ValueError(
-            "train_config.checkpoint_timestamp_reduce must be 'min' or 'max', "
-            f"got {ts_reduce!r}."
-        )
-    ts_trigger_active = ts_interval_s > 0 or len(ts_targets) > 0
+    # Centralize the save cadence (step / epoch / consumed-event-time) in the
+    # CheckpointManager. It owns the dedupe and the event-time watermark; the loop
+    # only gathers per-worker event-times and runs eval after a save.
+    ckpt_manager.set_save_policy(
+        save_checkpoints_steps,
+        save_checkpoints_epochs,
+        train_config.save_checkpoints_timestamp_interval,
+        list(train_config.save_checkpoints_timestamps),
+        train_config.save_checkpoints_timestamp_quorum,
+    )
+    need_ts = ckpt_manager.needs_worker_timestamps()
+    ts_device = next(model.parameters()).device if need_ts else None
 
     plogger = None
     summary_writer = None
@@ -408,22 +430,12 @@ def _train_and_evaluate(
         )
         prof.start()
 
-    last_ckpt_step = -1
-    # event-time at the last timestamp-triggered save (seconds since epoch); None
-    # until the first batch with a valid timestamp establishes the reference.
-    last_ckpt_data_ts_s: Optional[float] = None
-    ts_device = None
-    if ts_trigger_active:
-        ts_device = next(model.parameters()).device
     i_step = 0
     i_epoch = 0
     losses = {}
 
-    def do_checkpoint(step: int) -> None:
-        """Save a checkpoint (and run eval, if configured) at the given step."""
-        nonlocal last_ckpt_step
-        last_ckpt_step = step
-        ckpt_manager.save(step, model, optimizer, dataloader_state)
+    def run_eval(step: int, epoch: int) -> None:
+        """Run eval after a checkpoint save, if an eval dataloader is configured."""
         if eval_dataloader is not None:
             _evaluate(
                 model,
@@ -432,11 +444,13 @@ def _train_and_evaluate(
                 eval_result_filename=eval_result_filename,
                 global_step=step,
                 eval_summary_writer=eval_summary_writer,
-                global_epoch=i_epoch,
+                global_epoch=epoch,
                 check_all_workers_data_status=check_all_workers_data_status,
             )
             model.train()
 
+    # last gathered per-worker event-times, reused by the epoch / final saves
+    worker_ts: Optional[List[float]] = None
     for i_epoch in epoch_iter:
         pipeline = create_train_pipeline(
             model,
@@ -495,65 +509,33 @@ def _train_and_evaluate(
                 i_step -= 1
                 break
 
-            if save_checkpoints_steps > 0 and i_step > 0:
-                if i_step % save_checkpoints_steps == 0:
-                    do_checkpoint(i_step)
-
-            if ts_trigger_active:
-                # Reconcile each rank's consumed event-time before deciding to save
-                # (the save below is collective). Ranks without a timestamp this step
-                # contribute a neutral sentinel so they neither skew nor skip the
-                # collective. The all-reduce is gated only by the config-derived
-                # ts_trigger_active, so every rank participates.
-                if ts_reduce == "min":
-                    reduce_op = dist.ReduceOp.MIN
-                    local_ts_s = (
-                        batch.data_timestamp / 1000.0
-                        if batch.data_timestamp is not None
-                        else float("inf")
-                    )
-                else:
-                    reduce_op = dist.ReduceOp.MAX
-                    local_ts_s = (
-                        batch.data_timestamp / 1000.0
-                        if batch.data_timestamp is not None
-                        else float("-inf")
-                    )
-                if dist.is_initialized():
-                    ts_tensor = torch.tensor(
-                        [local_ts_s], dtype=torch.float64, device=ts_device
-                    )
-                    dist.all_reduce(ts_tensor, op=reduce_op)
-                    global_ts_s = ts_tensor.item()
-                else:
-                    global_ts_s = local_ts_s
-                # global_ts_s stays at the sentinel only when no rank had a valid
-                # timestamp this step; skip those steps.
-                if global_ts_s not in (float("inf"), float("-inf")):
-                    if last_ckpt_data_ts_s is None:
-                        # First observed event-time: set the reference, do not save.
-                        last_ckpt_data_ts_s = global_ts_s
-                    elif checkpoint_util.should_save_on_timestamp(
-                        global_ts_s,
-                        last_ckpt_data_ts_s,
-                        ts_interval_s,
-                        ts_targets,
-                    ):
-                        last_ckpt_data_ts_s = global_ts_s
-                        # Avoid double-saving when a step trigger already fired here.
-                        if i_step != last_ckpt_step:
-                            logger.info(
-                                f"saving checkpoint at step {i_step}, triggered by "
-                                f"consumed event-time {global_ts_s:.0f}s "
-                                f"(reduce={ts_reduce})"
-                            )
-                            do_checkpoint(i_step)
+            # Gather each rank's consumed event-time for the timestamp trigger.
+            # Done in lockstep across ranks under the same equal-step-count
+            # invariant the model's own gradient collectives already require: a
+            # rank that drains first hangs at the gradient all-reduce inside
+            # pipeline.progress before ever reaching here.
+            worker_ts = (
+                _gather_worker_event_times(batch.data_timestamp, ts_device)
+                if need_ts
+                else None
+            )
+            # Single entry point for step / epoch / event-time saves + dedupe.
+            if ckpt_manager.maybe_save(
+                i_step, model, optimizer, dataloader_state, worker_ts_list=worker_ts
+            ):
+                run_eval(i_step, i_epoch)
             if train_config.is_profiling:
                 prof.step()
 
-        if save_checkpoints_epochs > 0 and i_step > 0:
-            if (i_epoch + 1) % save_checkpoints_epochs == 0:
-                do_checkpoint(i_step)
+        if ckpt_manager.maybe_save(
+            i_step,
+            model,
+            optimizer,
+            dataloader_state,
+            epoch=i_epoch,
+            worker_ts_list=worker_ts,
+        ):
+            run_eval(i_step, i_epoch)
 
         if use_step and i_step >= train_config.num_steps - 1:
             break
@@ -575,8 +557,10 @@ def _train_and_evaluate(
         summary_writer.close()
     if train_config.is_profiling:
         prof.stop()
-    if last_ckpt_step != i_step:
-        do_checkpoint(i_step)
+    if ckpt_manager.maybe_save(
+        i_step, model, optimizer, dataloader_state, worker_ts_list=worker_ts, final=True
+    ):
+        run_eval(i_step, i_epoch)
     ckpt_manager.close()
 
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -12,7 +12,6 @@
 import copy
 import itertools
 import json
-import math
 import os
 from collections import OrderedDict
 from queue import Queue
@@ -316,22 +315,20 @@ def _log_train(
 
 
 def _gather_worker_event_times(
-    data_timestamp_s: Optional[float], device: Optional[torch.device]
+    data_timestamp_s: float, device: Optional[torch.device]
 ) -> List[float]:
     """All-gather each rank's consumed event-time (seconds) for the save quorum.
 
-    Ranks without a timestamp this step contribute a NaN that is filtered out, so
-    the returned list holds only the valid per-worker event-times. all_gather
-    (not all_reduce) is used so a NaN never poisons the others.
+    Ranks without a timestamp this step carry the -1.0 sentinel, which is filtered
+    out so the returned list holds only the valid per-worker event-times.
     """
-    local = data_timestamp_s if data_timestamp_s is not None else float("nan")
     if dist.is_initialized():
         world_size = dist.get_world_size()
-        local_t = torch.tensor([local], dtype=torch.float64, device=device)
+        local_t = torch.tensor([data_timestamp_s], dtype=torch.float64, device=device)
         gathered = torch.empty(world_size, dtype=torch.float64, device=device)
         dist.all_gather_into_tensor(gathered, local_t)
-        return [v for v in gathered.tolist() if not math.isnan(v)]
-    return [] if math.isnan(local) else [local]
+        return [v for v in gathered.tolist() if v >= 0]
+    return [data_timestamp_s] if data_timestamp_s >= 0 else []
 
 
 def _train_and_evaluate(

--- a/tzrec/protos/train.proto
+++ b/tzrec/protos/train.proto
@@ -72,5 +72,16 @@ message TrainConfig {
     optional GradClipping grad_clipping = 19;
     // maximum number of recent checkpoints to keep; 0 keeps all.
     optional uint32 keep_checkpoint_max = 20 [default = 0];
+    // event-time interval (seconds) for saving checkpoint, based on the consumed
+    // data timestamp (e.g. kafka message timestamp). saves once per epoch-aligned
+    // interval boundary that the consumed event-time crosses. 0 disables.
+    optional uint32 save_checkpoints_timestamp_interval = 21 [default = 0];
+    // absolute event-time targets (seconds since epoch); a checkpoint is saved once
+    // when the consumed data timestamp crosses each target. empty disables.
+    repeated uint64 save_checkpoints_timestamps = 22;
+    // how to reconcile per-rank consumed event-time before deciding to save a
+    // timestamp-triggered checkpoint: "min" (slowest rank passed the boundary) or
+    // "max" (latest event-time seen on any rank).
+    optional string checkpoint_timestamp_reduce = 23 [default = "min"];
     // TBD: qcomm config
 }

--- a/tzrec/protos/train.proto
+++ b/tzrec/protos/train.proto
@@ -73,15 +73,17 @@ message TrainConfig {
     // maximum number of recent checkpoints to keep; 0 keeps all.
     optional uint32 keep_checkpoint_max = 20 [default = 0];
     // event-time interval (seconds) for saving checkpoint, based on the consumed
-    // data timestamp (e.g. kafka message timestamp). saves once per epoch-aligned
-    // interval boundary that the consumed event-time crosses. 0 disables.
+    // data timestamp (e.g. kafka message timestamp). saves once per interval
+    // boundary (aligned to the Unix epoch / wall-clock, NOT training epochs) that
+    // the consumed event-time crosses. 0 disables.
     optional uint32 save_checkpoints_timestamp_interval = 21 [default = 0];
-    // absolute event-time targets (seconds since epoch); a checkpoint is saved once
+    // absolute event-time targets (Unix-epoch seconds); a checkpoint is saved once
     // when the consumed data timestamp crosses each target. empty disables.
     repeated uint64 save_checkpoints_timestamps = 22;
-    // how to reconcile per-rank consumed event-time before deciding to save a
-    // timestamp-triggered checkpoint: "min" (slowest rank passed the boundary) or
-    // "max" (latest event-time seen on any rank).
-    optional string checkpoint_timestamp_reduce = 23 [default = "min"];
+    // fraction of data-carrying workers (0,1], default 0.5, that must have consumed
+    // past a boundary/target before a timestamp-triggered checkpoint fires.
+    // 1.0 = all workers (most conservative), smaller -> fewer (down to any one).
+    // robust to a single outlier/garbage timestamp at the default.
+    optional float save_checkpoints_timestamp_quorum = 23 [default = 0.5];
     // TBD: qcomm config
 }

--- a/tzrec/protos/train.proto
+++ b/tzrec/protos/train.proto
@@ -74,8 +74,8 @@ message TrainConfig {
     optional uint32 keep_checkpoint_max = 20 [default = 0];
     // event-time interval (seconds) for saving checkpoint, based on the consumed
     // data timestamp (e.g. kafka message timestamp). saves once per interval
-    // boundary (aligned to the Unix epoch / wall-clock, NOT training epochs) that
-    // the consumed event-time crosses. 0 disables.
+    // boundary crossed, aligned to the Unix epoch (wall-clock), not training
+    // epochs. 0 disables.
     optional uint32 save_checkpoints_timestamp_interval = 21 [default = 0];
     // absolute event-time targets (Unix-epoch seconds); a checkpoint is saved once
     // when the consumed data timestamp crosses each target. empty disables.

--- a/tzrec/protos/train.proto
+++ b/tzrec/protos/train.proto
@@ -72,18 +72,14 @@ message TrainConfig {
     optional GradClipping grad_clipping = 19;
     // maximum number of recent checkpoints to keep; 0 keeps all.
     optional uint32 keep_checkpoint_max = 20 [default = 0];
-    // event-time interval (seconds) for saving checkpoint, based on the consumed
-    // data timestamp (e.g. kafka message timestamp). saves once per interval
-    // boundary crossed, aligned to the Unix epoch (wall-clock), not training
-    // epochs. 0 disables.
+    // save every N seconds of consumed event-time (e.g. kafka message timestamp),
+    // aligned to the Unix epoch (not training epochs). 0 disables.
     optional uint32 save_checkpoints_timestamp_interval = 21 [default = 0];
-    // absolute event-time targets (Unix-epoch seconds); a checkpoint is saved once
-    // when the consumed data timestamp crosses each target. empty disables.
+    // absolute event-time targets (Unix-epoch seconds); save once when consumed
+    // data crosses each. empty disables.
     repeated uint64 save_checkpoints_timestamps = 22;
-    // fraction of data-carrying workers (0,1], default 0.5, that must have consumed
-    // past a boundary/target before a timestamp-triggered checkpoint fires.
-    // 1.0 = all workers (most conservative), smaller -> fewer (down to any one).
-    // robust to a single outlier/garbage timestamp at the default.
+    // fraction of workers (0,1] that must pass a boundary/target before a
+    // timestamp checkpoint fires; default 0.5 (1.0 = all). outlier-robust.
     optional float save_checkpoints_timestamp_quorum = 23 [default = 0.5];
     // TBD: qcomm config
 }

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -11,6 +11,7 @@
 
 import glob
 import json
+import math
 import os
 import queue
 import re
@@ -298,6 +299,16 @@ class CheckpointManager:
         self._lock = threading.Lock()
         self._prune_worker: Optional[threading.Thread] = None
         self._finalizer: Optional[weakref.finalize] = None
+        # save-cadence policy (set via set_save_policy on the train path only;
+        # defaults disable all triggers so eval/predict/export paths are unaffected)
+        self._save_steps = 0
+        self._save_epochs = 0
+        self._ts_interval = 0
+        self._ts_targets: List[int] = []
+        self._ts_quorum = 0.5
+        # cadence state owned here so dedupe is centralized across all save sites
+        self._last_ckpt_step = -1
+        self._last_data_ts: Optional[float] = None
 
     def save(
         self,
@@ -313,6 +324,95 @@ class CheckpointManager:
             save_dataloader_state(ckpt_dir, dataloader_state)
         self.prune()
         return ckpt_dir
+
+    def set_save_policy(
+        self,
+        save_steps: int,
+        save_epochs: int,
+        ts_interval_s: int,
+        ts_targets: List[int],
+        ts_quorum: float,
+    ) -> None:
+        """Configure when ``maybe_save`` fires (train path only).
+
+        Sets cadence config only; never resets ``_last_ckpt_step`` /
+        ``_last_data_ts`` so a watermark seeded by ``restore_dataloader_state``
+        on resume survives.
+        """
+        if (ts_interval_s > 0 or len(ts_targets) > 0) and not (0.0 < ts_quorum <= 1.0):
+            raise ValueError(
+                f"save_checkpoints_timestamp_quorum must be in (0, 1], got {ts_quorum}."
+            )
+        self._save_steps = save_steps
+        self._save_epochs = save_epochs
+        self._ts_interval = ts_interval_s
+        self._ts_targets = ts_targets
+        self._ts_quorum = ts_quorum
+
+    def needs_worker_timestamps(self) -> bool:
+        """Whether the configured policy needs per-worker event-times."""
+        return self._ts_interval > 0 or len(self._ts_targets) > 0
+
+    def maybe_save(
+        self,
+        step: int,
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer] = None,
+        dataloader_state: Optional[Dict[str, int]] = None,
+        *,
+        epoch: Optional[int] = None,
+        worker_ts_list: Optional[List[float]] = None,
+        final: bool = False,
+    ) -> bool:
+        """Save a checkpoint if a configured trigger fires; return whether it did.
+
+        Centralizes the step / epoch / event-time decisions and the single
+        per-step dedupe, so no call site can re-save a step another already
+        saved. ``worker_ts_list`` is the per-rank consumed event-times the caller
+        gathered (``all_gather``); reconciliation (quorum), the event-time
+        watermark advance/persist, and the save all happen here.
+
+        The decision is deterministic and identical across ranks (same gathered
+        list -> same quorum -> same config), so the collective ``save`` is
+        entered in lockstep; nothing collective runs when not saving.
+        """
+        data_ts = (
+            quorum_event_time(worker_ts_list, self._ts_quorum)
+            if worker_ts_list
+            else None
+        )
+
+        want = final
+        if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
+            want = True
+        if (
+            epoch is not None
+            and self._save_epochs > 0
+            and step > 0
+            and (epoch + 1) % self._save_epochs == 0
+        ):
+            want = True
+        if data_ts is not None:
+            if self._last_data_ts is None:
+                # first observed event-time: initialize the reference, do not save
+                self._last_data_ts = data_ts
+            elif should_save_on_timestamp(
+                data_ts, self._last_data_ts, self._ts_interval, self._ts_targets
+            ):
+                want = True
+
+        if not want or step == self._last_ckpt_step:
+            return False
+
+        self._last_ckpt_step = step
+        if data_ts is not None:
+            # advance + persist the watermark on ANY save (step/epoch/timestamp/
+            # final) so resume re-fires no already-saved boundary and misses none
+            self._last_data_ts = data_ts
+            if dataloader_state is not None:
+                dataloader_state[DATA_TS_WATERMARK] = data_ts
+        self.save(step, model, optimizer, dataloader_state)
+        return True
 
     def prune(self) -> None:
         """Request an async prune pass (keep recent N + best). Rank 0 only.
@@ -370,8 +470,16 @@ class CheckpointManager:
         restore_model(ckpt_path, model, optimizer, ckpt_param_map_path)
 
     def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, int]]:
-        """Restore dataloader state saved alongside a checkpoint."""
-        return restore_dataloader_state(ckpt_path)
+        """Restore dataloader state saved alongside a checkpoint.
+
+        Also seeds the event-time watermark so ``maybe_save`` resumes the
+        timestamp trigger from where it left off (re-firing no already-saved
+        boundary and missing none); absent/None -> initialize from first batch.
+        """
+        state = restore_dataloader_state(ckpt_path)
+        if state is not None:
+            self._last_data_ts = state.get(DATA_TS_WATERMARK)
+        return state
 
     @staticmethod
     def _drain(prune_queue: "queue.Queue[object]", worker: threading.Thread) -> None:
@@ -766,6 +874,9 @@ def save_model(
 
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
+# reserved key in dataloader_state holding the event-time watermark (Unix-epoch
+# seconds) of the last checkpoint; no ":" so per-source consumers skip it.
+DATA_TS_WATERMARK = "__data_ts_watermark__"
 
 
 def save_dataloader_state(
@@ -865,20 +976,21 @@ def should_save_on_timestamp(
     Drives event-time checkpointing from the data timestamp (e.g. the kafka
     message timestamp surfaced on ``Batch.data_timestamp``). Two triggers:
 
-    * interval: an epoch-aligned boundary (``floor(ts / interval_s)``) has been
-      crossed since the last timestamp-triggered save.
+    * interval: a boundary ``floor(ts / interval_s)`` -- aligned to the Unix
+      epoch (wall-clock), NOT to training epochs -- has been crossed since the
+      last save.
     * targets: the consumed event-time has crossed an absolute target.
 
     Args:
-        data_ts_s: current consumed event-time (seconds since epoch), already
+        data_ts_s: current consumed event-time (Unix-epoch seconds), already
             reconciled across ranks.
-        last_ckpt_ts_s: event-time at the last timestamp-triggered save, or None
-            when no reference has been established yet (first batch / just
-            restored). When None this returns False so the caller only
-            initializes the reference instead of saving.
-        interval_s: epoch-aligned event-time interval in seconds; 0 disables the
-            interval trigger.
-        target_ts_list: absolute event-time targets (seconds since epoch); a save
+        last_ckpt_ts_s: event-time at the last save, or None when no reference
+            has been established yet (first batch / just restored). When None
+            this returns False so the caller only initializes the reference
+            instead of saving.
+        interval_s: event-time interval in seconds, boundaries aligned to the
+            Unix epoch; 0 disables the interval trigger.
+        target_ts_list: absolute event-time targets (Unix-epoch seconds); a save
             fires once when the consumed event-time crosses each target.
 
     Returns:
@@ -887,7 +999,7 @@ def should_save_on_timestamp(
     # No reference yet: only initialize, never save on the first observed batch.
     if last_ckpt_ts_s is None:
         return False
-    # Epoch-aligned interval boundary crossed since the last save.
+    # Unix-epoch-aligned interval boundary crossed since the last save.
     if interval_s > 0 and int(data_ts_s // interval_s) > int(
         last_ckpt_ts_s // interval_s
     ):
@@ -897,6 +1009,33 @@ def should_save_on_timestamp(
         if last_ckpt_ts_s < target <= data_ts_s:
             return True
     return False
+
+
+def quorum_event_time(local_ts_list: List[float], quorum: float) -> Optional[float]:
+    """Reconcile per-worker consumed event-times into one global event-time.
+
+    Returns the event-time that at least ``quorum`` fraction of the workers have
+    reached -- i.e. the ``(1 - quorum)`` upper quantile of the per-worker values:
+    the largest ``T`` such that at least ``ceil(quorum * m)`` of the ``m`` values
+    are ``>= T``. ``quorum=1.0`` -> min (all workers past ``T``); ``quorum`` near
+    0 -> max (any one worker). Using a quantile makes the default (0.5) robust to
+    a single outlier/garbage timestamp.
+
+    Args:
+        local_ts_list: per-worker event-times (seconds); invalid/missing entries
+            should already be filtered out by the caller.
+        quorum: fraction of workers in (0, 1].
+
+    Returns:
+        The reconciled event-time, or None when ``local_ts_list`` is empty.
+    """
+    vals = sorted(local_ts_list)
+    m = len(vals)
+    if m == 0:
+        return None
+    # epsilon guards float overshoot (e.g. 0.1 * 10 -> 1.0000000001 -> ceil 2)
+    k = max(1, min(m, math.ceil(quorum * m - 1e-9)))
+    return vals[m - k]
 
 
 def list_distcp_param(checkpoint_dir: str) -> List[str]:

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -854,6 +854,51 @@ def update_dataloder_state(
             dataloader_state[key] = value
 
 
+def should_save_on_timestamp(
+    data_ts_s: float,
+    last_ckpt_ts_s: Optional[float],
+    interval_s: int,
+    target_ts_list: List[int],
+) -> bool:
+    """Decide whether to save a checkpoint based on consumed event-time.
+
+    Drives event-time checkpointing from the data timestamp (e.g. the kafka
+    message timestamp surfaced on ``Batch.data_timestamp``). Two triggers:
+
+    * interval: an epoch-aligned boundary (``floor(ts / interval_s)``) has been
+      crossed since the last timestamp-triggered save.
+    * targets: the consumed event-time has crossed an absolute target.
+
+    Args:
+        data_ts_s: current consumed event-time (seconds since epoch), already
+            reconciled across ranks.
+        last_ckpt_ts_s: event-time at the last timestamp-triggered save, or None
+            when no reference has been established yet (first batch / just
+            restored). When None this returns False so the caller only
+            initializes the reference instead of saving.
+        interval_s: epoch-aligned event-time interval in seconds; 0 disables the
+            interval trigger.
+        target_ts_list: absolute event-time targets (seconds since epoch); a save
+            fires once when the consumed event-time crosses each target.
+
+    Returns:
+        True if a checkpoint should be saved for this event-time.
+    """
+    # No reference yet: only initialize, never save on the first observed batch.
+    if last_ckpt_ts_s is None:
+        return False
+    # Epoch-aligned interval boundary crossed since the last save.
+    if interval_s > 0 and int(data_ts_s // interval_s) > int(
+        last_ckpt_ts_s // interval_s
+    ):
+        return True
+    # Any absolute target crossed within (last_ckpt_ts_s, data_ts_s].
+    for target in target_ts_list:
+        if last_ckpt_ts_s < target <= data_ts_s:
+            return True
+    return False
+
+
 def list_distcp_param(checkpoint_dir: str) -> List[str]:
     """List distributed checkpoint parameter names."""
     meta_paths = []

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -335,9 +335,15 @@ class CheckpointManager:
     ) -> None:
         """Configure when ``maybe_save`` fires (train path only).
 
-        Sets cadence config only; never resets ``_last_ckpt_step`` /
-        ``_last_data_ts`` so a watermark seeded by ``restore_dataloader_state``
-        on resume survives.
+        Sets cadence config only (never the ``_last_*`` state), so a watermark
+        seeded on resume survives.
+
+        Args:
+            save_steps: step interval; 0 disables the step trigger.
+            save_epochs: epoch interval; 0 disables the epoch trigger.
+            ts_interval_s: event-time interval in seconds; 0 disables.
+            ts_targets: absolute event-time targets (Unix-epoch seconds).
+            ts_quorum: fraction of workers (0, 1] past a boundary to trigger a save.
         """
         if (ts_interval_s > 0 or len(ts_targets) > 0) and not (0.0 < ts_quorum <= 1.0):
             raise ValueError(
@@ -350,7 +356,7 @@ class CheckpointManager:
         self._ts_quorum = ts_quorum
 
     def needs_worker_timestamps(self) -> bool:
-        """Whether the configured policy needs per-worker event-times."""
+        """Return whether the policy needs per-worker event-times gathered."""
         return self._ts_interval > 0 or len(self._ts_targets) > 0
 
     def maybe_save(
@@ -367,20 +373,33 @@ class CheckpointManager:
         """Save a checkpoint if a configured trigger fires; return whether it did.
 
         Centralizes the step / epoch / event-time decisions and the single
-        per-step dedupe, so no call site can re-save a step another already
-        saved. ``worker_ts_list`` is the per-rank consumed event-times the caller
-        gathered (``all_gather``); reconciliation (quorum), the event-time
-        watermark advance/persist, and the save all happen here.
+        per-step dedupe so no call site can re-save a step another already saved.
+        The decision is deterministic and identical across ranks, so the
+        collective ``save`` is entered in lockstep and nothing collective runs
+        when not saving.
 
-        The decision is deterministic and identical across ranks (same gathered
-        list -> same quorum -> same config), so the collective ``save`` is
-        entered in lockstep; nothing collective runs when not saving.
+        Args:
+            step: current global step.
+            model: model to save.
+            optimizer: optimizer to save, if any.
+            dataloader_state: dataloader resume state; the event-time watermark is
+                stamped into it on save.
+            epoch: current epoch; enables the epoch trigger when not None.
+            worker_ts_list: per-rank consumed event-times (seconds) gathered by the
+                caller; reconciled here via the worker quorum.
+            final: force a save (still subject to the dedupe), e.g. at train end.
+
+        Returns:
+            True if a checkpoint was saved.
         """
         data_ts = (
             quorum_event_time(worker_ts_list, self._ts_quorum)
             if worker_ts_list
             else None
         )
+        # a -1.0-dominated quorum (too few workers with a timestamp) -> no event-time
+        if data_ts is not None and data_ts < 0:
+            data_ts = None
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
@@ -394,7 +413,7 @@ class CheckpointManager:
             want = True
         if data_ts is not None:
             if self._last_data_ts is None:
-                # first observed event-time: initialize the reference, do not save
+                # first event-time seen: set the reference, do not save
                 self._last_data_ts = data_ts
             elif should_save_on_timestamp(
                 data_ts, self._last_data_ts, self._ts_interval, self._ts_targets
@@ -406,8 +425,7 @@ class CheckpointManager:
 
         self._last_ckpt_step = step
         if data_ts is not None:
-            # advance + persist the watermark on ANY save (step/epoch/timestamp/
-            # final) so resume re-fires no already-saved boundary and misses none
+            # advance + persist the watermark on every save so resume is exact
             self._last_data_ts = data_ts
             if dataloader_state is not None:
                 dataloader_state[DATA_TS_WATERMARK] = data_ts
@@ -473,8 +491,7 @@ class CheckpointManager:
         """Restore dataloader state saved alongside a checkpoint.
 
         Also seeds the event-time watermark so ``maybe_save`` resumes the
-        timestamp trigger from where it left off (re-firing no already-saved
-        boundary and missing none); absent/None -> initialize from first batch.
+        timestamp trigger; absent -> initialize from the first batch.
         """
         state = restore_dataloader_state(ckpt_path)
         if state is not None:
@@ -1021,9 +1038,13 @@ def quorum_event_time(local_ts_list: List[float], quorum: float) -> Optional[flo
     0 -> max (any one worker). Using a quantile makes the default (0.5) robust to
     a single outlier/garbage timestamp.
 
+    A worker without a timestamp carries the -1.0 sentinel, which sorts low and so
+    counts as "not past" -- the quorum is over all workers; the result is negative
+    when too few have a real timestamp.
+
     Args:
-        local_ts_list: per-worker event-times (seconds); invalid/missing entries
-            should already be filtered out by the caller.
+        local_ts_list: per-worker event-times (seconds), -1.0 for workers without
+            one.
         quorum: fraction of workers in (0, 1].
 
     Returns:

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -306,6 +306,8 @@ class CheckpointManager:
         self._ts_interval = 0
         self._ts_targets: List[int] = []
         self._ts_quorum = 0.5
+        # CPU (gloo) group for the event-time gather; created in set_save_policy
+        self._ts_group: Optional[dist.ProcessGroup] = None
         # cadence state owned here so dedupe is centralized across all save sites
         self._last_ckpt_step = -1
         self._last_data_ts: Optional[float] = None
@@ -336,7 +338,9 @@ class CheckpointManager:
         """Configure when ``maybe_save`` fires (train path only).
 
         Sets cadence config only (never the ``_last_*`` state), so a watermark
-        seeded on resume survives.
+        seeded on resume survives. When timestamp triggers are active under a
+        distributed run, also creates the dedicated CPU (gloo) group used for the
+        per-step event-time gather -- a collective, so all ranks must call this.
 
         Args:
             save_steps: step interval; 0 disables the step trigger.
@@ -354,10 +358,36 @@ class CheckpointManager:
         self._ts_interval = ts_interval_s
         self._ts_targets = ts_targets
         self._ts_quorum = ts_quorum
+        if self.needs_worker_timestamps() and dist.is_initialized():
+            self._ts_group = dist.new_group(backend="gloo")
 
     def needs_worker_timestamps(self) -> bool:
         """Return whether the policy needs per-worker event-times gathered."""
         return self._ts_interval > 0 or len(self._ts_targets) > 0
+
+    def _reconcile_event_time(self, data_timestamp: float) -> Optional[float]:
+        """Quorum-reconcile this rank's event-time across workers.
+
+        Gathers over the CPU group from ``set_save_policy``. Each worker without a
+        timestamp contributes the -1.0 sentinel (sorts low, so it counts as "not
+        past"). Returns None when timestamp triggers are off or too few workers
+        have a real timestamp.
+
+        Args:
+            data_timestamp: this rank's consumed event-time (seconds), -1.0 if none.
+
+        Returns:
+            The quorum event-time (seconds), or None.
+        """
+        if not self.needs_worker_timestamps():
+            return None
+        if dist.is_initialized():
+            worker_ts: List[float] = [0.0] * dist.get_world_size(self._ts_group)
+            dist.all_gather_object(worker_ts, data_timestamp, group=self._ts_group)
+        else:
+            worker_ts = [data_timestamp]
+        data_ts = quorum_event_time(worker_ts, self._ts_quorum)
+        return data_ts if data_ts is not None and data_ts >= 0 else None
 
     def maybe_save(
         self,
@@ -367,7 +397,7 @@ class CheckpointManager:
         dataloader_state: Optional[Dict[str, Any]] = None,
         *,
         epoch: Optional[int] = None,
-        worker_ts_list: Optional[List[float]] = None,
+        data_timestamp: float = -1.0,
         final: bool = False,
     ) -> bool:
         """Save a checkpoint if a configured trigger fires; return whether it did.
@@ -385,21 +415,14 @@ class CheckpointManager:
             dataloader_state: dataloader resume state; the event-time watermark is
                 stamped into it on save.
             epoch: current epoch; enables the epoch trigger when not None.
-            worker_ts_list: per-rank consumed event-times (seconds) gathered by the
-                caller; reconciled here via the worker quorum.
+            data_timestamp: this rank's consumed event-time (seconds), -1.0 if none;
+                reconciled across workers (quorum) for the event-time trigger.
             final: force a save (still subject to the dedupe), e.g. at train end.
 
         Returns:
             True if a checkpoint was saved.
         """
-        data_ts = (
-            quorum_event_time(worker_ts_list, self._ts_quorum)
-            if worker_ts_list
-            else None
-        )
-        # a -1.0-dominated quorum (too few workers with a timestamp) -> no event-time
-        if data_ts is not None and data_ts < 0:
-            data_ts = None
+        data_ts = self._reconcile_event_time(data_timestamp)
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -19,7 +19,7 @@ import shutil
 import threading
 import weakref
 from dataclasses import replace
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -315,7 +315,7 @@ class CheckpointManager:
         step: int,
         model: nn.Module,
         optimizer: Optional[optim.Optimizer] = None,
-        dataloader_state: Optional[Dict[str, int]] = None,
+        dataloader_state: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Save a checkpoint at the given step, then request an async prune."""
         ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
@@ -364,7 +364,7 @@ class CheckpointManager:
         step: int,
         model: nn.Module,
         optimizer: Optional[optim.Optimizer] = None,
-        dataloader_state: Optional[Dict[str, int]] = None,
+        dataloader_state: Optional[Dict[str, Any]] = None,
         *,
         epoch: Optional[int] = None,
         worker_ts_list: Optional[List[float]] = None,
@@ -487,7 +487,7 @@ class CheckpointManager:
         """Restore model/optimizer state from a checkpoint dir."""
         restore_model(ckpt_path, model, optimizer, ckpt_param_map_path)
 
-    def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, int]]:
+    def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, Any]]:
         """Restore dataloader state saved alongside a checkpoint.
 
         Also seeds the event-time watermark so ``maybe_save`` resumes the
@@ -898,7 +898,7 @@ DATA_TS_WATERMARK = "__data_ts_watermark__"
 
 def save_dataloader_state(
     checkpoint_dir: str,
-    dataloader_state: Dict[str, int],
+    dataloader_state: Dict[str, Any],
 ) -> None:
     """Save dataloader state, aggregating from all ranks first.
 
@@ -917,7 +917,7 @@ def save_dataloader_state(
         dist.all_gather_object(all_states, dataloader_state)
 
         # Merge by taking max for each key
-        merged_state: Dict[str, int] = {}
+        merged_state: Dict[str, Any] = {}
         for state in all_states:
             if state:
                 for key, value in state.items():
@@ -937,7 +937,9 @@ def save_dataloader_state(
         logger.info(f"Saved dataloader state to {ckpt_path}")
 
 
-def restore_dataloader_state(checkpoint_dir: str) -> Optional[Dict[str, int]]:
+def restore_dataloader_state(
+    checkpoint_dir: str,
+) -> Optional[Dict[str, Any]]:
     """Restore dataloader checkpoint state from file.
 
     Args:
@@ -961,7 +963,7 @@ def restore_dataloader_state(checkpoint_dir: str) -> Optional[Dict[str, int]]:
 
 
 def update_dataloder_state(
-    dataloader_state: Dict[str, int],
+    dataloader_state: Dict[str, Any],
     checkpoint_info: Optional[Dict[str, int]],
 ) -> None:
     """Merge batch's checkpoint_info into dataloader_state by taking max per key.

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -914,8 +914,8 @@ def save_model(
 
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
-# reserved key in dataloader_state holding the event-time watermark (Unix-epoch
-# seconds) of the last checkpoint; no ":" so per-source consumers skip it.
+# reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
+# no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"
 
 

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -674,43 +674,39 @@ class DataloaderCheckpointTest(unittest.TestCase):
     def test_maybe_save_timestamp_init_then_fire(self):
         mgr = self._policy_manager(ts_interval_s=3600)
         # first observed event-time only initializes the reference, no save
-        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[3599.0]))
+        self.assertFalse(mgr.maybe_save(1, model=None, data_timestamp=3599.0))
         # crossing the next Unix-epoch-aligned boundary fires
-        self.assertTrue(mgr.maybe_save(2, model=None, worker_ts_list=[3600.0]))
-
-    def test_maybe_save_timestamp_quorum(self):
-        # quorum=1.0: only fires once the slowest worker crosses
-        mgr = self._policy_manager(ts_interval_s=3600, ts_quorum=1.0)
-        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[3000.0, 3000.0]))
-        # one worker crossed, the other not -> min still in old bucket -> no save
-        self.assertFalse(mgr.maybe_save(2, model=None, worker_ts_list=[3700.0, 3500.0]))
-        # both crossed -> save
-        self.assertTrue(mgr.maybe_save(3, model=None, worker_ts_list=[3700.0, 3601.0]))
+        self.assertTrue(mgr.maybe_save(2, model=None, data_timestamp=3600.0))
 
     def test_maybe_save_timestamp_sentinel(self):
-        # -1.0 sentinels (workers without a timestamp) never establish/advance the
-        # reference nor trigger a save; a real time later initializes cleanly
+        # -1.0 (no timestamp this step) never establishes/advances the reference
+        # nor triggers a save; a real time later initializes cleanly
         mgr = self._policy_manager(ts_interval_s=3600)
-        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[-1.0, -1.0]))
+        self.assertFalse(mgr.maybe_save(1, model=None, data_timestamp=-1.0))
         self.assertIsNone(mgr._last_data_ts)  # not initialized to -1.0
-        self.assertFalse(mgr.maybe_save(2, model=None, worker_ts_list=[3599.0, 3599.0]))
+        self.assertFalse(mgr.maybe_save(2, model=None, data_timestamp=3599.0))
         self.assertEqual(mgr._last_data_ts, 3599.0)  # real time initializes
-        self.assertTrue(mgr.maybe_save(3, model=None, worker_ts_list=[3600.0, 3600.0]))
+        self.assertTrue(mgr.maybe_save(3, model=None, data_timestamp=3600.0))
 
     def test_maybe_save_stamps_watermark(self):
         mgr = self._policy_manager(ts_interval_s=3600)
         state = {}
         self.assertFalse(
-            mgr.maybe_save(
-                1, model=None, dataloader_state=state, worker_ts_list=[3599.0]
-            )
+            mgr.maybe_save(1, model=None, dataloader_state=state, data_timestamp=3599.0)
         )
         self.assertTrue(
-            mgr.maybe_save(
-                2, model=None, dataloader_state=state, worker_ts_list=[3600.0]
-            )
+            mgr.maybe_save(2, model=None, dataloader_state=state, data_timestamp=3600.0)
         )
         self.assertEqual(state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+
+    def test_reconcile_event_time_single_process(self):
+        # not distributed: this rank's value passes through (quorum of one); -1.0
+        # (no timestamp) -> None; disabled policy -> None
+        mgr = self._policy_manager(ts_interval_s=3600)
+        self.assertEqual(mgr._reconcile_event_time(1717000000.0), 1717000000.0)
+        self.assertIsNone(mgr._reconcile_event_time(-1.0))
+        mgr_off = self._policy_manager()
+        self.assertIsNone(mgr_off._reconcile_event_time(1717000000.0))
 
     def test_restore_seeds_watermark(self):
         mgr = self._policy_manager(ts_interval_s=3600)
@@ -722,9 +718,9 @@ class DataloaderCheckpointTest(unittest.TestCase):
         state = mgr.restore_dataloader_state(tmp_dir)
         self.assertEqual(state[checkpoint_util.DATA_TS_WATERMARK], 7200.0)
         # seeded reference: a value in the same bucket does not re-fire
-        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[7201.0]))
+        self.assertFalse(mgr.maybe_save(1, model=None, data_timestamp=7201.0))
         # crossing the next boundary fires
-        self.assertTrue(mgr.maybe_save(2, model=None, worker_ts_list=[10800.0]))
+        self.assertTrue(mgr.maybe_save(2, model=None, data_timestamp=10800.0))
 
 
 if __name__ == "__main__":

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 import torch
 import torch.distributed as dist
 import torchrec
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torch import nn
 from torchrec import EmbeddingBagCollection
 from torchrec.distributed.model_parallel import (
@@ -481,125 +481,139 @@ class DataloaderCheckpointTest(unittest.TestCase):
 
         self.assertEqual(checkpoint_state, {"path:0": 100, "path:500": 200})
 
-    def test_should_save_on_timestamp_first_batch(self):
-        """No reference yet -> only initialize, never save."""
-        self.assertFalse(
-            checkpoint_util.should_save_on_timestamp(
-                1000, None, interval_s=600, target_ts_list=[500]
-            )
-        )
-
-    def test_should_save_on_timestamp_interval_crossed(self):
-        """Crossing an epoch-aligned interval boundary fires."""
-        # floor(3600/3600)=1 > floor(3599/3600)=0
-        self.assertTrue(
-            checkpoint_util.should_save_on_timestamp(
-                3600, 3599, interval_s=3600, target_ts_list=[]
-            )
-        )
-
-    def test_should_save_on_timestamp_interval_not_crossed(self):
-        """Same interval bucket does not fire."""
-        # floor(3500/3600) == floor(3000/3600) == 0
-        self.assertFalse(
-            checkpoint_util.should_save_on_timestamp(
-                3500, 3000, interval_s=3600, target_ts_list=[]
-            )
-        )
-
-    def test_should_save_on_timestamp_interval_disabled(self):
-        """interval_s=0 disables the interval trigger."""
-        self.assertFalse(
-            checkpoint_util.should_save_on_timestamp(
-                10000, 0, interval_s=0, target_ts_list=[]
-            )
-        )
-
-    def test_should_save_on_timestamp_target_crossed(self):
-        """Crossing an absolute target fires (boundary inclusive on the right)."""
-        self.assertTrue(
-            checkpoint_util.should_save_on_timestamp(
-                1500, 1000, interval_s=0, target_ts_list=[1500]
-            )
-        )
-        self.assertTrue(
-            checkpoint_util.should_save_on_timestamp(
-                1600, 1000, interval_s=0, target_ts_list=[1500]
-            )
-        )
-
-    def test_should_save_on_timestamp_target_not_reached(self):
-        """Target ahead of consumed event-time does not fire."""
-        self.assertFalse(
-            checkpoint_util.should_save_on_timestamp(
-                1400, 1000, interval_s=0, target_ts_list=[1500]
-            )
-        )
-
-    def test_should_save_on_timestamp_target_no_refire(self):
-        """A target already behind the reference does not refire."""
-        self.assertFalse(
-            checkpoint_util.should_save_on_timestamp(
-                2000, 1500, interval_s=0, target_ts_list=[1500]
-            )
-        )
-
-    def test_should_save_on_timestamp_multiple_targets(self):
-        """Any one crossed target in the window fires."""
-        self.assertTrue(
-            checkpoint_util.should_save_on_timestamp(
-                1600, 1000, interval_s=0, target_ts_list=[900, 1500, 5000]
-            )
-        )
-
-    def test_should_save_on_timestamp_interval_and_targets(self):
-        """Targets fire even when the interval boundary is not crossed."""
-        # same interval bucket (floor(1600/3600)==floor(1000/3600)==0) but a target
-        # at 1500 is crossed.
-        self.assertTrue(
-            checkpoint_util.should_save_on_timestamp(
-                1600, 1000, interval_s=3600, target_ts_list=[1500]
-            )
-        )
-
-    def test_quorum_event_time_empty(self):
-        self.assertIsNone(checkpoint_util.quorum_event_time([], 0.5))
-
-    def test_quorum_event_time_single(self):
-        self.assertEqual(checkpoint_util.quorum_event_time([42.0], 0.5), 42.0)
-
-    def test_quorum_event_time_all_equal(self):
-        self.assertEqual(checkpoint_util.quorum_event_time([5.0, 5.0, 5.0], 0.5), 5.0)
-
-    def test_quorum_event_time_full_quorum_is_min(self):
-        # quorum=1.0 -> all workers must be past T -> min
+    @parameterized.expand(
+        [
+            # no reference yet -> only initialize, never save
+            param(
+                "first_batch",
+                data_ts=1000,
+                last=None,
+                interval=600,
+                targets=[500],
+                expected=False,
+            ),
+            # floor(3600/3600)=1 > floor(3599/3600)=0
+            param(
+                "interval_crossed",
+                data_ts=3600,
+                last=3599,
+                interval=3600,
+                targets=[],
+                expected=True,
+            ),
+            # floor(3500/3600) == floor(3000/3600) == 0
+            param(
+                "interval_not_crossed",
+                data_ts=3500,
+                last=3000,
+                interval=3600,
+                targets=[],
+                expected=False,
+            ),
+            param(
+                "interval_disabled",
+                data_ts=10000,
+                last=0,
+                interval=0,
+                targets=[],
+                expected=False,
+            ),
+            # target boundary is inclusive on the right
+            param(
+                "target_crossed_exact",
+                data_ts=1500,
+                last=1000,
+                interval=0,
+                targets=[1500],
+                expected=True,
+            ),
+            param(
+                "target_crossed_past",
+                data_ts=1600,
+                last=1000,
+                interval=0,
+                targets=[1500],
+                expected=True,
+            ),
+            param(
+                "target_not_reached",
+                data_ts=1400,
+                last=1000,
+                interval=0,
+                targets=[1500],
+                expected=False,
+            ),
+            param(
+                "target_no_refire",
+                data_ts=2000,
+                last=1500,
+                interval=0,
+                targets=[1500],
+                expected=False,
+            ),
+            param(
+                "multiple_targets",
+                data_ts=1600,
+                last=1000,
+                interval=0,
+                targets=[900, 1500, 5000],
+                expected=True,
+            ),
+            # same interval bucket, but a target at 1500 is crossed
+            param(
+                "interval_and_targets",
+                data_ts=1600,
+                last=1000,
+                interval=3600,
+                targets=[1500],
+                expected=True,
+            ),
+        ]
+    )
+    def test_should_save_on_timestamp(
+        self, _name, data_ts, last, interval, targets, expected
+    ):
         self.assertEqual(
-            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 1.0), 10.0
+            checkpoint_util.should_save_on_timestamp(data_ts, last, interval, targets),
+            expected,
         )
 
-    def test_quorum_event_time_tiny_quorum_is_max(self):
-        # quorum near 0 -> any one worker -> max
-        self.assertEqual(
-            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 0.01), 40.0
-        )
-
-    def test_quorum_event_time_half_even(self):
-        # m=4, k=ceil(0.5*4)=2 -> vals[4-2]=vals[2] = 2nd largest, half are >= it
-        self.assertEqual(
-            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 0.5), 30.0
-        )
-
-    def test_quorum_event_time_half_odd(self):
-        # m=3, k=ceil(0.5*3)=ceil(1.5)=2 -> vals[3-2]=vals[1] = median
-        self.assertEqual(
-            checkpoint_util.quorum_event_time([10.0, 30.0, 20.0], 0.5), 20.0
-        )
-
-    def test_quorum_event_time_robust_to_outlier(self):
-        # a single far-future garbage value does not move the median (quorum 0.5)
-        self.assertEqual(
-            checkpoint_util.quorum_event_time([100.0, 101.0, 1e18], 0.5), 101.0
-        )
+    @parameterized.expand(
+        [
+            param("empty", ts_list=[], quorum=0.5, expected=None),
+            param("single", ts_list=[42.0], quorum=0.5, expected=42.0),
+            param("all_equal", ts_list=[5.0, 5.0, 5.0], quorum=0.5, expected=5.0),
+            # quorum=1.0 -> all workers must be past T -> min
+            param(
+                "full_quorum_is_min",
+                ts_list=[10.0, 20.0, 30.0, 40.0],
+                quorum=1.0,
+                expected=10.0,
+            ),
+            # quorum near 0 -> any one worker -> max
+            param(
+                "tiny_quorum_is_max",
+                ts_list=[10.0, 20.0, 30.0, 40.0],
+                quorum=0.01,
+                expected=40.0,
+            ),
+            # m=4, k=ceil(0.5*4)=2 -> 2nd largest, half are >= it
+            param(
+                "half_even", ts_list=[10.0, 20.0, 30.0, 40.0], quorum=0.5, expected=30.0
+            ),
+            # m=3, k=ceil(1.5)=2 -> median
+            param("half_odd", ts_list=[10.0, 30.0, 20.0], quorum=0.5, expected=20.0),
+            # a single far-future garbage value does not move the median
+            param(
+                "robust_to_outlier",
+                ts_list=[100.0, 101.0, 1e18],
+                quorum=0.5,
+                expected=101.0,
+            ),
+        ]
+    )
+    def test_quorum_event_time(self, _name, ts_list, quorum, expected):
+        self.assertEqual(checkpoint_util.quorum_event_time(ts_list, quorum), expected)
 
     def _policy_manager(self, **policy):
         """A CheckpointManager with save() mocked and a save policy applied."""

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -610,6 +610,21 @@ class DataloaderCheckpointTest(unittest.TestCase):
                 quorum=0.5,
                 expected=101.0,
             ),
+            # -1.0 (worker without a timestamp) sorts low, counts as "not past":
+            # 2 of 3 have a real time, quorum 0.5 met -> 100.0
+            param(
+                "sentinel_quorum_met",
+                ts_list=[100.0, 101.0, -1.0],
+                quorum=0.5,
+                expected=100.0,
+            ),
+            # only 1 of 3 has a real time, quorum 0.5 not met -> negative result
+            param(
+                "sentinel_quorum_unmet",
+                ts_list=[100.0, -1.0, -1.0],
+                quorum=0.5,
+                expected=-1.0,
+            ),
         ]
     )
     def test_quorum_event_time(self, _name, ts_list, quorum, expected):
@@ -671,6 +686,16 @@ class DataloaderCheckpointTest(unittest.TestCase):
         self.assertFalse(mgr.maybe_save(2, model=None, worker_ts_list=[3700.0, 3500.0]))
         # both crossed -> save
         self.assertTrue(mgr.maybe_save(3, model=None, worker_ts_list=[3700.0, 3601.0]))
+
+    def test_maybe_save_timestamp_sentinel(self):
+        # -1.0 sentinels (workers without a timestamp) never establish/advance the
+        # reference nor trigger a save; a real time later initializes cleanly
+        mgr = self._policy_manager(ts_interval_s=3600)
+        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[-1.0, -1.0]))
+        self.assertIsNone(mgr._last_data_ts)  # not initialized to -1.0
+        self.assertFalse(mgr.maybe_save(2, model=None, worker_ts_list=[3599.0, 3599.0]))
+        self.assertEqual(mgr._last_data_ts, 3599.0)  # real time initializes
+        self.assertTrue(mgr.maybe_save(3, model=None, worker_ts_list=[3600.0, 3600.0]))
 
     def test_maybe_save_stamps_watermark(self):
         mgr = self._policy_manager(ts_interval_s=3600)

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -562,6 +562,131 @@ class DataloaderCheckpointTest(unittest.TestCase):
             )
         )
 
+    def test_quorum_event_time_empty(self):
+        self.assertIsNone(checkpoint_util.quorum_event_time([], 0.5))
+
+    def test_quorum_event_time_single(self):
+        self.assertEqual(checkpoint_util.quorum_event_time([42.0], 0.5), 42.0)
+
+    def test_quorum_event_time_all_equal(self):
+        self.assertEqual(checkpoint_util.quorum_event_time([5.0, 5.0, 5.0], 0.5), 5.0)
+
+    def test_quorum_event_time_full_quorum_is_min(self):
+        # quorum=1.0 -> all workers must be past T -> min
+        self.assertEqual(
+            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 1.0), 10.0
+        )
+
+    def test_quorum_event_time_tiny_quorum_is_max(self):
+        # quorum near 0 -> any one worker -> max
+        self.assertEqual(
+            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 0.01), 40.0
+        )
+
+    def test_quorum_event_time_half_even(self):
+        # m=4, k=ceil(0.5*4)=2 -> vals[4-2]=vals[2] = 2nd largest, half are >= it
+        self.assertEqual(
+            checkpoint_util.quorum_event_time([10.0, 20.0, 30.0, 40.0], 0.5), 30.0
+        )
+
+    def test_quorum_event_time_half_odd(self):
+        # m=3, k=ceil(0.5*3)=ceil(1.5)=2 -> vals[3-2]=vals[1] = median
+        self.assertEqual(
+            checkpoint_util.quorum_event_time([10.0, 30.0, 20.0], 0.5), 20.0
+        )
+
+    def test_quorum_event_time_robust_to_outlier(self):
+        # a single far-future garbage value does not move the median (quorum 0.5)
+        self.assertEqual(
+            checkpoint_util.quorum_event_time([100.0, 101.0, 1e18], 0.5), 101.0
+        )
+
+    def _policy_manager(self, **policy):
+        """A CheckpointManager with save() mocked and a save policy applied."""
+        tmp_dir = tempfile.mkdtemp(dir="./")
+        self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
+        mgr = checkpoint_util.CheckpointManager(tmp_dir)
+        defaults = dict(
+            save_steps=0,
+            save_epochs=0,
+            ts_interval_s=0,
+            ts_targets=[],
+            ts_quorum=0.5,
+        )
+        defaults.update(policy)
+        mgr.set_save_policy(**defaults)
+        mgr.save = mock.MagicMock(return_value="ckpt")
+        return mgr
+
+    def test_maybe_save_step_interval(self):
+        mgr = self._policy_manager(save_steps=10)
+        self.assertFalse(mgr.maybe_save(5, model=None))
+        self.assertTrue(mgr.maybe_save(10, model=None))
+        self.assertEqual(mgr.save.call_count, 1)
+
+    def test_maybe_save_epoch_interval(self):
+        mgr = self._policy_manager(save_epochs=2)
+        self.assertFalse(mgr.maybe_save(100, model=None, epoch=0))
+        self.assertTrue(mgr.maybe_save(100, model=None, epoch=1))
+
+    def test_maybe_save_dedupe_epoch_after_same_step(self):
+        # regression: an epoch save right after a same-step save must not re-save
+        mgr = self._policy_manager(save_steps=10, save_epochs=1)
+        self.assertTrue(mgr.maybe_save(10, model=None))  # step trigger
+        self.assertFalse(mgr.maybe_save(10, model=None, epoch=0))  # same step -> no-op
+        self.assertEqual(mgr.save.call_count, 1)
+
+    def test_maybe_save_final_dedupe(self):
+        mgr = self._policy_manager(save_steps=10)
+        self.assertTrue(mgr.maybe_save(10, model=None))
+        self.assertFalse(mgr.maybe_save(10, model=None, final=True))  # already saved
+        self.assertTrue(mgr.maybe_save(11, model=None, final=True))  # new step
+
+    def test_maybe_save_timestamp_init_then_fire(self):
+        mgr = self._policy_manager(ts_interval_s=3600)
+        # first observed event-time only initializes the reference, no save
+        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[3599.0]))
+        # crossing the next Unix-epoch-aligned boundary fires
+        self.assertTrue(mgr.maybe_save(2, model=None, worker_ts_list=[3600.0]))
+
+    def test_maybe_save_timestamp_quorum(self):
+        # quorum=1.0: only fires once the slowest worker crosses
+        mgr = self._policy_manager(ts_interval_s=3600, ts_quorum=1.0)
+        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[3000.0, 3000.0]))
+        # one worker crossed, the other not -> min still in old bucket -> no save
+        self.assertFalse(mgr.maybe_save(2, model=None, worker_ts_list=[3700.0, 3500.0]))
+        # both crossed -> save
+        self.assertTrue(mgr.maybe_save(3, model=None, worker_ts_list=[3700.0, 3601.0]))
+
+    def test_maybe_save_stamps_watermark(self):
+        mgr = self._policy_manager(ts_interval_s=3600)
+        state = {}
+        self.assertFalse(
+            mgr.maybe_save(
+                1, model=None, dataloader_state=state, worker_ts_list=[3599.0]
+            )
+        )
+        self.assertTrue(
+            mgr.maybe_save(
+                2, model=None, dataloader_state=state, worker_ts_list=[3600.0]
+            )
+        )
+        self.assertEqual(state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+
+    def test_restore_seeds_watermark(self):
+        mgr = self._policy_manager(ts_interval_s=3600)
+        tmp_dir = tempfile.mkdtemp(dir="./")
+        self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
+        checkpoint_util.save_dataloader_state(
+            tmp_dir, {"topic:0": 5, checkpoint_util.DATA_TS_WATERMARK: 7200.0}
+        )
+        state = mgr.restore_dataloader_state(tmp_dir)
+        self.assertEqual(state[checkpoint_util.DATA_TS_WATERMARK], 7200.0)
+        # seeded reference: a value in the same bucket does not re-fire
+        self.assertFalse(mgr.maybe_save(1, model=None, worker_ts_list=[7201.0]))
+        # crossing the next boundary fires
+        self.assertTrue(mgr.maybe_save(2, model=None, worker_ts_list=[10800.0]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -481,6 +481,87 @@ class DataloaderCheckpointTest(unittest.TestCase):
 
         self.assertEqual(checkpoint_state, {"path:0": 100, "path:500": 200})
 
+    def test_should_save_on_timestamp_first_batch(self):
+        """No reference yet -> only initialize, never save."""
+        self.assertFalse(
+            checkpoint_util.should_save_on_timestamp(
+                1000, None, interval_s=600, target_ts_list=[500]
+            )
+        )
+
+    def test_should_save_on_timestamp_interval_crossed(self):
+        """Crossing an epoch-aligned interval boundary fires."""
+        # floor(3600/3600)=1 > floor(3599/3600)=0
+        self.assertTrue(
+            checkpoint_util.should_save_on_timestamp(
+                3600, 3599, interval_s=3600, target_ts_list=[]
+            )
+        )
+
+    def test_should_save_on_timestamp_interval_not_crossed(self):
+        """Same interval bucket does not fire."""
+        # floor(3500/3600) == floor(3000/3600) == 0
+        self.assertFalse(
+            checkpoint_util.should_save_on_timestamp(
+                3500, 3000, interval_s=3600, target_ts_list=[]
+            )
+        )
+
+    def test_should_save_on_timestamp_interval_disabled(self):
+        """interval_s=0 disables the interval trigger."""
+        self.assertFalse(
+            checkpoint_util.should_save_on_timestamp(
+                10000, 0, interval_s=0, target_ts_list=[]
+            )
+        )
+
+    def test_should_save_on_timestamp_target_crossed(self):
+        """Crossing an absolute target fires (boundary inclusive on the right)."""
+        self.assertTrue(
+            checkpoint_util.should_save_on_timestamp(
+                1500, 1000, interval_s=0, target_ts_list=[1500]
+            )
+        )
+        self.assertTrue(
+            checkpoint_util.should_save_on_timestamp(
+                1600, 1000, interval_s=0, target_ts_list=[1500]
+            )
+        )
+
+    def test_should_save_on_timestamp_target_not_reached(self):
+        """Target ahead of consumed event-time does not fire."""
+        self.assertFalse(
+            checkpoint_util.should_save_on_timestamp(
+                1400, 1000, interval_s=0, target_ts_list=[1500]
+            )
+        )
+
+    def test_should_save_on_timestamp_target_no_refire(self):
+        """A target already behind the reference does not refire."""
+        self.assertFalse(
+            checkpoint_util.should_save_on_timestamp(
+                2000, 1500, interval_s=0, target_ts_list=[1500]
+            )
+        )
+
+    def test_should_save_on_timestamp_multiple_targets(self):
+        """Any one crossed target in the window fires."""
+        self.assertTrue(
+            checkpoint_util.should_save_on_timestamp(
+                1600, 1000, interval_s=0, target_ts_list=[900, 1500, 5000]
+            )
+        )
+
+    def test_should_save_on_timestamp_interval_and_targets(self):
+        """Targets fire even when the interval boundary is not crossed."""
+        # same interval bucket (floor(1600/3600)==floor(1000/3600)==0) but a target
+        # at 1500 is crossed.
+        self.assertTrue(
+            checkpoint_util.should_save_on_timestamp(
+                1600, 1000, interval_s=3600, target_ts_list=[1500]
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tzrec/utils/dist_util.py
+++ b/tzrec/utils/dist_util.py
@@ -88,27 +88,6 @@ def get_dist_object_pg(world_size: Optional[int] = None) -> Optional[dist.Proces
     return pg
 
 
-def gather_float_scalar(
-    value: float, group: Optional[dist.ProcessGroup] = None
-) -> List[float]:
-    """All-gather a float scalar from every rank into one list.
-
-    Args:
-        value: this rank's scalar.
-        group: process group to gather over; pass a CPU (gloo) group to keep the
-            gather off the GPU and avoid a per-call device sync. Defaults to the
-            world group.
-
-    Returns:
-        Each rank's value in rank order (``[value]`` when not distributed).
-    """
-    if not dist.is_initialized():
-        return [value]
-    gathered: List[float] = [0.0] * dist.get_world_size(group)
-    dist.all_gather_object(gathered, value, group=group)
-    return gathered
-
-
 # fix missing create_mean_pooling_callback of mc-ebc input_dist
 def _mc_ebc_input_dist(
     # pyre-ignore [2]

--- a/tzrec/utils/dist_util.py
+++ b/tzrec/utils/dist_util.py
@@ -88,6 +88,27 @@ def get_dist_object_pg(world_size: Optional[int] = None) -> Optional[dist.Proces
     return pg
 
 
+def gather_float_scalar(
+    value: float, device: Optional[torch.device] = None
+) -> List[float]:
+    """All-gather a float scalar from every rank into one list.
+
+    Args:
+        value: this rank's scalar.
+        device: device for the gather tensors.
+
+    Returns:
+        Each rank's value, in rank order (just ``[value]`` when not distributed).
+    """
+    if not dist.is_initialized():
+        return [value]
+    world_size = dist.get_world_size()
+    local = torch.tensor([value], dtype=torch.float64, device=device)
+    gathered = torch.empty(world_size, dtype=torch.float64, device=device)
+    dist.all_gather_into_tensor(gathered, local)
+    return gathered.tolist()
+
+
 # fix missing create_mean_pooling_callback of mc-ebc input_dist
 def _mc_ebc_input_dist(
     # pyre-ignore [2]

--- a/tzrec/utils/dist_util.py
+++ b/tzrec/utils/dist_util.py
@@ -89,24 +89,24 @@ def get_dist_object_pg(world_size: Optional[int] = None) -> Optional[dist.Proces
 
 
 def gather_float_scalar(
-    value: float, device: Optional[torch.device] = None
+    value: float, group: Optional[dist.ProcessGroup] = None
 ) -> List[float]:
     """All-gather a float scalar from every rank into one list.
 
     Args:
         value: this rank's scalar.
-        device: device for the gather tensors.
+        group: process group to gather over; pass a CPU (gloo) group to keep the
+            gather off the GPU and avoid a per-call device sync. Defaults to the
+            world group.
 
     Returns:
-        Each rank's value, in rank order (just ``[value]`` when not distributed).
+        Each rank's value in rank order (``[value]`` when not distributed).
     """
     if not dist.is_initialized():
         return [value]
-    world_size = dist.get_world_size()
-    local = torch.tensor([value], dtype=torch.float64, device=device)
-    gathered = torch.empty(world_size, dtype=torch.float64, device=device)
-    dist.all_gather_into_tensor(gathered, local)
-    return gathered.tolist()
+    gathered: List[float] = [0.0] * dist.get_world_size(group)
+    dist.all_gather_object(gathered, value, group=group)
+    return gathered
 
 
 # fix missing create_mean_pooling_callback of mc-ebc input_dist

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"


### PR DESCRIPTION
## Motivation

For online/streaming training from Kafka, `KafkaReader` previously surfaced only the message **offset** (as the resume cursor); the Kafka message **timestamp** was never read, so there was no way to checkpoint based on the *event-time* of the consumed data. This PR surfaces the message timestamp and uses it to drive checkpoint saves on consumed event-time, which is what you want for time-aligned snapshots of a stream.

## What it does

Surfaces the Kafka message timestamp on the batch and adds event-time–driven checkpoint triggers, alongside the existing step/epoch triggers:

- **`batch.data_timestamp`** — the max consumed event-time in the batch, as **Unix-epoch seconds** (`float`; `-1.0` when the source has no timestamps). `KafkaReader` normalizes its ms timestamp to seconds; `BaseDataset._build_batch` just surfaces the per-batch max (unit-agnostic, so non-Kafka datasets are unaffected).
- **New `TrainConfig` fields:**
  - `save_checkpoints_timestamp_interval` — save every N seconds of consumed event-time, aligned to the Unix epoch (wall-clock), not training epochs. `0` disables.
  - `save_checkpoints_timestamps` — absolute event-time targets (Unix-epoch seconds); save once when consumed data crosses each. Empty disables.
  - `save_checkpoints_timestamp_quorum` — fraction of workers `(0, 1]`, default `0.5`, that must have consumed past a boundary/target before a save fires.

## Design

- **Centralized save policy.** All save cadence (step / epoch / event-time) + the single per-step dedupe + the event-time watermark live in `CheckpointManager.maybe_save(...) -> bool`; the training loop calls it at the step / epoch / final points and runs eval when it returns `True`. This removes the four hand-guarded save sites in the loop (the source of an epoch-vs-timestamp double-save) and makes the decision logic unit-testable.
- **Worker quorum (not min/max).** Each rank passes its local event-time to `maybe_save`, which all-gathers across workers and reduces to the `(1 - quorum)` upper quantile — the event-time that ≥ `quorum` fraction of workers have reached. This generalizes min (`quorum=1.0`) / max (`quorum→0`), is robust to a single outlier/garbage timestamp at the default `0.5`, and counts a worker without a timestamp (`-1.0`) as "not past" so the quorum is over all workers.
- **Off the GPU.** The per-step reconciliation gathers over a dedicated CPU (gloo) process group that `CheckpointManager` creates in `set_save_policy` and owns, so it never runs on the model device or forces a per-step device sync that would stall the `TrainPipelineSparseDist` prefetch.
- **Resume-correct.** The event-time watermark is persisted in `dataloader_state` (saved every checkpoint, restored on `continue_train`) and advanced on every save, so resume re-fires no already-saved boundary and misses none. It's a single global float, identical across ranks (the per-key max-merge is a no-op on it) and ignored by the existing `dataloader_state` consumers. `dataloader_state` is typed `Dict[str, Any]` since it now holds the float watermark alongside the int offsets.
- **Distributed-safe.** The reconciliation is gated only by config (identical on all ranks) and the save decision is deterministic + identical across ranks, so the collective `save` is entered in lockstep; nothing collective runs when not saving. It relies on the same equal-step-count invariant the model's own gradient collectives already require.
- **No behavior change when unset** — with the new config fields unset, training is identical to before.

## Tests

- Pure helpers `quorum_event_time` (quantile incl. outlier/sentinel cases) and `should_save_on_timestamp` (interval/target crossings, no-refire, first-batch init) — parameterized.
- `CheckpointManager.maybe_save` — step/epoch/timestamp triggers, the dedupe (incl. the epoch-after-same-step regression), watermark stamping, restore seeding, and the `-1.0`-sentinel path; plus `_reconcile_event_time` single-process behavior (`save` mocked, no GPU/dist needed).
- `_build_batch` `data_timestamp` extraction; Kafka roundtrip asserts a positive seconds value.
- Docs: the three new `TrainConfig` fields documented in `train.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
