### PR TITLE
[ci] code review: disable Remote Control in headless Claude run

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -116,6 +116,7 @@ jobs:
           claude -p \
             --output-format stream-json \
             --verbose \
+            --settings '{"disableRemoteControl": true}' \
             --mcp-config "$MCP_CONFIG" \
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent" \
             -- "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${PR_NUMBER}"


### PR DESCRIPTION
## What

Add `--settings '{"disableRemoteControl": true}'` to the `claude -p` invocation in the Code Review workflow.

## Why

The code-review workflow runs Claude **non-interactively** on the self-hosted `tzrec-codereview-runner`, authenticating with the OAuth credentials stored on that runner via `claude /login`. Disabling Remote Control ensures this headless session cannot be attached to or driven externally via the Remote Control feature — a hardening measure for the runner that holds the login credentials. The flag is inert for the print-mode (`-p`) run and only removes the remote-control surface.

## Change

```diff
           claude -p              --output-format stream-json              --verbose +            --settings '{"disableRemoteControl": true}'              --mcp-config "$MCP_CONFIG" ```

Verified locally: `--settings` accepts an inline JSON string (Claude Code 2.1.185), and the workflow YAML still parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)