### PR TITLE
[doc] fix grouped sequence_fields default rule; drop epoch/wall-clock note from train.md

### DIFF
--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -778,7 +778,7 @@ feature_configs {
     - 在不指定sequence_fields的情况下:
       - 对于只有一个输入字段的特征算子（如: IdFeature，RawFeature，TokenizeFeature等），`input_side != feature`的输入字段默认是序列类型
         - 以上述配置中`item_id`子特征为例，`item:iid`对应的输入样本数据中列名应为`click_seq__iid`
-      - 对于输入字段大于一个的特征算子（如: LookupFeature，ComboFeature等），`input_side != item`的输入字段默认是序列类型
+      - 对于输入字段大于一个的特征算子（如: LookupFeature，ComboFeature等），`input_side == item`的输入字段默认是序列类型，其余输入字段默认不是序列类型
         - 以上述配置中`user_cate_cnt`子特征为例，`item:cate`对应的输入样本数据中列名应为`click_seq__cate`，`user:kv_cate_cnt`对应的输入样本数据中列名应为`kv_cate_cnt`
     - 在指定sequence_fields的情况下：只有指定的字段认为是序列类型
       - 以上述配置中`user_search_cate_cnt`子特征为例，`user:searched_cate`对应的输入样本数据中列名应为`click_seq__searched_cate`，`user:kv_search_cate_cnt`对应的输入样本数据中列名应为`kv_search_cate_cnt`

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -63,7 +63,7 @@ LR策略可以支持按epoch更新或者按step更新
 - num_epochs: 训练的epoch数
 - save_checkpoints_steps: 保存模型的步数间隔，保存模型后会做一次评估
 - save_checkpoints_epochs: 保存模型的Epoch数间隔，保存模型后会做一次评估，与save_checkpoints_steps不能同时设置
-- save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次；边界按 Unix 时间(epoch/墙钟)对齐，而非训练 epoch。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
+- save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
 - save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的 Unix 时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
 - save_checkpoints_timestamp_quorum: 分布式训练下各rank消费的分区不同，事件时间也不同；当至少该比例（取值(0,1\]，默认0.5）的rank已消费越过边界/时间点时才触发保存。1.0表示所有rank都越过才保存（最保守），越小越激进（最小可仅需一个rank）；默认值对单个异常/超前的timestamp具有鲁棒性
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint


### PR DESCRIPTION
## What

Two doc fixes:

1. **`docs/source/feature/feature.md`** — fix an inverted condition in the grouped sequence feature docs: for multi-input feature ops (LookupFeature, ComboFeature, etc.) without explicit `sequence_fields`, inputs with `input_side == item` default to sequence type — the doc previously said `input_side != item`.
2. **`docs/source/usage/train.md`** — remove the confusing parenthetical「边界按 Unix 时间(epoch/墙钟)对齐，而非训练 epoch」from the `save_checkpoints_timestamp_interval` description; it used "epoch" in two senses (Unix epoch vs training epoch) in one sentence. The remaining text already describes the trigger; precise boundary semantics stay documented in `checkpoint_util.py`.

## Why

For (1), the stated rule contradicted both the implementation and the doc's own example on the next line:

- `BaseFeature._is_sequence_input` returns `side == "item"` for multi-input feature classes (`tzrec/features/feature.py`), mirroring the pyfg C++ rule in `sequence_feature.cc`.
- The example already shows the correct behavior: `item:cate` maps to column `click_seq__cate` (sequence, prefixed) while `user:kv_cate_cnt` maps to `kv_cate_cnt` (non-sequence, unprefixed).

Verified live: a grouped `lookup_feature` with `map: "user:kv_cate_cnt"`, `key: "item:cate"` and no `sequence_fields` yields `sequence_input_names == ['click_seq__cate']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)