### PR TITLE
[bugfix] correct dataloader checkpoint resume across forked workers and epochs

### DIFF
--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -756,6 +756,7 @@ def create_dataloader(
     mode: Mode = Mode.TRAIN,
     gl_cluster: Optional[Dict[str, Union[int, str]]] = None,
     debug_level: int = 0,
+    checkpoint_state: Optional[Dict[str, Any]] = None,
 ) -> DataLoader:
     """Build dataloader.
 
@@ -768,6 +769,11 @@ def create_dataloader(
         gl_cluster (dict, bool): if set, reuse the graphlearn cluster.
         debug_level (int): dataset debug level, when mode=predict and
             debug_level > 0, will dump fg encoded data to debug_str
+        checkpoint_state (dict, optional): dataloader checkpoint state for
+            resume. Must be set here rather than on the returned dataloader:
+            the eager ``iter(dataloader)`` below forks persistent workers,
+            which keep a fork-time copy of the dataset, so state applied
+            afterwards never reaches them.
 
     Return:
         dataloader (dataloader): a DataLoader.
@@ -783,6 +789,8 @@ def create_dataloader(
         mode=mode,
         debug_level=debug_level,
     )
+    if checkpoint_state:
+        dataset.load_state_dict(checkpoint_state)
 
     kwargs = {}
     if data_config.num_workers < 1:

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -306,6 +306,10 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         worker_id, num_workers = self.get_worker_info()
         for input_data in self._reader.to_batches(worker_id, num_workers):
             yield self._build_batch(input_data)
+        # Normal exhaustion = the resumed pass is complete; clear the state so
+        # subsequent epochs do full passes. close()/GeneratorExit skips this
+        # line, so dataloader resets mid-pass still re-seek from the state.
+        self._reader.load_state_dict(None)
 
     def _build_batch(self, input_data: Dict[str, pa.Array]) -> Batch:
         """Process input data and build batch.
@@ -790,7 +794,7 @@ def create_dataloader(
         debug_level=debug_level,
     )
     if checkpoint_state:
-        dataset.load_state_dict(checkpoint_state)
+        dataset.load_state_dict(dict(checkpoint_state))
 
     kwargs = {}
     if data_config.num_workers < 1:

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -306,9 +306,7 @@ class BaseDataset(IterableDataset, metaclass=_dataset_meta_cls):
         worker_id, num_workers = self.get_worker_info()
         for input_data in self._reader.to_batches(worker_id, num_workers):
             yield self._build_batch(input_data)
-        # Normal exhaustion = the resumed pass is complete; clear the state so
-        # subsequent epochs do full passes. close()/GeneratorExit skips this
-        # line, so dataloader resets mid-pass still re-seek from the state.
+        # pass complete: clear the resume state so later epochs do full passes
         self._reader.load_state_dict(None)
 
     def _build_batch(self, input_data: Dict[str, pa.Array]) -> Batch:
@@ -773,11 +771,8 @@ def create_dataloader(
         gl_cluster (dict, bool): if set, reuse the graphlearn cluster.
         debug_level (int): dataset debug level, when mode=predict and
             debug_level > 0, will dump fg encoded data to debug_str
-        checkpoint_state (dict, optional): dataloader checkpoint state for
-            resume. Must be set here rather than on the returned dataloader:
-            the eager ``iter(dataloader)`` below forks persistent workers,
-            which keep a fork-time copy of the dataset, so state applied
-            afterwards never reaches them.
+        checkpoint_state (dict, optional): resume state, applied before the
+            eager ``iter()`` forks workers so it reaches them.
 
     Return:
         dataloader (dataloader): a DataLoader.
@@ -849,10 +844,7 @@ def create_dataloader(
     first_iterator = iter(dataloader)
 
     def get_iterator() -> Iterator[Batch]:
-        # First call returns the eagerly created iterator so its prefetched
-        # batches (including a short resumed tail) are consumed instead of
-        # being reset and discarded by a new iter(); later calls return a
-        # fresh iterator.
+        # return the eager iterator first (keeps its prefetch), then fresh ones
         nonlocal first_iterator
         if first_iterator is not None:
             it, first_iterator = first_iterator, None

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -846,5 +846,18 @@ def create_dataloader(
     # For PyTorch versions 2.6 and above, we initialize the data iterator before
     # beginning the training process to avoid potential CUDA-related issues following
     # model saving.
-    iter(dataloader)
+    first_iterator = iter(dataloader)
+
+    def get_iterator() -> Iterator[Batch]:
+        # First call returns the eagerly created iterator so its prefetched
+        # batches (including a short resumed tail) are consumed instead of
+        # being reset and discarded by a new iter(); later calls return a
+        # fresh iterator.
+        nonlocal first_iterator
+        if first_iterator is not None:
+            it, first_iterator = first_iterator, None
+            return it
+        return iter(dataloader)
+
+    dataloader.get_iterator = get_iterator  # pyre-ignore[16]
     return dataloader

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -23,6 +23,7 @@ from pyarrow import parquet
 from torch import distributed as dist
 from torch.utils.data import DataLoader
 
+from tzrec.datasets.dataset import create_dataloader
 from tzrec.datasets.parquet_dataset import ParquetDataset, ParquetReader, ParquetWriter
 from tzrec.features.feature import create_features
 from tzrec.protos import data_pb2, feature_pb2
@@ -234,6 +235,50 @@ class ParquetDatasetTest(unittest.TestCase):
                 if key in checkpoint_state_acc:
                     # New offset should be less than or equal to acc checkpoint offset
                     self.assertLessEqual(new_offset, checkpoint_state_acc[key])
+
+    def test_create_dataloader_checkpoint_state_reaches_workers(self):
+        """State passed to create_dataloader must reach forked workers.
+
+        create_dataloader eagerly starts persistent workers, so state applied
+        to the returned dataloader's dataset afterwards never reaches them;
+        the checkpoint_state argument applies it before the fork.
+        """
+        feature_cfgs = self._create_feature_cfgs()
+        features = create_features(feature_cfgs)
+
+        with tempfile.TemporaryDirectory(prefix="tzrec_") as test_dir:
+            # 20000 rows at max_rows_per_file=5000 -> 4 files, so
+            # data_config.num_workers=2 survives the num_files clamp.
+            self._create_test_parquet_data(test_dir, num_rows=20000)
+            input_path = f"{test_dir}/*.parquet"
+            data_config = data_pb2.DataConfig(
+                batch_size=128,
+                dataset_type=data_pb2.DatasetType.ParquetDataset,
+                fg_mode=data_pb2.FgMode.FG_NONE,
+                label_fields=["label"],
+                num_workers=2,
+            )
+
+            dataloader1 = create_dataloader(data_config, features, input_path)
+            iterator1 = iter(dataloader1)
+            checkpoint_state = {}
+            for _ in range(4):
+                batch1 = next(iterator1)
+                update_dataloder_state(checkpoint_state, batch1.checkpoint_info)
+            self.assertGreater(len(checkpoint_state), 0)
+            del iterator1, dataloader1
+
+            dataloader2 = create_dataloader(
+                data_config, features, input_path, checkpoint_state=checkpoint_state
+            )
+            iterator2 = iter(dataloader2)
+            for _ in range(4):
+                batch2 = next(iterator2)
+                for key, new_offset in batch2.checkpoint_info.items():
+                    if key in checkpoint_state:
+                        # without the pre-fork state, workers replay from row 0
+                        self.assertGreater(new_offset, checkpoint_state[key])
+            del iterator2, dataloader2
 
 
 class ParquetReaderTest(unittest.TestCase):

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -28,7 +28,7 @@ from tzrec.datasets.parquet_dataset import ParquetDataset, ParquetReader, Parque
 from tzrec.features.feature import create_features
 from tzrec.protos import data_pb2, feature_pb2
 from tzrec.utils import misc_util
-from tzrec.utils.checkpoint_util import update_dataloder_state
+from tzrec.utils.checkpoint_util import EPOCHS_COMPLETED, update_dataloder_state
 
 
 class ParquetDatasetTest(unittest.TestCase):
@@ -300,6 +300,19 @@ class ParquetDatasetTest(unittest.TestCase):
             _, num_second_pass_rows = _drain(iter(dataloader2))
             self.assertEqual(num_second_pass_rows, num_total_rows)
             del dataloader2
+
+            # epoch-boundary checkpoints carry only reserved meta keys
+            # (__epochs_completed__ etc.); readers must skip them and read
+            # the full dataset
+            dataloader3 = create_dataloader(
+                data_config,
+                features,
+                input_path,
+                checkpoint_state={EPOCHS_COMPLETED: 1},
+            )
+            _, num_meta_only_rows = _drain(iter(dataloader3))
+            self.assertEqual(num_meta_only_rows, num_total_rows)
+            del dataloader3
 
 
 class ParquetReaderTest(unittest.TestCase):

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -246,9 +246,17 @@ class ParquetDatasetTest(unittest.TestCase):
         feature_cfgs = self._create_feature_cfgs()
         features = create_features(feature_cfgs)
 
+        def _drain(iterator):
+            keys = set()
+            num_rows = 0
+            for batch in iterator:
+                keys |= set(batch.checkpoint_info)
+                num_rows += len(batch.labels["label"])
+            return keys, num_rows
+
         with tempfile.TemporaryDirectory(prefix="tzrec_") as test_dir:
-            # 20000 rows at max_rows_per_file=5000 -> 4 files, so
-            # data_config.num_workers=2 survives the num_files clamp.
+            # 20000 rows at max_rows_per_file=5000 -> 4 files: rebalanced
+            # multi-worker intervals plus a tail remaining after 4 batches.
             self._create_test_parquet_data(test_dir, num_rows=20000)
             input_path = f"{test_dir}/*.parquet"
             data_config = data_pb2.DataConfig(
@@ -266,19 +274,32 @@ class ParquetDatasetTest(unittest.TestCase):
                 batch1 = next(iterator1)
                 update_dataloder_state(checkpoint_state, batch1.checkpoint_info)
             self.assertGreater(len(checkpoint_state), 0)
+            # baseline rows of a full pass: 4 consumed batches + the rest
+            _, num_remain_rows = _drain(iterator1)
+            num_total_rows = 4 * 128 + num_remain_rows
             del iterator1, dataloader1
 
+            num_consumed_rows = sum(
+                consumed - int(key.rsplit(":", 1)[1]) + 1
+                for key, consumed in checkpoint_state.items()
+            )
             dataloader2 = create_dataloader(
                 data_config, features, input_path, checkpoint_state=checkpoint_state
             )
-            iterator2 = iter(dataloader2)
-            for _ in range(4):
-                batch2 = next(iterator2)
-                for key, new_offset in batch2.checkpoint_info.items():
-                    if key in checkpoint_state:
-                        # without the pre-fork state, workers replay from row 0
-                        self.assertGreater(new_offset, checkpoint_state[key])
-            del iterator2, dataloader2
+            resumed_keys, num_resumed_rows = _drain(iter(dataloader2))
+            # resumed intervals start at consumed+1, never at a saved start;
+            # without the pre-fork state, workers would replay the saved keys
+            self.assertTrue(resumed_keys.isdisjoint(checkpoint_state))
+            for key, consumed in checkpoint_state.items():
+                path = key.rsplit(":", 1)[0]
+                self.assertIn(f"{path}:{consumed + 1}", resumed_keys)
+            self.assertEqual(num_resumed_rows, num_total_rows - num_consumed_rows)
+
+            # state is consumed by the completed pass: a second iter() on the
+            # same (persistent-worker) dataloader reads the full dataset again
+            _, num_second_pass_rows = _drain(iter(dataloader2))
+            self.assertEqual(num_second_pass_rows, num_total_rows)
+            del dataloader2
 
 
 class ParquetReaderTest(unittest.TestCase):

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -314,6 +314,64 @@ class ParquetDatasetTest(unittest.TestCase):
             self.assertEqual(num_meta_only_rows, num_total_rows)
             del dataloader3
 
+    def test_create_dataloader_get_iterator_reuses_eager_iterator(self):
+        """get_iterator() yields the eagerly prefetched iterator first.
+
+        When a resumed tail fits inside the eager iter()'s prefetch window it
+        exhausts (and clears the state) before training starts; reusing that
+        same iterator -- rather than resetting with a fresh iter() -- keeps the
+        tail's batches instead of silently re-reading the full share.
+        """
+        feature_cfgs = self._create_feature_cfgs()
+        features = create_features(feature_cfgs)
+
+        def _drain(iterator):
+            num_rows = 0
+            for batch in iterator:
+                num_rows += len(batch.labels["label"])
+            return num_rows
+
+        with tempfile.TemporaryDirectory(prefix="tzrec_") as test_dir:
+            self._create_test_parquet_data(test_dir, num_rows=20000)
+            input_path = f"{test_dir}/*.parquet"
+            data_config = data_pb2.DataConfig(
+                batch_size=128,
+                dataset_type=data_pb2.DatasetType.ParquetDataset,
+                fg_mode=data_pb2.FgMode.FG_NONE,
+                label_fields=["label"],
+                num_workers=2,
+            )
+
+            # full pass to learn the per-worker interval keys + total rows
+            dataloader0 = create_dataloader(data_config, features, input_path)
+            full_state = {}
+            num_total_rows = 0
+            for batch in dataloader0.get_iterator():  # pyre-ignore[16]
+                update_dataloder_state(full_state, batch.checkpoint_info)
+                num_total_rows += len(batch.labels["label"])
+            del dataloader0
+
+            # leave a tiny tail (a few rows per interval) that fits prefetch
+            tail = 3
+            tail_state = {key: consumed - tail for key, consumed in full_state.items()}
+            expected_tail_rows = sum(
+                consumed - int(key.rsplit(":", 1)[1]) + 1
+                for key, consumed in tail_state.items()
+            )
+            expected_tail_rows = num_total_rows - expected_tail_rows
+
+            dataloader = create_dataloader(
+                data_config, features, input_path, checkpoint_state=tail_state
+            )
+            # first get_iterator() == the eager iterator -> resumed tail only
+            num_tail_rows = _drain(dataloader.get_iterator())  # pyre-ignore[16]
+            self.assertEqual(num_tail_rows, expected_tail_rows)
+            self.assertLess(num_tail_rows, num_total_rows)
+            # state cleared on exhaustion -> next get_iterator() is a full pass
+            num_next_rows = _drain(dataloader.get_iterator())  # pyre-ignore[16]
+            self.assertEqual(num_next_rows, num_total_rows)
+            del dataloader
+
 
 class ParquetReaderTest(unittest.TestCase):
     def setUp(self):

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -237,12 +237,7 @@ class ParquetDatasetTest(unittest.TestCase):
                     self.assertLessEqual(new_offset, checkpoint_state_acc[key])
 
     def test_create_dataloader_checkpoint_state_reaches_workers(self):
-        """State passed to create_dataloader must reach forked workers.
-
-        create_dataloader eagerly starts persistent workers, so state applied
-        to the returned dataloader's dataset afterwards never reaches them;
-        the checkpoint_state argument applies it before the fork.
-        """
+        """checkpoint_state passed to create_dataloader must reach forked workers."""
         feature_cfgs = self._create_feature_cfgs()
         features = create_features(feature_cfgs)
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -480,6 +480,9 @@ def _train_and_evaluate(
                     if not lr.by_epoch:
                         lr.step()
             except StopIteration:
+                # pass completed: later saves should record positions
+                # within the next pass.
+                dataloader_state.clear()
                 step_iter = itertools.chain([i_step], step_iter)
                 i_step -= 1
                 break

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -349,9 +349,8 @@ def _train_and_evaluate(
     use_step = train_config.num_steps and train_config.num_steps > 0
     epochs_completed = dataloader_state.get(checkpoint_util.EPOCHS_COMPLETED, 0)
     if use_epoch and epochs_completed >= train_config.num_epochs:
-        # nothing left to train: returning here avoids re-saving a checkpoint
-        # of freshly-initialized weights (the model restore lives inside the
-        # epoch loop, which would not run).
+        # nothing left to train; return before the model restore (inside the
+        # epoch loop) is skipped and a fresh-weight checkpoint is re-saved.
         if is_local_rank_zero:
             logger.warning(
                 f"{epochs_completed} epochs already completed in the restored "

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -608,7 +608,7 @@ def train_and_evaluate(
                 f"[{pipeline_config.train_config.fine_tune_checkpoint}] not exists."
             )
     if os.path.exists(pipeline_config.model_dir):
-        # Restore dataloader state if continuing training
+        # Find the latest checkpoint in model_dir when continuing training
         latest_ckpt_path, skip_steps = ckpt_manager.latest_checkpoint()
         if latest_ckpt_path:
             if continue_train:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -348,8 +348,18 @@ def _train_and_evaluate(
     use_epoch = train_config.num_epochs and train_config.num_epochs > 0
     use_step = train_config.num_steps and train_config.num_steps > 0
     epochs_completed = dataloader_state.get(checkpoint_util.EPOCHS_COMPLETED, 0)
+    if use_epoch and epochs_completed >= train_config.num_epochs:
+        # nothing left to train: returning here avoids re-saving a checkpoint
+        # of freshly-initialized weights (the model restore lives inside the
+        # epoch loop, which would not run).
+        if is_local_rank_zero:
+            logger.warning(
+                f"{epochs_completed} epochs already completed in the restored "
+                "checkpoint, no epochs left to train."
+            )
+        return
     epoch_iter = (
-        range(min(epochs_completed, train_config.num_epochs), train_config.num_epochs)
+        range(epochs_completed, train_config.num_epochs)
         if use_epoch
         else itertools.count(0, 0)
     )
@@ -440,23 +450,27 @@ def _train_and_evaluate(
         if plogger is not None:
             plogger.set_description(f"Training Epoch {i_epoch}")
 
-        train_iterator = iter(train_dataloader)
+        train_iterator = train_dataloader.get_iterator()  # pyre-ignore[16]
 
         # Restore model and optimizer checkpoint
         if i_step == 0 and ckpt_path is not None:
-            if ignore_restore_optimizer:
-                ckpt_manager.restore(
-                    ckpt_path, model, None, train_config.fine_tune_ckpt_param_map
-                )
-            else:
-                # because optimizer's state is lazy init, we should do a dummy
-                # step before restore.
-                peek_batch = next(train_iterator)
+            # because optimizer's state is lazy init, we should do a dummy
+            # step before restore. a fully-consumed resumed pass has no data
+            # to peek, so the optimizer state stays lazy and is restored on
+            # the next pass.
+            try:
+                peek_batch = None if ignore_restore_optimizer else next(train_iterator)
+            except StopIteration:
+                peek_batch = None
+            if peek_batch is not None:
                 pipeline.progress(iter([peek_batch]))
                 train_iterator = itertools.chain([peek_batch], train_iterator)
-                ckpt_manager.restore(
-                    ckpt_path, model, optimizer, train_config.fine_tune_ckpt_param_map
-                )
+            ckpt_manager.restore(
+                ckpt_path,
+                model,
+                None if peek_batch is None else optimizer,
+                train_config.fine_tune_ckpt_param_map,
+            )
 
         for i_step in step_iter:
             if i_step <= skip_steps:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -588,22 +588,6 @@ def train_and_evaluate(
     # Build feature
     features = _create_features(list(pipeline_config.feature_configs), data_config)
 
-    # Build dataloader
-    train_dataloader = create_dataloader(
-        data_config, features, pipeline_config.train_input_path, mode=Mode.TRAIN
-    )
-    eval_dataloader = None
-    if pipeline_config.eval_input_path:
-        # pyre-ignore [16]
-        gl_cluster = train_dataloader.dataset.get_sampler_cluster()
-        eval_dataloader = create_dataloader(
-            data_config,
-            features,
-            pipeline_config.eval_input_path,
-            mode=Mode.EVAL,
-            gl_cluster=gl_cluster,
-        )
-
     ckpt_manager = checkpoint_util.CheckpointManager(
         pipeline_config.model_dir,
         keep_checkpoint_max=train_config.keep_checkpoint_max,
@@ -637,12 +621,33 @@ def train_and_evaluate(
                     "--continue_train)"
                 )
 
-    # Restore dataloader checkpoint state
+    # Restore dataloader checkpoint state before building the dataloader:
+    # create_dataloader eagerly starts persistent workers, which keep a
+    # fork-time copy of the dataset, so state set afterwards is invisible
+    # to them.
     dataloader_state: Optional[Dict[str, Any]] = None
     if ckpt_path and continue_train:
         dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
-        if dataloader_state:
-            train_dataloader.dataset.load_state_dict(dataloader_state)
+
+    # Build dataloader
+    train_dataloader = create_dataloader(
+        data_config,
+        features,
+        pipeline_config.train_input_path,
+        mode=Mode.TRAIN,
+        checkpoint_state=dataloader_state,
+    )
+    eval_dataloader = None
+    if pipeline_config.eval_input_path:
+        # pyre-ignore [16]
+        gl_cluster = train_dataloader.dataset.get_sampler_cluster()
+        eval_dataloader = create_dataloader(
+            data_config,
+            features,
+            pipeline_config.eval_input_path,
+            mode=Mode.EVAL,
+            gl_cluster=gl_cluster,
+        )
 
     sampler_type = _get_sampler_type(data_config)
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -347,7 +347,20 @@ def _train_and_evaluate(
     )
     use_epoch = train_config.num_epochs and train_config.num_epochs > 0
     use_step = train_config.num_steps and train_config.num_steps > 0
-    epoch_iter = range(train_config.num_epochs) if use_epoch else itertools.count(0, 0)
+    epochs_completed = dataloader_state.get(checkpoint_util.EPOCHS_COMPLETED, 0)
+    if use_epoch and epochs_completed >= train_config.num_epochs:
+        if is_local_rank_zero:
+            logger.warning(
+                f"all {train_config.num_epochs} epochs already completed "
+                "in the restored checkpoint, no epochs left to train."
+            )
+    elif epochs_completed > 0 and is_local_rank_zero:
+        logger.info(f"resume training after {epochs_completed} completed epochs.")
+    epoch_iter = (
+        range(min(epochs_completed, train_config.num_epochs), train_config.num_epochs)
+        if use_epoch
+        else itertools.count(0, 0)
+    )
     step_iter = range(train_config.num_steps) if use_step else itertools.count(0)
 
     save_checkpoints_steps, save_checkpoints_epochs = 0, 0
@@ -481,8 +494,10 @@ def _train_and_evaluate(
                         lr.step()
             except StopIteration:
                 # pass completed: later saves should record positions
-                # within the next pass.
+                # within the next pass, on top of the completed-pass count.
+                epochs_completed += 1
                 dataloader_state.clear()
+                dataloader_state[checkpoint_util.EPOCHS_COMPLETED] = epochs_completed
                 step_iter = itertools.chain([i_step], step_iter)
                 i_step -= 1
                 break
@@ -610,12 +625,14 @@ def train_and_evaluate(
                 "fine_tune_checkpoint"
                 f"[{pipeline_config.train_config.fine_tune_checkpoint}] not exists."
             )
+    resume_own_model_dir = False
     if os.path.exists(pipeline_config.model_dir):
         # Find the latest checkpoint in model_dir when continuing training
         latest_ckpt_path, skip_steps = ckpt_manager.latest_checkpoint()
         if latest_ckpt_path:
             if continue_train:
                 ckpt_path = latest_ckpt_path
+                resume_own_model_dir = True
             else:
                 raise RuntimeError(
                     f"model_dir[{pipeline_config.model_dir}] already exists "
@@ -631,6 +648,10 @@ def train_and_evaluate(
     dataloader_state: Optional[Dict[str, Any]] = None
     if ckpt_path and continue_train:
         dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
+        if dataloader_state and not resume_own_model_dir:
+            # fine-tune checkpoints carry data positions, not this job's
+            # epoch budget.
+            dataloader_state.pop(checkpoint_util.EPOCHS_COMPLETED, None)
 
     # Build dataloader
     train_dataloader = create_dataloader(

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -348,14 +348,6 @@ def _train_and_evaluate(
     use_epoch = train_config.num_epochs and train_config.num_epochs > 0
     use_step = train_config.num_steps and train_config.num_steps > 0
     epochs_completed = dataloader_state.get(checkpoint_util.EPOCHS_COMPLETED, 0)
-    if use_epoch and epochs_completed >= train_config.num_epochs:
-        if is_local_rank_zero:
-            logger.warning(
-                f"all {train_config.num_epochs} epochs already completed "
-                "in the restored checkpoint, no epochs left to train."
-            )
-    elif epochs_completed > 0 and is_local_rank_zero:
-        logger.info(f"resume training after {epochs_completed} completed epochs.")
     epoch_iter = (
         range(min(epochs_completed, train_config.num_epochs), train_config.num_epochs)
         if use_epoch
@@ -641,16 +633,12 @@ def train_and_evaluate(
                     "--continue_train)"
                 )
 
-    # Restore dataloader checkpoint state before building the dataloader:
-    # create_dataloader eagerly starts persistent workers, which keep a
-    # fork-time copy of the dataset, so state set afterwards is invisible
-    # to them.
+    # Restore dataloader state before create_dataloader starts its workers
     dataloader_state: Optional[Dict[str, Any]] = None
     if ckpt_path and continue_train:
         dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
         if dataloader_state and not resume_own_model_dir:
-            # fine-tune checkpoints carry data positions, not this job's
-            # epoch budget.
+            # fine-tune checkpoints do not carry this job's epoch budget
             dataloader_state.pop(checkpoint_util.EPOCHS_COMPLETED, None)
 
     # Build dataloader

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -453,21 +453,19 @@ def _train_and_evaluate(
 
         # Restore model and optimizer checkpoint
         if i_step == 0 and ckpt_path is not None:
-            # optimizer state is lazy, so peek one batch to init it before
-            # restore; an empty resumed pass has none, so restore model only.
-            try:
-                peek_batch = None if ignore_restore_optimizer else next(train_iterator)
-            except StopIteration:
-                peek_batch = None
-            if peek_batch is not None:
+            if ignore_restore_optimizer:
+                ckpt_manager.restore(
+                    ckpt_path, model, None, train_config.fine_tune_ckpt_param_map
+                )
+            else:
+                # optimizer state is lazy, so peek one batch to init it
+                # before restore.
+                peek_batch = next(train_iterator)
                 pipeline.progress(iter([peek_batch]))
                 train_iterator = itertools.chain([peek_batch], train_iterator)
-            ckpt_manager.restore(
-                ckpt_path,
-                model,
-                None if peek_batch is None else optimizer,
-                train_config.fine_tune_ckpt_param_map,
-            )
+                ckpt_manager.restore(
+                    ckpt_path, model, optimizer, train_config.fine_tune_ckpt_param_map
+                )
 
         for i_step in step_iter:
             if i_step <= skip_steps:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -617,14 +617,14 @@ def train_and_evaluate(
                 "fine_tune_checkpoint"
                 f"[{pipeline_config.train_config.fine_tune_checkpoint}] not exists."
             )
-    resume_own_model_dir = False
+    restore_from_model_dir = False
     if os.path.exists(pipeline_config.model_dir):
         # Find the latest checkpoint in model_dir when continuing training
         latest_ckpt_path, skip_steps = ckpt_manager.latest_checkpoint()
         if latest_ckpt_path:
             if continue_train:
                 ckpt_path = latest_ckpt_path
-                resume_own_model_dir = True
+                restore_from_model_dir = True
             else:
                 raise RuntimeError(
                     f"model_dir[{pipeline_config.model_dir}] already exists "
@@ -637,7 +637,7 @@ def train_and_evaluate(
     dataloader_state: Optional[Dict[str, Any]] = None
     if ckpt_path and continue_train:
         dataloader_state = ckpt_manager.restore_dataloader_state(ckpt_path)
-        if dataloader_state and not resume_own_model_dir:
+        if dataloader_state and not restore_from_model_dir:
             # fine-tune checkpoints do not carry this job's epoch budget
             dataloader_state.pop(checkpoint_util.EPOCHS_COMPLETED, None)
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -178,7 +178,7 @@ def _evaluate(
     )
 
     use_step = eval_config.num_steps and eval_config.num_steps > 0
-    iterator = iter(eval_dataloader)
+    iterator = eval_dataloader.get_iterator()  # pyre-ignore[16]
     step_iter = range(eval_config.num_steps) if use_step else itertools.count(0)
 
     desc_suffix = ""
@@ -454,10 +454,8 @@ def _train_and_evaluate(
 
         # Restore model and optimizer checkpoint
         if i_step == 0 and ckpt_path is not None:
-            # because optimizer's state is lazy init, we should do a dummy
-            # step before restore. a fully-consumed resumed pass has no data
-            # to peek, so the optimizer state stays lazy and is restored on
-            # the next pass.
+            # optimizer state is lazy, so peek one batch to init it before
+            # restore; an empty resumed pass has none, so restore model only.
             try:
                 peek_batch = None if ignore_restore_optimizer else next(train_iterator)
             except StopIteration:
@@ -1180,7 +1178,7 @@ def predict(
         mode=Mode.PREDICT,
         debug_level=debug_level,
     )
-    infer_iterator = iter(infer_dataloader)
+    infer_iterator = infer_dataloader.get_iterator()  # pyre-ignore[16]
 
     if writer_type is None:
         writer_type = DatasetType.Name(data_config.dataset_type).replace(
@@ -1469,7 +1467,7 @@ def predict_checkpoint(
         model.device,
         execute_all_batches=True,
     )
-    iterator = iter(predict_dataloader)
+    iterator = predict_dataloader.get_iterator()  # pyre-ignore[16]
     step_iter = range(predict_steps) if predict_steps else itertools.count(0)
 
     desc_suffix = ""

--- a/tzrec/tools/create_fg_json.py
+++ b/tzrec/tools/create_fg_json.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         dataloader = create_dataloader(
             pipeline_config.data_config, features, pipeline_config.train_input_path
         )
-        iterator = iter(dataloader)
+        iterator = dataloader.get_iterator()  # pyre-ignore[16]
         _ = next(iterator)
 
     tmp_dir = tempfile.mkdtemp(prefix="tzrec_")

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -184,7 +184,7 @@ def tdm_retrieval(
         mode=Mode.PREDICT,
         debug_level=debug_level,
     )
-    infer_iterator = iter(infer_dataloader)
+    infer_iterator = infer_dataloader.get_iterator()  # pyre-ignore[16]
 
     if writer_type is None:
         writer_type = DatasetType.Name(data_config.dataset_type).replace(

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -999,11 +999,6 @@ def restore_dataloader_state(
     with open(ckpt_path, "r") as f:
         state = json.load(f)
 
-    if EPOCHS_COMPLETED in state:
-        # coerce so a hand-edited/legacy value fails loudly here rather than
-        # deep inside range() when building the epoch iterator.
-        state[EPOCHS_COMPLETED] = int(state[EPOCHS_COMPLETED])
-
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
     if is_local_rank_zero:
         logger.info(f"Restored dataloader state from {ckpt_path}")

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -917,6 +917,9 @@ DATALOADER_CKPT_FILENAME = "dataloader_state.json"
 # reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
 # no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"
+# reserved dataloader_state key: number of completed data passes; resume
+# continues the epoch budget from here. no ":" so per-source consumers skip it.
+EPOCHS_COMPLETED = "__epochs_completed__"
 
 
 def save_dataloader_state(

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -425,6 +425,11 @@ class CheckpointManager:
             True if a checkpoint was saved.
         """
         data_ts = self._reconcile_event_time(data_timestamp)
+        # copy so the watermark isn't leaked back into the train loop's state
+        if dataloader_state is not None:
+            dataloader_state = dict(dataloader_state)
+            if data_ts is not None:
+                dataloader_state[DATA_TS_WATERMARK] = data_ts
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
@@ -448,28 +453,22 @@ class CheckpointManager:
         if not want:
             return False
         if step == self._last_ckpt_step:
-            # the pass-end step was already saved with fully-consumed offsets;
-            # a following epoch / final save carries the cleared + bumped state
-            # for the same step. refresh the existing checkpoint's dataloader
-            # state so the bookkeeping is not lost to the per-step dedupe. all
-            # ranks reach this branch in lockstep, so the collective inside
-            # save_dataloader_state is safe.
+            # a boundary save dedup'd against an already-saved step: refresh
+            # that checkpoint's state so the cleared + bumped bookkeeping is
+            # not lost to the dedupe (lockstep across ranks, so the collective
+            # in save_dataloader_state is safe).
             if (
                 (final or epoch is not None)
                 and dataloader_state is not None
                 and self._last_ckpt_dir is not None
             ):
-                if data_ts is not None:
-                    dataloader_state[DATA_TS_WATERMARK] = data_ts
                 save_dataloader_state(self._last_ckpt_dir, dataloader_state)
             return False
 
         self._last_ckpt_step = step
         if data_ts is not None:
-            # advance + persist the watermark on every save so resume is exact
+            # advance the watermark on every save so resume is exact
             self._last_data_ts = data_ts
-            if dataloader_state is not None:
-                dataloader_state[DATA_TS_WATERMARK] = data_ts
         self.save(step, model, optimizer, dataloader_state)
         return True
 

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -310,6 +310,7 @@ class CheckpointManager:
         self._ts_group: Optional[dist.ProcessGroup] = None
         # cadence state owned here so dedupe is centralized across all save sites
         self._last_ckpt_step = -1
+        self._last_ckpt_dir: Optional[str] = None
         self._last_data_ts: Optional[float] = None
 
     def save(
@@ -324,6 +325,7 @@ class CheckpointManager:
         save_model(ckpt_dir, model, optimizer)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
+        self._last_ckpt_dir = ckpt_dir
         self.prune()
         return ckpt_dir
 
@@ -443,7 +445,23 @@ class CheckpointManager:
             ):
                 want = True
 
-        if not want or step == self._last_ckpt_step:
+        if not want:
+            return False
+        if step == self._last_ckpt_step:
+            # the pass-end step was already saved with fully-consumed offsets;
+            # a following epoch / final save carries the cleared + bumped state
+            # for the same step. refresh the existing checkpoint's dataloader
+            # state so the bookkeeping is not lost to the per-step dedupe. all
+            # ranks reach this branch in lockstep, so the collective inside
+            # save_dataloader_state is safe.
+            if (
+                (final or epoch is not None)
+                and dataloader_state is not None
+                and self._last_ckpt_dir is not None
+            ):
+                if data_ts is not None:
+                    dataloader_state[DATA_TS_WATERMARK] = data_ts
+                save_dataloader_state(self._last_ckpt_dir, dataloader_state)
             return False
 
         self._last_ckpt_step = step
@@ -981,6 +999,11 @@ def restore_dataloader_state(
 
     with open(ckpt_path, "r") as f:
         state = json.load(f)
+
+    if EPOCHS_COMPLETED in state:
+        # coerce so a hand-edited/legacy value fails loudly here rather than
+        # deep inside range() when building the epoch iterator.
+        state[EPOCHS_COMPLETED] = int(state[EPOCHS_COMPLETED])
 
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
     if is_local_rank_zero:

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -697,7 +697,10 @@ class DataloaderCheckpointTest(unittest.TestCase):
         self.assertTrue(
             mgr.maybe_save(2, model=None, dataloader_state=state, data_timestamp=3600.0)
         )
-        self.assertEqual(state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+        # the watermark is stamped into the saved state, not the caller's dict
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, state)
+        saved_state = mgr.save.call_args.args[3]
+        self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
 
     def test_reconcile_event_time_single_process(self):
         # not distributed: this rank's value passes through (quorum of one); -1.0

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -207,7 +207,7 @@ def export_model_normal(
         # for mc modules, fix output_segments_tensor is a meta tensor.
         fix_mch_state(model)
 
-        batch = next(iter(dataloader))
+        batch = next(dataloader.get_iterator())  # pyre-ignore[16]
 
         # Quantize on CPU before moving to CUDA. The fbgemm CUDA kernel
         # for nbit quantization uses int32 pointer arithmetic which
@@ -752,7 +752,7 @@ def export_rtp_model(
     data_config.batch_size = acc_utils.get_max_export_batch_size()
     input_path = data_input_path or pipeline_config.train_input_path
     dataloader = create_dataloader(data_config, features, input_path, mode=Mode.PREDICT)
-    batch = next(iter(dataloader))
+    batch = next(dataloader.get_iterator())  # pyre-ignore[16]
     data = batch.to(device).to_dict(sparse_dtype=torch.int64)
 
     # Build Sharded Model

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.20"
+__version__ = "1.2.21"

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.18"
+__version__ = "1.2.19"

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.19"
+__version__ = "1.2.20"


### PR DESCRIPTION
## Problem

`train_and_evaluate` restored the dataloader checkpoint state **after** `create_dataloader`, but `create_dataloader` ends with an eager `iter(dataloader)` (`persistent_workers=True`) that forks the DataLoader workers immediately. Workers keep a fork-time copy of the dataset with `_checkpoint_state=None`; the later `load_state_dict` mutates only the parent, and persistent workers are never re-pickled (`_ResumeIteration` recreates the fetcher from the worker's own copy). The restored state therefore never reached the processes that read data.

Symptom: on resume with `--fine_tune_checkpoint` + `--continue_train`, Kafka consumers ignored `dataloader_state.json` and re-seeked via `start.timestamp.ms` (days of data re-trained). The same ordering bug affected Parquet/ODPS resume.

The eager `iter()` must stay — forking workers later, once CUDA-holding garbage cycles exist in the heap, makes worker GC abort with `CUDA error: initialization error` (the reason it was added in v0.7.0). So the state has to reach the workers before that fork.

## Fix

**State reaches the workers.** `create_dataloader` takes an optional `checkpoint_state` and applies it to the dataset **before** building the DataLoader, so the eager `iter()` forks workers that already carry it. `train_and_evaluate` hoists `CheckpointManager` construction, ckpt-path resolution and `restore_dataloader_state` above `create_dataloader` (logic unchanged; the event-time watermark seeding is preserved). The eager iterator is no longer discarded: `create_dataloader` exposes `get_iterator()`, which returns the prefetched iterator on first use and fresh ones after, and every consumer (train / eval / predict / export) uses it — so a resumed tail that fits the prefetch window is trained instead of being reset-and-re-read.

**Per-pass state lifecycle.** The restored state is consumed by the first completed pass. `BaseDataset.__iter__` clears the reader state when its `to_batches` generator exhausts normally (a `close()` keeps it, so mid-pass resets still re-seek), and the train loop resets the accumulated `dataloader_state` at the same pass boundary. So a mid-pass resume finishes the remaining intervals and later epochs read full passes; checkpoints taken during a pass record positions within that pass, while epoch-boundary and final checkpoints store an empty state that resumes as a fresh full pass. Streaming sources (Kafka) are unaffected — their generators never exhaust.

**Epoch-aware resume.** The checkpoint records the completed-pass count (reserved key `__epochs_completed__`, bumped at each pass boundary); `num_epochs` jobs resume with `range(completed, num_epochs)`, so a job that dies mid-pass-N trains exactly the remaining budget (`skip_steps` already covered `num_steps` jobs). When `__epochs_completed__ >= num_epochs` the run returns before any save, instead of writing `model.ckpt-0` from freshly-initialized weights. Fine-tune restores keep their data positions but drop the counter — the epoch budget belongs to the job, not the warm-start weights.

**Save-dedupe refresh.** When `save_checkpoints_steps` divides the pass length, the pass-end step save and the boundary/final save land on the same step; the boundary save refreshes the existing checkpoint's `dataloader_state.json` so the cleared state + counter bump is not dropped by the per-step dedupe.

## Tests

- `test_create_dataloader_checkpoint_state_reaches_workers` (parquet, `num_workers=2`): state passed through `create_dataloader` is honored by forked workers — asserts the resumed-interval invariants, row-count conservation, and that a second pass reads the full dataset; fails on the old set-after-create pattern.
- `test_create_dataloader_get_iterator_reuses_eager_iterator`: a resumed tail smaller than the prefetch window is yielded by `get_iterator()`, then the full dataset on the next call.
- Existing parquet / checkpoint_util / kafka dataset suites and the `multi_tower_din` train-eval-export and finetune integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
