### PR TITLE
[ci] resolve externals symlink for DSW authZ mount allowlist

### DIFF
--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -23,7 +23,8 @@ jobs:
         id: run_unittest_h20_ci
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
-          EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
+          # Resolve symlink: runner self-update makes externals a symlink, which DSW authZ rejects as a mount source.
+          EXTERNALS_ROOT="$(readlink -f "$(dirname "$WORK_ROOT")/externals")"
           docker run --rm --name "h20-ci-${{ github.run_id }}" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --gpus all --shm-size=512g --ulimit memlock=-1 \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -24,7 +24,8 @@ jobs:
         id: run_unittest_ppu_ci
         run: |
           WORK_ROOT="$(dirname "$RUNNER_WORKSPACE")"
-          EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
+          # Resolve symlink: runner self-update makes externals a symlink, which DSW authZ rejects as a mount source.
+          EXTERNALS_ROOT="$(readlink -f "$(dirname "$WORK_ROOT")/externals")"
           docker run --rm --name "ppu-ci-${{ github.run_id }}" \
             --workdir /__w/TorchEasyRec/TorchEasyRec \
             --device=/dev/alixpu_ppu0 --device=/dev/alixpu_ppu1 --device=/dev/alixpu --device=/dev/alixpu_ctl \


### PR DESCRIPTION
## Problem

All **Unit Test H20 CI** jobs have failed in ~40s since 2026-06-22 09:57Z with:

```
docker: Error response from daemon: authorization denied by plugin authZ: Permission denied
##[error]Process completed with exit code 125.
```

No test ran — the container never started. (Example: run [27994492069](https://github.com/alibaba/TorchEasyRec/actions/runs/27994492069/job/82853713706) on PR #544.)

## Root cause

The self-hosted H20/PPU runners execute `docker` on a PAI **DSW** host whose **authZ plugin restricts bind-mount sources** (it already blocks `/var/run/docker.sock`, which is why this workflow avoids `container:`). On that host, mount sources must be **real directories under `/mnt/data`** — **symlink** sources are rejected.

At **2026-06-22 06:58Z** the GitHub Actions runner **self-updated 2.334.0 → 2.335.1**. The new runner converts `externals/` into a **symlink** (`externals -> externals.<version>`). The workflow mounts it read-only:

```
EXTERNALS_ROOT="$(dirname "$WORK_ROOT")/externals"
... -v "$EXTERNALS_ROOT":/__e:ro
```

- Under 2.334.0 `externals` was a real dir → allowed.
- Under 2.335.1 `externals` is a symlink → **denied**.

The first job on 2.335.1 (09:57Z) and every job since failed; the last job on 2.334.0 (03:22Z) passed.

Verified on the host: mounting the `externals` symlink → `DENIED`; mounting its `readlink -f` target → `OK`. All other mounts (`--gpus all`, `--shm-size`, `--ulimit`, the `_work` subdir mounts) are fine.

## Fix

Resolve the symlink with `readlink -f` so the mount source is the real versioned directory the authZ plugin allows. Applied to both H20 and PPU workflows (identical pattern, same DSW constraint — PPU would break the same way on its next runner update). `readlink -f` is a no-op on a non-symlink path, so it is safe regardless of runner version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)