### PR TITLE
[ci] cut GPU + H20 unit-test CI toward 1 hour (cache persistence, derandomize, GPU scoping)

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -24,10 +24,10 @@ jobs:
       - name: RunUnitTestCI
         id: run_unittest_ci
         run: |
-          CACHE_ROOT="/__w/${{ github.event.repository.name }}/tzrec-ci-cache"
+          CACHE_ROOT="/__w/TorchEasyRec/tzrec-ci-cache"
           mkdir -p "$CACHE_ROOT/triton" "$CACHE_ROOT/inductor"
           cd run_${{ github.run_id }}
           TRITON_CACHE_DIR="$CACHE_ROOT/triton" \
           TORCHINDUCTOR_CACHE_DIR="$CACHE_ROOT/inductor" \
-          CUDA_HOME=/usr/local/cuda-12 CI_HYPOTHESIS=true \
+          CUDA_HOME=/usr/local/cuda-12 \
           bash scripts/ci/ci_test.sh --scope gpu

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -24,9 +24,10 @@ jobs:
       - name: RunUnitTestCI
         id: run_unittest_ci
         run: |
-          mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor
+          CACHE_ROOT="/__w/${{ github.event.repository.name }}/tzrec-ci-cache"
+          mkdir -p "$CACHE_ROOT/triton" "$CACHE_ROOT/inductor"
           cd run_${{ github.run_id }}
-          TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
-          TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
+          TRITON_CACHE_DIR="$CACHE_ROOT/triton" \
+          TORCHINDUCTOR_CACHE_DIR="$CACHE_ROOT/inductor" \
           CUDA_HOME=/usr/local/cuda-12 CI_HYPOTHESIS=true \
           bash scripts/ci/ci_test.sh --scope gpu

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -24,5 +24,9 @@ jobs:
       - name: RunUnitTestCI
         id: run_unittest_ci
         run: |
+          mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor
           cd run_${{ github.run_id }}
-          TORCHINDUCTOR_CACHE_DIR=$HOME/.torchinductor CUDA_HOME=/usr/local/cuda-12 CI_HYPOTHESIS=true bash scripts/ci/ci_test.sh
+          TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+          TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
+          CUDA_HOME=/usr/local/cuda-12 CI_HYPOTHESIS=true \
+          bash scripts/ci/ci_test.sh --scope gpu

--- a/.github/workflows/unittest_cpu_ci.yml
+++ b/.github/workflows/unittest_cpu_ci.yml
@@ -32,4 +32,4 @@ jobs:
           CI_REGION: ${{ secrets.CI_REGION }}
         run: |
           cd run_${{ github.run_id }}
-          CI_HYPOTHESIS=true bash scripts/ci/ci_test_cpu.sh
+          bash scripts/ci/ci_test_cpu.sh

--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -33,7 +33,8 @@ jobs:
             -e CI=true \
             -e CUDA_HOME=/usr/local/cuda-12 \
             -e CI_HYPOTHESIS=true \
-            -e TORCHINDUCTOR_CACHE_DIR=/github/home/.torchinductor \
+            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -42,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2 \
-            bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
+            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -32,9 +32,8 @@ jobs:
             -e GITHUB_ACTIONS=true \
             -e CI=true \
             -e CUDA_HOME=/usr/local/cuda-12 \
-            -e CI_HYPOTHESIS=true \
-            -e TRITON_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton \
-            -e TORCHINDUCTOR_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor \
+            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -43,7 +42,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2 \
-            bash -c 'mkdir -p /__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton /__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
+            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -33,8 +33,8 @@ jobs:
             -e CI=true \
             -e CUDA_HOME=/usr/local/cuda-12 \
             -e CI_HYPOTHESIS=true \
-            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
-            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
+            -e TRITON_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -43,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2 \
-            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
+            bash -c 'mkdir -p /__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton /__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test.sh --scope h20'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/.github/workflows/unittest_nightly.yml
+++ b/.github/workflows/unittest_nightly.yml
@@ -28,5 +28,8 @@ jobs:
           CI_ALIKAFKA_BROKERS: ${{ secrets.CI_ALIKAFKA_BROKERS }}
           CI_REGION: ${{ secrets.CI_REGION }}
         run: |
+          mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor
           cd run_${{ github.run_id }}
+          TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+          TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
           CUDA_HOME=/usr/local/cuda-12 bash scripts/ci/ci_test.sh

--- a/.github/workflows/unittest_nightly.yml
+++ b/.github/workflows/unittest_nightly.yml
@@ -28,8 +28,12 @@ jobs:
           CI_ALIKAFKA_BROKERS: ${{ secrets.CI_ALIKAFKA_BROKERS }}
           CI_REGION: ${{ secrets.CI_REGION }}
         run: |
-          mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor
+          # schedule-triggered: github.event.repository.name is empty here, so
+          # derive the repo name from $GITHUB_REPOSITORY.
+          CACHE_ROOT="/__w/${GITHUB_REPOSITORY##*/}/tzrec-ci-cache"
+          mkdir -p "$CACHE_ROOT/triton" "$CACHE_ROOT/inductor"
           cd run_${{ github.run_id }}
-          TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
-          TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
+          CI_NIGHTLY=true \
+          TRITON_CACHE_DIR="$CACHE_ROOT/triton" \
+          TORCHINDUCTOR_CACHE_DIR="$CACHE_ROOT/inductor" \
           CUDA_HOME=/usr/local/cuda-12 bash scripts/ci/ci_test.sh

--- a/.github/workflows/unittest_nightly.yml
+++ b/.github/workflows/unittest_nightly.yml
@@ -28,9 +28,7 @@ jobs:
           CI_ALIKAFKA_BROKERS: ${{ secrets.CI_ALIKAFKA_BROKERS }}
           CI_REGION: ${{ secrets.CI_REGION }}
         run: |
-          # schedule-triggered: github.event.repository.name is empty here, so
-          # derive the repo name from $GITHUB_REPOSITORY.
-          CACHE_ROOT="/__w/${GITHUB_REPOSITORY##*/}/tzrec-ci-cache"
+          CACHE_ROOT="/__w/TorchEasyRec/tzrec-ci-cache"
           mkdir -p "$CACHE_ROOT/triton" "$CACHE_ROOT/inductor"
           cd run_${{ github.run_id }}
           CI_NIGHTLY=true \

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -35,8 +35,8 @@ jobs:
             -e CI=true \
             -e CI_HYPOTHESIS=true \
             -e TZREC_TEST_TIMEOUT_SCALE=4 \
-            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
-            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
+            -e TRITON_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -45,7 +45,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
-            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
+            bash -c 'mkdir -p /__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton /__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -35,7 +35,8 @@ jobs:
             -e CI=true \
             -e CI_HYPOTHESIS=true \
             -e TZREC_TEST_TIMEOUT_SCALE=4 \
-            -e TORCHINDUCTOR_CACHE_DIR=/github/home/.torchinductor \
+            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -44,7 +45,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
-            bash -c 'cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
+            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -33,10 +33,9 @@ jobs:
             -e HOME=/github/home \
             -e GITHUB_ACTIONS=true \
             -e CI=true \
-            -e CI_HYPOTHESIS=true \
             -e TZREC_TEST_TIMEOUT_SCALE=4 \
-            -e TRITON_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton \
-            -e TORCHINDUCTOR_CACHE_DIR=/__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor \
+            -e TRITON_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/triton \
+            -e TORCHINDUCTOR_CACHE_DIR=/__w/TorchEasyRec/tzrec-ci-cache/inductor \
             -v "$WORK_ROOT":/__w \
             -v "$EXTERNALS_ROOT":/__e:ro \
             -v "$WORK_ROOT/_temp":/__w/_temp \
@@ -45,7 +44,7 @@ jobs:
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
             mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
-            bash -c 'mkdir -p /__w/${{ github.event.repository.name }}/tzrec-ci-cache/triton /__w/${{ github.event.repository.name }}/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
+            bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()
         run: |

--- a/tzrec/datasets/csv_dataset_test.py
+++ b/tzrec/datasets/csv_dataset_test.py
@@ -25,6 +25,7 @@ from torch.utils.data import DataLoader
 from tzrec.datasets.csv_dataset import CsvDataset, CsvWriter
 from tzrec.features.feature import FgMode, create_features
 from tzrec.protos import data_pb2, feature_pb2
+from tzrec.utils.test_util import make_test_dir
 
 
 class CsvDatasetTest(unittest.TestCase):
@@ -220,9 +221,7 @@ class CsvDatasetTest(unittest.TestCase):
 
 class CsvWriterTest(unittest.TestCase):
     def setUp(self):
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if os.path.exists(self.test_dir):

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -29,6 +29,7 @@ from tzrec.features.feature import create_features
 from tzrec.protos import data_pb2, feature_pb2
 from tzrec.utils import misc_util
 from tzrec.utils.checkpoint_util import EPOCHS_COMPLETED, update_dataloder_state
+from tzrec.utils.test_util import make_test_dir
 
 
 class ParquetDatasetTest(unittest.TestCase):
@@ -370,9 +371,7 @@ class ParquetDatasetTest(unittest.TestCase):
 
 class ParquetReaderTest(unittest.TestCase):
     def setUp(self):
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if os.path.exists(self.test_dir):
@@ -435,9 +434,7 @@ class ParquetReaderTest(unittest.TestCase):
 
 class ParquetWriterTest(unittest.TestCase):
     def setUp(self):
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if os.path.exists(self.test_dir):

--- a/tzrec/features/feature_test.py
+++ b/tzrec/features/feature_test.py
@@ -34,6 +34,7 @@ from tzrec.protos import feature_pb2
 
 class FeatureTest(unittest.TestCase):
     def setUp(self):
+        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):

--- a/tzrec/features/feature_test.py
+++ b/tzrec/features/feature_test.py
@@ -12,7 +12,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 from collections import OrderedDict
 
@@ -30,11 +29,11 @@ from tzrec.features import (
 from tzrec.features import feature as feature_lib
 from tzrec.features.feature import FgMode
 from tzrec.protos import feature_pb2
+from tzrec.utils.test_util import make_test_dir
 
 
 class FeatureTest(unittest.TestCase):
     def setUp(self):
-        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):
@@ -336,7 +335,7 @@ class FeatureTest(unittest.TestCase):
         token_file = "data/test/tokenizer.json"
         vocab_file = "data/test/id_vocab_list_0"
         if with_asset_dir:
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             asset_dir = self.test_dir
             token_file = "tokenizer_b2faab7921bbfb593973632993ca4c85.json"
             vocab_file = "id_vocab_list_0_583794bd44eb2c6d83336c71258521e8"
@@ -485,7 +484,7 @@ class FeatureTest(unittest.TestCase):
         asset_dir = None
         token_file = "data/test/tokenizer.json"
         if with_asset_dir:
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             asset_dir = self.test_dir
             token_file = "tokenizer_b2faab7921bbfb593973632993ca4c85.json"
         feature_cfgs = self._create_test_feature_cfgs()
@@ -628,7 +627,7 @@ class FeatureTest(unittest.TestCase):
         token_file = "data/test/tokenizer.json"
         vocab_file = "data/test/id_vocab_list_0"
         if with_asset_dir:
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             asset_dir = self.test_dir
             token_file = "tokenizer_b2faab7921bbfb593973632993ca4c85.json"
             vocab_file = "id_vocab_list_0_583794bd44eb2c6d83336c71258521e8"

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -40,6 +40,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    mark_ci_scope,
 )
 from tzrec.utils.test_util import (
     hypothesis_settings as settings,
@@ -363,6 +364,7 @@ def _build_batch(
     ).to(device)
 
 
+@mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
     def setUp(self):
         self.test_dir = None

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -11,7 +11,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 from collections import OrderedDict
 
@@ -40,6 +39,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    make_test_dir,
     mark_ci_scope,
 )
 from tzrec.utils.test_util import (
@@ -367,7 +367,6 @@ def _build_batch(
 @mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
     def setUp(self):
-        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):
@@ -436,7 +435,7 @@ class DlrmHSTUTest(unittest.TestCase):
         elif graph_type == TestGraphType.AOT_INDUCTOR:
             data = batch.to_dict()
             data = OrderedDict(sorted(data.items()))
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             dlrm_hstu.set_is_inference(True)
             dlrm_hstu = create_test_model(dlrm_hstu, graph_type, data, self.test_dir)
             predictions = dlrm_hstu(data)

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -367,6 +367,7 @@ def _build_batch(
 @mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
     def setUp(self):
+        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -16,7 +16,7 @@ import unittest
 from collections import OrderedDict
 
 import torch
-from hypothesis import Verbosity, assume, given, settings
+from hypothesis import Verbosity, assume, given
 from hypothesis import strategies as st
 from torchrec import JaggedTensor, KeyedJaggedTensor
 
@@ -36,7 +36,14 @@ from tzrec.protos import (
 )
 from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.utils.state_dict_util import init_parameters
-from tzrec.utils.test_util import TestGraphType, create_test_model, gpu_unavailable
+from tzrec.utils.test_util import (
+    TestGraphType,
+    create_test_model,
+    gpu_unavailable,
+)
+from tzrec.utils.test_util import (
+    hypothesis_settings as settings,
+)
 
 
 def _build_model(

--- a/tzrec/models/dssm_test.py
+++ b/tzrec/models/dssm_test.py
@@ -26,9 +26,10 @@ from tzrec.models.dssm import DSSM
 from tzrec.protos import feature_pb2, loss_pb2, model_pb2, module_pb2, tower_pb2
 from tzrec.protos.models import match_model_pb2
 from tzrec.utils.state_dict_util import init_parameters
-from tzrec.utils.test_util import TestGraphType, create_test_model
+from tzrec.utils.test_util import TestGraphType, create_test_model, mark_ci_scope
 
 
+@mark_ci_scope("gpu")
 class DSSMTest(unittest.TestCase):
     @parameterized.expand(
         [[TestGraphType.NORMAL], [TestGraphType.FX_TRACE], [TestGraphType.JIT_SCRIPT]]

--- a/tzrec/models/hstu_test.py
+++ b/tzrec/models/hstu_test.py
@@ -12,7 +12,7 @@
 import unittest
 
 import torch
-from hypothesis import Verbosity, assume, given, settings
+from hypothesis import Verbosity, assume, given
 from hypothesis import strategies as st
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
@@ -32,7 +32,14 @@ from tzrec.protos import (
 )
 from tzrec.protos.models import match_model_pb2
 from tzrec.utils.state_dict_util import init_parameters
-from tzrec.utils.test_util import TestGraphType, create_test_model, gpu_unavailable
+from tzrec.utils.test_util import (
+    TestGraphType,
+    create_test_model,
+    gpu_unavailable,
+)
+from tzrec.utils.test_util import (
+    hypothesis_settings as settings,
+)
 
 
 def _build_model(device: torch.device) -> HSTUMatch:

--- a/tzrec/models/hstu_test.py
+++ b/tzrec/models/hstu_test.py
@@ -36,6 +36,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    mark_ci_scope,
 )
 from tzrec.utils.test_util import (
     hypothesis_settings as settings,
@@ -220,6 +221,7 @@ def _build_batch(device: torch.device) -> Batch:
     ).to(device)
 
 
+@mark_ci_scope("gpu")
 class HSTUMatchTest(unittest.TestCase):
     @given(
         graph_type=st.sampled_from(

--- a/tzrec/models/multi_tower_din_test.py
+++ b/tzrec/models/multi_tower_din_test.py
@@ -32,9 +32,15 @@ from tzrec.protos import (
 )
 from tzrec.protos.models import rank_model_pb2
 from tzrec.utils.state_dict_util import init_parameters
-from tzrec.utils.test_util import TestGraphType, create_test_model, gpu_unavailable
+from tzrec.utils.test_util import (
+    TestGraphType,
+    create_test_model,
+    gpu_unavailable,
+    mark_ci_scope,
+)
 
 
+@mark_ci_scope("gpu")
 class MultiTowerDINTest(unittest.TestCase):
     def setUp(self):
         self.test_dir = None

--- a/tzrec/models/multi_tower_din_test.py
+++ b/tzrec/models/multi_tower_din_test.py
@@ -11,7 +11,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 from collections import OrderedDict
 
@@ -36,6 +35,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    make_test_dir,
     mark_ci_scope,
 )
 
@@ -43,7 +43,6 @@ from tzrec.utils.test_util import (
 @mark_ci_scope("gpu")
 class MultiTowerDINTest(unittest.TestCase):
     def setUp(self):
-        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):
@@ -189,7 +188,7 @@ class MultiTowerDINTest(unittest.TestCase):
         elif graph_type == TestGraphType.AOT_INDUCTOR:
             data = batch.to_dict()
             data = OrderedDict(sorted(data.items()))
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             multi_tower_din = create_test_model(
                 multi_tower_din, graph_type, data, self.test_dir
             )

--- a/tzrec/models/multi_tower_din_test.py
+++ b/tzrec/models/multi_tower_din_test.py
@@ -43,6 +43,7 @@ from tzrec.utils.test_util import (
 @mark_ci_scope("gpu")
 class MultiTowerDINTest(unittest.TestCase):
     def setUp(self):
+        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -329,6 +329,7 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
 @mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
     def setUp(self):
+        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from typing import List, Tuple
 
 import torch
-from hypothesis import Verbosity, assume, given, settings
+from hypothesis import Verbosity, assume, given
 from hypothesis import strategies as st
 from parameterized import parameterized
 from torchrec import JaggedTensor, KeyedJaggedTensor
@@ -38,7 +38,14 @@ from tzrec.protos import (
 )
 from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.utils.state_dict_util import init_parameters
-from tzrec.utils.test_util import TestGraphType, create_test_model, gpu_unavailable
+from tzrec.utils.test_util import (
+    TestGraphType,
+    create_test_model,
+    gpu_unavailable,
+)
+from tzrec.utils.test_util import (
+    hypothesis_settings as settings,
+)
 
 
 def _hstu_subconfig(channel_name: str, embedding_dim: int) -> module_pb2.HSTU:

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -42,6 +42,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    mark_ci_scope,
 )
 from tzrec.utils.test_util import (
     hypothesis_settings as settings,
@@ -325,6 +326,7 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
     ).to(device)
 
 
+@mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
     def setUp(self):
         self.test_dir = None

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -11,7 +11,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 from collections import OrderedDict
 from typing import List, Tuple
@@ -42,6 +41,7 @@ from tzrec.utils.test_util import (
     TestGraphType,
     create_test_model,
     gpu_unavailable,
+    make_test_dir,
     mark_ci_scope,
 )
 from tzrec.utils.test_util import (
@@ -329,7 +329,6 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
 @mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
     def setUp(self):
-        os.makedirs("./tmp", exist_ok=True)
         self.test_dir = None
 
     def tearDown(self):
@@ -424,7 +423,7 @@ class UltraHSTUTest(unittest.TestCase):
         elif graph_type == TestGraphType.AOT_INDUCTOR:
             data = batch.to_dict()
             data = OrderedDict(sorted(data.items()))
-            self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+            self.test_dir = make_test_dir()
             ultra_hstu.set_is_inference(True)
             ultra_hstu = create_test_model(ultra_hstu, graph_type, data, self.test_dir)
             predictions = ultra_hstu(data)

--- a/tzrec/modules/gr/action_encoder_test.py
+++ b/tzrec/modules/gr/action_encoder_test.py
@@ -24,7 +24,7 @@ from tzrec.utils.test_util import (
 )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class ActionEncoderTest(unittest.TestCase):
     @parameterized.expand([[TestGraphType.NORMAL], [TestGraphType.FX_TRACE]])
     @unittest.skipIf(*gpu_unavailable)

--- a/tzrec/modules/gr/content_encoder_test.py
+++ b/tzrec/modules/gr/content_encoder_test.py
@@ -22,7 +22,7 @@ from tzrec.modules.gr.content_encoder import (
 from tzrec.utils.test_util import TestGraphType, gpu_unavailable, mark_ci_scope
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class ContentEncoderTest(unittest.TestCase):
     @parameterized.expand([[TestGraphType.NORMAL], [TestGraphType.FX_TRACE]])
     @unittest.skipIf(*gpu_unavailable)

--- a/tzrec/modules/gr/hstu_transducer_test.py
+++ b/tzrec/modules/gr/hstu_transducer_test.py
@@ -77,7 +77,7 @@ class _StubOutputPostprocessor(torch.nn.Module):
         return seq_embeddings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class HSTUTransducerTest(unittest.TestCase):
     # ---------- _replay_truncation_state unit tests ----------
 

--- a/tzrec/modules/gr/postprocessors_test.py
+++ b/tzrec/modules/gr/postprocessors_test.py
@@ -21,7 +21,7 @@ from tzrec.modules.gr.postprocessors import (
 from tzrec.utils.test_util import mark_ci_scope
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class PostprocessorTest(unittest.TestCase):
     def test_l2norm_postprocessor(self):
         postprocessor = L2NormPostprocessor()

--- a/tzrec/modules/gr/preprocessors_test.py
+++ b/tzrec/modules/gr/preprocessors_test.py
@@ -19,7 +19,7 @@ from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class PreprocessorTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore
@@ -250,7 +250,7 @@ class PreprocessorTest(unittest.TestCase):
         )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class UIHPreprocessorTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     def test_uih_preprocessor_contextual(self) -> None:

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -14,7 +14,7 @@ import unittest
 from typing import List
 
 import torch
-from hypothesis import Verbosity, given, settings
+from hypothesis import Verbosity, given
 from hypothesis import strategies as st
 from parameterized import parameterized
 
@@ -23,6 +23,9 @@ from tzrec.utils.test_util import (
     gpu_unavailable,
     mark_ci_scope,
     reference_stu_truncation,
+)
+from tzrec.utils.test_util import (
+    hypothesis_settings as settings,
 )
 
 

--- a/tzrec/modules/gr/stu_test.py
+++ b/tzrec/modules/gr/stu_test.py
@@ -42,7 +42,7 @@ def _inplace_swap(
     return x
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class StuTest(unittest.TestCase):
     # pyre-ignore
     @given(
@@ -529,7 +529,7 @@ class StuTest(unittest.TestCase):
             )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class STUStackTruncationTest(unittest.TestCase):
     """Cover the mid-stack truncation block in ``STUStack.forward``.
 

--- a/tzrec/modules/norm_test.py
+++ b/tzrec/modules/norm_test.py
@@ -27,7 +27,7 @@ from tzrec.utils.test_util import (
 )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class LayerNormTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]

--- a/tzrec/modules/norm_test.py
+++ b/tzrec/modules/norm_test.py
@@ -13,11 +13,18 @@ import copy
 import unittest
 
 import torch
-from hypothesis import Verbosity, given, settings
+from hypothesis import Verbosity, given
 from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
-from tzrec.utils.test_util import get_test_dtypes, gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import (
+    get_test_dtypes,
+    gpu_unavailable,
+    mark_ci_scope,
+)
+from tzrec.utils.test_util import (
+    hypothesis_settings as settings,
+)
 
 
 @mark_ci_scope("h20")

--- a/tzrec/ops/hstu_attention_test.py
+++ b/tzrec/ops/hstu_attention_test.py
@@ -308,7 +308,7 @@ def test_delta_attn(
     )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class HSTUAttentionTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()

--- a/tzrec/ops/hstu_attention_utils_test.py
+++ b/tzrec/ops/hstu_attention_utils_test.py
@@ -142,7 +142,7 @@ class _ReplayTruncationWrapper(nn.Module):
         return torch.cat([out_x, out_ts], dim=-1)
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class BuildSlaFuncTensorTest(unittest.TestCase):
     """Verify the per-position interval values written to the func tensor.
 
@@ -299,7 +299,7 @@ _TRUNCATION_CASES = [
 ]
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class StuTruncationTest(unittest.TestCase):
     """``compute_stu_truncation_plan`` + ``apply_stu_truncation_plan``.
 

--- a/tzrec/ops/hstu_compute_test.py
+++ b/tzrec/ops/hstu_compute_test.py
@@ -29,7 +29,7 @@ from tzrec.utils.test_util import (
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class HSTUComputeTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()
@@ -495,7 +495,7 @@ class HSTUComputeTest(unittest.TestCase):
             )
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class Hstu4WayRematParityTest(unittest.TestCase):
     """Forward + backward parity for ``hstu_compute_uqvk``'s 4 remat combos.
 

--- a/tzrec/ops/jagged_tensors_test.py
+++ b/tzrec/ops/jagged_tensors_test.py
@@ -27,7 +27,7 @@ from tzrec.utils.test_util import (
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class JaggedTensorsTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()

--- a/tzrec/ops/layer_norm_test.py
+++ b/tzrec/ops/layer_norm_test.py
@@ -22,7 +22,7 @@ from tzrec.utils.test_util import get_test_dtypes, gpu_unavailable, mark_ci_scop
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class LayerNormTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()

--- a/tzrec/ops/mm_test.py
+++ b/tzrec/ops/mm_test.py
@@ -22,7 +22,7 @@ from tzrec.utils.test_util import get_test_dtypes, gpu_unavailable, mark_ci_scop
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class MMlTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()

--- a/tzrec/ops/position_test.py
+++ b/tzrec/ops/position_test.py
@@ -43,7 +43,7 @@ def _retry(max_attempts=3):
     return decorator
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class PositionEmbeddingsTest(unittest.TestCase):
     def teardown_example(self, example):
         gc.collect()

--- a/tzrec/ops/utils_test.py
+++ b/tzrec/ops/utils_test.py
@@ -15,7 +15,7 @@ from tzrec.ops.utils import prev_power_of_2
 from tzrec.utils.test_util import mark_ci_scope
 
 
-@mark_ci_scope("h20")
+@mark_ci_scope("h20", "gpu")
 class OpUtilsTest(unittest.TestCase):
     def test_prev_power_of_2(self):
         self.assertEqual(prev_power_of_2(30), 16)

--- a/tzrec/tests/ci_scope_coverage_test.py
+++ b/tzrec/tests/ci_scope_coverage_test.py
@@ -19,8 +19,7 @@ import glob
 import os
 import unittest
 
-# Tokens whose presence in a skip decorator means the test needs a GPU lane
-# (the resource -- a GPU, or an extra.txt-only wheel -- is absent on the CPU lane).
+# A skip referencing any of these means the test needs a GPU lane.
 _GPU_SKIP_TOKENS = (
     "gpu_unavailable",
     "cutlass_hstu_unavailable",
@@ -47,8 +46,7 @@ def _is_gpu_required(decorators) -> bool:
             continue
         if any(tok in s for tok in _GPU_SKIP_TOKENS):
             return True
-        # skipUnless(cuda.is_available()) / skipIf(not cuda.is_available()) skip on
-        # CPU; skipIf(cuda.is_available()) (the FAISS CPU-only pattern) does NOT.
+        # skipUnless(cuda) / skipIf(not cuda) skip on CPU; skipIf(cuda) does not.
         if "cuda.is_available()" in s and (
             "skipUnless" in s or "not torch.cuda.is_available()" in s
         ):

--- a/tzrec/tests/ci_scope_coverage_test.py
+++ b/tzrec/tests/ci_scope_coverage_test.py
@@ -8,15 +8,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Lint: every GPU-only test must carry a CI scope marker.
+"""Lint: every test that skips on the CPU lane must carry a gpu/h20 marker.
 
-The per-PR GPU lane runs ``run.py --scope gpu`` and the H20 lane runs
-``--scope h20``; the CPU lane runs the full suite but has neither a GPU nor
-the ``requirements/extra.txt`` wheels (dynamicemb / fbgemm_gpu_hstu /
-torch_fx_tool / tensorrt). So any test that *skips on the CPU lane* runs
-**only** on a GPU lane -- and if it carries no ``@mark_ci_scope("gpu")`` /
-``("h20")`` it is filtered out there too and silently runs on **no** per-PR
-lane. This test statically asserts that can't happen.
+Such a test runs only on a scoped GPU lane (``run.py --scope gpu``/``h20``);
+without the marker it is filtered out there too and runs on no per-PR lane.
 """
 
 import ast

--- a/tzrec/tests/ci_scope_coverage_test.py
+++ b/tzrec/tests/ci_scope_coverage_test.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lint: every GPU-only test must carry a CI scope marker.
+
+The per-PR GPU lane runs ``run.py --scope gpu`` and the H20 lane runs
+``--scope h20``; the CPU lane runs the full suite but has neither a GPU nor
+the ``requirements/extra.txt`` wheels (dynamicemb / fbgemm_gpu_hstu /
+torch_fx_tool / tensorrt). So any test that *skips on the CPU lane* runs
+**only** on a GPU lane -- and if it carries no ``@mark_ci_scope("gpu")`` /
+``("h20")`` it is filtered out there too and silently runs on **no** per-PR
+lane. This test statically asserts that can't happen.
+"""
+
+import ast
+import glob
+import os
+import unittest
+
+# Tokens whose presence in a skip decorator means the test needs a GPU lane
+# (the resource -- a GPU, or an extra.txt-only wheel -- is absent on the CPU lane).
+_GPU_SKIP_TOKENS = (
+    "gpu_unavailable",
+    "cutlass_hstu_unavailable",
+    "has_dynamicemb",
+    "has_tensorrt",
+    "torch_fx_tool_unavailable",
+    "device_count",
+)
+_TZREC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+
+def _src(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return ""
+
+
+def _is_gpu_required(decorators) -> bool:
+    """True if any decorator skips the test when run on the CPU lane."""
+    for dec in decorators:
+        s = _src(dec)
+        if "skipIf" not in s and "skipUnless" not in s:
+            continue
+        if any(tok in s for tok in _GPU_SKIP_TOKENS):
+            return True
+        # skipUnless(cuda.is_available()) / skipIf(not cuda.is_available()) skip on
+        # CPU; skipIf(cuda.is_available()) (the FAISS CPU-only pattern) does NOT.
+        if "cuda.is_available()" in s and (
+            "skipUnless" in s or "not torch.cuda.is_available()" in s
+        ):
+            return True
+    return False
+
+
+def _has_scope(decorators) -> bool:
+    for dec in decorators:
+        # ast.unparse normalizes string quotes to single, so normalize before matching.
+        s = _src(dec).replace("'", '"')
+        if "mark_ci_scope" in s and ('"gpu"' in s or '"h20"' in s):
+            return True
+    return False
+
+
+class CIScopeCoverageTest(unittest.TestCase):
+    def test_gpu_only_tests_carry_a_scope_marker(self) -> None:
+        violations = []
+        for fp in glob.glob(
+            os.path.join(_TZREC_ROOT, "**", "*_test.py"), recursive=True
+        ):
+            rel = os.path.relpath(fp, os.path.dirname(_TZREC_ROOT))
+            tree = ast.parse(open(fp).read(), filename=fp)
+            for cls in tree.body:
+                if not isinstance(cls, ast.ClassDef):
+                    continue
+                cls_scoped = _has_scope(cls.decorator_list)
+                if _is_gpu_required(cls.decorator_list) and not cls_scoped:
+                    violations.append(f"{rel}::{cls.name} (class)")
+                for item in cls.body:
+                    if not (
+                        isinstance(item, ast.FunctionDef)
+                        and item.name.startswith("test")
+                    ):
+                        continue
+                    if _is_gpu_required(item.decorator_list) and not (
+                        cls_scoped or _has_scope(item.decorator_list)
+                    ):
+                        violations.append(f"{rel}::{cls.name}.{item.name}")
+        self.assertEqual(
+            violations,
+            [],
+            'GPU-only tests missing @mark_ci_scope("gpu"/"h20") -- they skip on '
+            "the CPU lane and are filtered out of the scoped GPU lanes, so they run "
+            "on NO per-PR lane:\n  " + "\n  ".join(violations),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/tests/match_integration_test.py
+++ b/tzrec/tests/match_integration_test.py
@@ -12,20 +12,16 @@
 import json
 import os
 import shutil
-import tempfile
 import unittest
 
 from tzrec.tests import utils
-from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import gpu_unavailable, make_test_dir, mark_ci_scope
 
 
 class MatchIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if self.success:

--- a/tzrec/tests/match_integration_test.py
+++ b/tzrec/tests/match_integration_test.py
@@ -16,7 +16,7 @@ import tempfile
 import unittest
 
 from tzrec.tests import utils
-from tzrec.utils.test_util import gpu_unavailable
+from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 
 
 class MatchIntegrationTest(unittest.TestCase):
@@ -230,6 +230,7 @@ class MatchIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_dssm_with_fg_train_eval_export_aot(self):
         # AOT variant exercises TowerWrapper through the helpers refactored
         # to take feature_groups (_compute_seq_share_groups +
@@ -257,6 +258,7 @@ class MatchIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_dssm_v2_with_fg_train_eval_export_aot(self):
         # AOT variant exercises TowerWoEGWrapper through the helpers
         # refactored to take feature_groups.
@@ -369,6 +371,7 @@ class MatchIntegrationTest(unittest.TestCase):
         self.assertTrue(self.success)
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_hstu_with_fg_train_eval(self):
         self.success = utils.test_train_eval(
             "tzrec/tests/configs/hstu_kuairand_1k.config",

--- a/tzrec/tests/match_integration_test.py
+++ b/tzrec/tests/match_integration_test.py
@@ -275,6 +275,7 @@ class MatchIntegrationTest(unittest.TestCase):
             item_id="item_id",
         )
 
+    @mark_ci_scope("gpu")
     def test_tdm_train_eval_export(self):
         self.success = utils.test_train_eval(
             "tzrec/tests/configs/tdm_fg_mock.config",

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -28,15 +28,15 @@ from tzrec.utils.test_util import (
     cutlass_hstu_unavailable,
     dfs_are_close,
     gpu_unavailable,
+    is_ci_nightly,
     mark_ci_scope,
     torch_fx_tool_unavailable,
 )
 
-# Quant export covers every dtype only in the nightly full run; per-PR CI
-# runs a representative subset to keep the GPU lane fast.
+# Full dtype matrix only in nightly; per-PR runs a fast subset.
 _QUANT_EMBS = (
     ["FP32", "FP16", "INT8", "INT4", "INT2", "0"]
-    if os.environ.get("CI_NIGHTLY", "false").lower() == "true"
+    if is_ci_nightly()
     else ["FP16", "INT8"]
 )
 

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -36,7 +36,7 @@ from tzrec.utils.test_util import (
 # runs a representative subset to keep the GPU lane fast.
 _QUANT_EMBS = (
     ["FP32", "FP16", "INT8", "INT4", "INT2", "0"]
-    if os.environ.get("CI_NIGHTLY")
+    if os.environ.get("CI_NIGHTLY", "false").lower() == "true"
     else ["FP16", "INT8"]
 )
 

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -12,7 +12,6 @@
 import json
 import os
 import shutil
-import tempfile
 import unittest
 
 import torch
@@ -29,6 +28,7 @@ from tzrec.utils.test_util import (
     dfs_are_close,
     gpu_unavailable,
     is_ci_nightly,
+    make_test_dir,
     mark_ci_scope,
     torch_fx_tool_unavailable,
 )
@@ -44,10 +44,7 @@ _QUANT_EMBS = (
 class RankIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if self.success:

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -32,6 +32,14 @@ from tzrec.utils.test_util import (
     torch_fx_tool_unavailable,
 )
 
+# Quant export covers every dtype only in the nightly full run; per-PR CI
+# runs a representative subset to keep the GPU lane fast.
+_QUANT_EMBS = (
+    ["FP32", "FP16", "INT8", "INT4", "INT2", "0"]
+    if os.environ.get("CI_NIGHTLY")
+    else ["FP16", "INT8"]
+)
+
 
 class RankIntegrationTest(unittest.TestCase):
     def setUp(self):
@@ -76,6 +84,7 @@ class RankIntegrationTest(unittest.TestCase):
             os.path.exists(os.path.join(self.test_dir, "export/scripted_model.pt"))
         )
 
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_fg_encoded_train_eval_export(self):
         self._test_rank_nofg(
             "tzrec/tests/configs/multi_tower_din_mock.config",
@@ -191,7 +200,7 @@ class RankIntegrationTest(unittest.TestCase):
             user_id="user_id",
             item_id="item_id",
         )
-        for quant_emb in ["FP32", "FP16", "INT8", "INT4", "INT2", "0"]:
+        for quant_emb in _QUANT_EMBS:
             test_dir = os.path.join(self.test_dir, f"quant_{quant_emb.lower()}")
             if self.success:
                 self.success = utils.test_export(
@@ -848,6 +857,7 @@ class RankIntegrationTest(unittest.TestCase):
             else:
                 os.environ["TEST_NPROC_PER_NODE"] = prev_nproc
 
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_with_fg_export_quant(self):
         self._test_rank_with_fg_quant(
             "tzrec/tests/configs/multi_tower_din_fg_mock.config"

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -783,6 +783,7 @@ class RankIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_with_fg_fp16_ga_train_eval_export(self):
         self._test_rank_with_fg(
             "tzrec/tests/configs/multi_tower_din_fg_mock_fp16_ga.config",
@@ -790,6 +791,7 @@ class RankIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_with_fg_bf16_emb_fp16_train_eval_export(self):
         self._test_rank_with_fg(
             "tzrec/tests/configs/multi_tower_din_fg_mock_bf16_emb_fp16.config",
@@ -797,6 +799,7 @@ class RankIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_zch_with_fg_train_eval_export(self):
         self._test_rank_with_fg(
             "tzrec/tests/configs/multi_tower_din_zch_fg_mock.config",
@@ -807,6 +810,7 @@ class RankIntegrationTest(unittest.TestCase):
         not torch.cuda.is_available() or torch.cuda.device_count() < 2,
         "needs >= 2 GPUs to exercise different world sizes",
     )
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_zch_finetune_world_size_change(self):
         # First train on 1 GPU, then finetune from that checkpoint on 2 GPUs.
         # Regression test for the assertion in MCH validate_state caused by
@@ -889,12 +893,14 @@ class RankIntegrationTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_zch_with_fg_train_eval_export_input_tile(self):
         self._test_rank_with_fg_input_tile(
             "tzrec/tests/configs/multi_tower_din_zch_fg_mock.config"
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_with_fg_train_eval_aot_export_input_tile(self):
         self._test_rank_with_fg_aot_input_tile(
             "tzrec/tests/configs/multi_tower_din_fg_mock.config"
@@ -1023,7 +1029,7 @@ class RankIntegrationTest(unittest.TestCase):
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg["cand_seq_pk"], "cand_seq")
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_train_eval_export(self):
         # Default path: legacy two-stage export (sparse JIT + dense AOTI).
@@ -1038,7 +1044,7 @@ class RankIntegrationTest(unittest.TestCase):
         with open(os.path.join(self.test_dir, "export/model_acc.json")) as f:
             self.assertEqual(json.load(f).get("ENABLE_AOT"), "1")
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_train_eval_export_unified_aot(self):
         # Unified AOTI export (ENABLE_AOT=2): fused sparse+dense single .pt2.
@@ -1054,7 +1060,7 @@ class RankIntegrationTest(unittest.TestCase):
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg.get("ENABLE_AOT"), "2")
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_train_eval_export_autotune_with_sample_inputs(self):
         # Exercise the AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS path with a small
@@ -1070,7 +1076,7 @@ class RankIntegrationTest(unittest.TestCase):
             self.assertEqual(acc_cfg.get("AOTI_AUTOTUNE_WITH_SAMPLE_INPUTS"), "1")
             self.assertEqual(acc_cfg.get("MAX_EXPORT_BATCH_SIZE"), "2")
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_dlrm_hstu_cutlass_train_eval_export(self):
@@ -1100,7 +1106,7 @@ class RankIntegrationTest(unittest.TestCase):
             )
         self.assertTrue(self.success)
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*cutlass_hstu_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_rank_ultra_hstu_cutlass_train_eval_export(self):
@@ -1135,6 +1141,7 @@ class RankIntegrationTest(unittest.TestCase):
         gpu_unavailable[0] or not dynamicemb_util.has_dynamicemb,
         "dynamicemb not available.",
     )
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_with_dynamicemb_train_eval(self):
         self.success = utils.test_train_eval(
             "tzrec/tests/configs/multi_tower_din_fg_dynamicemb_mock.config",
@@ -1155,6 +1162,7 @@ class RankIntegrationTest(unittest.TestCase):
     @unittest.skipIf(
         gpu_unavailable[0] or not trt_utils.has_tensorrt, "tensorrt not available."
     )
+    @mark_ci_scope("gpu")
     def test_multi_tower_with_fg_train_eval_export_trt(self):
         self._test_rank_with_fg_trt(
             "tzrec/tests/configs/multi_tower_din_fg_mock.config",
@@ -1164,6 +1172,7 @@ class RankIntegrationTest(unittest.TestCase):
     @unittest.skipIf(
         gpu_unavailable[0] or not trt_utils.has_tensorrt, "tensorrt not available."
     )
+    @mark_ci_scope("gpu")
     def test_multi_tower_zch_with_fg_train_eval_export_trt(self):
         self._test_rank_with_fg_trt(
             "tzrec/tests/configs/multi_tower_din_zch_fg_mock_nodice.config",
@@ -1176,6 +1185,7 @@ class RankIntegrationTest(unittest.TestCase):
         "dynamicemb not available (config sets `dynamicemb { }` on features).",
     )
     @unittest.skipIf(*gpu_unavailable)
+    @mark_ci_scope("gpu")
     def test_multi_tower_din_rtp_train_export(self):
         # set USE_RTP env here for gen correct rtp style train/eval data
         os.environ["USE_RTP"] = "1"
@@ -1207,7 +1217,7 @@ class RankIntegrationTest(unittest.TestCase):
             in weight_json
         )
 
-    @mark_ci_scope("h20")
+    @mark_ci_scope("h20", "gpu")
     @unittest.skipIf(*torch_fx_tool_unavailable)
     @unittest.skipIf(*gpu_unavailable)
     def test_dlrm_hstu_rtp_train_export(self):

--- a/tzrec/tests/run.py
+++ b/tzrec/tests/run.py
@@ -252,6 +252,9 @@ if __name__ == "__main__":
     test_suite_main, test_suite_subproc = _gather_test_cases(args)
 
     if not args.list_tests:
+        # Tests that mkdtemp(dir="./tmp") rely on it existing; create it once
+        # here so coverage is independent of test order and the --scope subset.
+        os.makedirs("./tmp", exist_ok=True)
         runner_result = runner.run(test_suite_main, test_suite_subproc)
         failed, errored = len(runner_result.failures), len(runner_result.errors)
         if failed > 0 or errored > 0:

--- a/tzrec/tests/run.py
+++ b/tzrec/tests/run.py
@@ -252,8 +252,6 @@ if __name__ == "__main__":
     test_suite_main, test_suite_subproc = _gather_test_cases(args)
 
     if not args.list_tests:
-        # Ensure ./tmp exists for tests that mkdtemp into it (scope-independent).
-        os.makedirs("./tmp", exist_ok=True)
         runner_result = runner.run(test_suite_main, test_suite_subproc)
         failed, errored = len(runner_result.failures), len(runner_result.errors)
         if failed > 0 or errored > 0:

--- a/tzrec/tests/run.py
+++ b/tzrec/tests/run.py
@@ -252,8 +252,7 @@ if __name__ == "__main__":
     test_suite_main, test_suite_subproc = _gather_test_cases(args)
 
     if not args.list_tests:
-        # Tests that mkdtemp(dir="./tmp") rely on it existing; create it once
-        # here so coverage is independent of test order and the --scope subset.
+        # Ensure ./tmp exists for tests that mkdtemp into it (scope-independent).
         os.makedirs("./tmp", exist_ok=True)
         runner_result = runner.run(test_suite_main, test_suite_subproc)
         failed, errored = len(runner_result.failures), len(runner_result.errors)

--- a/tzrec/tests/sid_integration_test.py
+++ b/tzrec/tests/sid_integration_test.py
@@ -25,7 +25,7 @@ import torch
 
 from tzrec.tests import utils
 from tzrec.utils import config_util
-from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import mark_ci_scope
 
 
 class SidIntegrationTest(unittest.TestCase):
@@ -123,7 +123,6 @@ class SidIntegrationTest(unittest.TestCase):
         self.assertGreater(metrics["unique_sid_ratio"], 0.0)
 
     @mark_ci_scope("gpu")
-    @unittest.skipIf(*gpu_unavailable)
     def test_sid_rqvae_train_eval(self):
         """End-to-end SidRqvae train -> checkpoint -> eval (gradient-trained).
 

--- a/tzrec/tests/sid_integration_test.py
+++ b/tzrec/tests/sid_integration_test.py
@@ -14,7 +14,6 @@ import json
 import math
 import os
 import shutil
-import tempfile
 import unittest
 from unittest import mock
 
@@ -25,16 +24,13 @@ import torch
 
 from tzrec.tests import utils
 from tzrec.utils import config_util
-from tzrec.utils.test_util import mark_ci_scope
+from tzrec.utils.test_util import make_test_dir, mark_ci_scope
 
 
 class SidIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir()
         # SidRqkmeans is single-process; pin nproc=1 (the CI harness defaults
         # to 2, which would trip the world_size>1 guard).
         patcher = mock.patch.dict(os.environ, {"TEST_NPROC_PER_NODE": "1"})

--- a/tzrec/tests/sid_integration_test.py
+++ b/tzrec/tests/sid_integration_test.py
@@ -25,6 +25,7 @@ import torch
 
 from tzrec.tests import utils
 from tzrec.utils import config_util
+from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 
 
 class SidIntegrationTest(unittest.TestCase):
@@ -121,11 +122,8 @@ class SidIntegrationTest(unittest.TestCase):
         self.assertLess(metrics["rel_loss"], 1.0)
         self.assertGreater(metrics["unique_sid_ratio"], 0.0)
 
-    @unittest.skipIf(
-        torch.cuda.is_available(),
-        "the SID integration tests run on the CPU CI job; forcing CPU on a "
-        "CUDA-built (GPU) image is unreliable.",
-    )
+    @mark_ci_scope("gpu")
+    @unittest.skipIf(*gpu_unavailable)
     def test_sid_rqvae_train_eval(self):
         """End-to-end SidRqvae train -> checkpoint -> eval (gradient-trained).
 

--- a/tzrec/tools/convert_easyrec_config_to_tzrec_config_test.py
+++ b/tzrec/tools/convert_easyrec_config_to_tzrec_config_test.py
@@ -12,13 +12,13 @@
 import json
 import os
 import shutil
-import tempfile
 import unittest
 
 from google.protobuf import text_format
 
 from tzrec.protos import pipeline_pb2 as tzrec_pipeline_pb2
 from tzrec.tools.convert_easyrec_config_to_tzrec_config import ConvertConfig
+from tzrec.utils.test_util import make_test_dir
 
 FG_JSON = {
     "features": [
@@ -2004,9 +2004,7 @@ class ConvertConfigTest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_convert_", dir="./tmp")
+        self.test_dir = make_test_dir(prefix="tzrec_convert_")
         self.fg_path = os.path.join(self.test_dir, "fg.json")
         self.easyrec_path = os.path.join(self.test_dir, "easyrec.config")
         self.tzrec_path = os.path.join(self.test_dir, "tzrec.config")

--- a/tzrec/tools/dynamicemb/create_dynamicemb_init_ckpt_test.py
+++ b/tzrec/tools/dynamicemb/create_dynamicemb_init_ckpt_test.py
@@ -20,7 +20,7 @@ import pyarrow.dataset as ds
 
 from tzrec.tests import utils
 from tzrec.utils import config_util, dynamicemb_util, misc_util
-from tzrec.utils.test_util import gpu_unavailable
+from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 
 
 class CreateDynamicEmbInitCkptTest(unittest.TestCase):
@@ -40,6 +40,7 @@ class CreateDynamicEmbInitCkptTest(unittest.TestCase):
         gpu_unavailable[0] or not dynamicemb_util.has_dynamicemb,
         "dynamicemb not available.",
     )
+    @mark_ci_scope("gpu")
     def test_create_dynamicemb_init_ckpt(self):
         pipeline_config = config_util.load_pipeline_config(
             "tzrec/tests/configs/multi_tower_din_fg_dynamicemb_mock.config"

--- a/tzrec/tools/dynamicemb/create_dynamicemb_init_ckpt_test.py
+++ b/tzrec/tools/dynamicemb/create_dynamicemb_init_ckpt_test.py
@@ -12,7 +12,6 @@
 import os
 import random
 import shutil
-import tempfile
 import unittest
 
 import pyarrow as pa
@@ -20,16 +19,13 @@ import pyarrow.dataset as ds
 
 from tzrec.tests import utils
 from tzrec.utils import config_util, dynamicemb_util, misc_util
-from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import gpu_unavailable, make_test_dir, mark_ci_scope
 
 
 class CreateDynamicEmbInitCkptTest(unittest.TestCase):
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if self.success:

--- a/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
+++ b/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
@@ -30,7 +30,7 @@ from tzrec.tests import utils
 from tzrec.tools.dynamicemb import zch_to_dynamicemb_convert as conv
 from tzrec.utils import checkpoint_util, misc_util
 from tzrec.utils.dynamicemb_util import has_dynamicemb
-from tzrec.utils.test_util import gpu_unavailable
+from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 
 _IINFO_MAX = torch.iinfo(torch.int64).max
 
@@ -585,6 +585,7 @@ class ConvertE2ETests(unittest.TestCase):
         gpu_unavailable[0] or not has_dynamicemb,
         "dynamicemb not available.",
     )
+    @mark_ci_scope("gpu")
     def test_convert_e2e(self):
         # 1. Train a ZCH model briefly to produce a real source checkpoint.
         src_train_dir = os.path.join(self.test_dir, "src_train")

--- a/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
+++ b/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
@@ -310,6 +310,7 @@ class DeriveScoresTests(unittest.TestCase):
 
 
 @unittest.skipUnless(has_dynamicemb, "dynamicemb not available")
+@mark_ci_scope("gpu")
 class ShardWriteTests(unittest.TestCase):
     """Parameterized tests for ``_gather_and_shard_writes`` output files."""
 

--- a/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
+++ b/tzrec/tools/dynamicemb/zch_to_dynamicemb_convert_test.py
@@ -30,7 +30,7 @@ from tzrec.tests import utils
 from tzrec.tools.dynamicemb import zch_to_dynamicemb_convert as conv
 from tzrec.utils import checkpoint_util, misc_util
 from tzrec.utils.dynamicemb_util import has_dynamicemb
-from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import gpu_unavailable, make_test_dir, mark_ci_scope
 
 _IINFO_MAX = torch.iinfo(torch.int64).max
 
@@ -573,10 +573,7 @@ class ConvertE2ETests(unittest.TestCase):
 
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_zch_to_dyemb_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir(prefix="tzrec_zch_to_dyemb_")
 
     def tearDown(self):
         if self.success and os.path.exists(self.test_dir):

--- a/tzrec/tools/tdm/gen_tree/tree_search_util_test.py
+++ b/tzrec/tools/tdm/gen_tree/tree_search_util_test.py
@@ -20,13 +20,12 @@ from parameterized import parameterized
 
 from tzrec.tools.tdm.gen_tree.tree_cluster import TreeCluster
 from tzrec.tools.tdm.gen_tree.tree_search_util import TreeSearch
+from tzrec.utils.test_util import make_test_dir
 
 
 class TreeSearchtest(unittest.TestCase):
     def setUp(self) -> None:
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
         self.tmp_file = tempfile.NamedTemporaryFile(
             dir=self.test_dir, mode="w", delete=False, newline="", suffix=".csv"
         )

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -37,6 +37,7 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.utils import checkpoint_util, misc_util
+from tzrec.utils.test_util import make_test_dir
 
 
 def _create_test_model(large_table_cnt=2, small_table_cnt=2):
@@ -173,9 +174,7 @@ def _remap_restore_worker(test_dir, rank, world_size, port, remap_file_path):
 
 class CheckpointUtilTest(unittest.TestCase):
     def setUp(self):
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if os.path.exists(self.test_dir):
@@ -408,9 +407,7 @@ class DataloaderCheckpointTest(unittest.TestCase):
     """Tests for dataloader checkpoint utilities."""
 
     def setUp(self):
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
+        self.test_dir = make_test_dir()
 
     def tearDown(self):
         if os.path.exists(self.test_dir):

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -54,7 +54,7 @@ from tzrec.utils.delta_embedding_dump import (
     validate_delta_embedding_dump_no_zch_features,
 )
 from tzrec.utils.dynamicemb_util import has_dynamicemb
-from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import gpu_unavailable, make_test_dir, mark_ci_scope
 
 _SHARDED_TABLE_NAME = "table_1"
 _SHARDED_FEATURE_NAME = "feature_1"
@@ -854,10 +854,7 @@ class DeltaEmbeddingDumpDynamicembIntegrationTest(unittest.TestCase):
 
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_delta_dyn_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir(prefix="tzrec_delta_dyn_")
 
     def tearDown(self):
         if self.success and os.path.exists(self.test_dir):

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -54,7 +54,7 @@ from tzrec.utils.delta_embedding_dump import (
     validate_delta_embedding_dump_no_zch_features,
 )
 from tzrec.utils.dynamicemb_util import has_dynamicemb
-from tzrec.utils.test_util import gpu_unavailable
+from tzrec.utils.test_util import gpu_unavailable, mark_ci_scope
 
 _SHARDED_TABLE_NAME = "table_1"
 _SHARDED_FEATURE_NAME = "feature_1"
@@ -811,6 +811,7 @@ class DeltaEmbeddingDumpShardedIntegrationTest(MultiProcessTestBase):
         self.world_size = 2
 
     @unittest.skipIf(torch.cuda.device_count() < 2, "test requires 2+ GPUs")
+    @mark_ci_scope("gpu")
     def test_row_wise_sharded_dump_writes_global_key_ids(self):
         with (
             tempfile.TemporaryDirectory() as tmp_dir,
@@ -864,6 +865,7 @@ class DeltaEmbeddingDumpDynamicembIntegrationTest(unittest.TestCase):
         gpu_unavailable[0] or not has_dynamicemb,
         "dynamicemb or GPU not available.",
     )
+    @mark_ci_scope("gpu")
     def test_dynamicemb_multi_gpu_delta_dump_writes_uniform_shards(self):
         world_size = int(os.getenv("TEST_NPROC_PER_NODE", "2"))
         pipeline_config = config_util.load_pipeline_config(

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -752,6 +752,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
 
     @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for dynamicemb.")
+    @mark_ci_scope("gpu")
     def test_lookup_dynamic_embeddings_filters_missing_ids(self):
         from dynamicemb.types import CopyMode
 
@@ -780,6 +781,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
 
     @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for dynamicemb.")
+    @mark_ci_scope("gpu")
     def test_lookup_dynamic_embeddings_flushes_module_once_per_dump(self):
         torch.cuda.set_device(0)
         dumper = object.__new__(DeltaEmbeddingDumper)

--- a/tzrec/utils/dynamicemb_util_test.py
+++ b/tzrec/utils/dynamicemb_util_test.py
@@ -14,11 +14,13 @@ import unittest
 from parameterized import parameterized
 
 from tzrec.utils import dynamicemb_util
+from tzrec.utils.test_util import mark_ci_scope
 
 
 @unittest.skipUnless(
     dynamicemb_util.has_dynamicemb, "dynamicemb is not installed; skipping."
 )
+@mark_ci_scope("gpu")
 class StorageFormulaTest(unittest.TestCase):
     """Mode-aware ``_calculate_dynamicemb_table_storage_specific_size``."""
 

--- a/tzrec/utils/filesystem_util_test.py
+++ b/tzrec/utils/filesystem_util_test.py
@@ -11,20 +11,17 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 
 from tzrec.tests import utils
 from tzrec.utils import filesystem_util
+from tzrec.utils.test_util import make_test_dir
 
 
 class FileSystemUtilTest(unittest.TestCase):
     def setUp(self):
         self.success = False
-        if not os.path.exists("./tmp"):
-            os.makedirs("./tmp")
-        self.test_dir = tempfile.mkdtemp(prefix="tzrec_", dir="./tmp")
-        os.chmod(self.test_dir, 0o755)
+        self.test_dir = make_test_dir()
         filesystem_util.apply_monkeypatch()
 
     def tearDown(self):

--- a/tzrec/utils/plan_util_test.py
+++ b/tzrec/utils/plan_util_test.py
@@ -29,6 +29,7 @@ from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.plan_util import DynamicProgrammingProposer, _sparse_dp_proposor_numpy
+from tzrec.utils.test_util import mark_ci_scope
 
 
 class PlanUtilTest(unittest.TestCase):
@@ -444,6 +445,7 @@ class DynamicProgrammingProposerTest(unittest.TestCase):
 
 @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for dynamicemb.")
+@mark_ci_scope("gpu")
 class PlanUtilDynamicEmbE2ETest(unittest.TestCase):
     """End-to-end exercise of the dynamicemb planner integration."""
 

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -122,6 +122,11 @@ def parameterized_name_func(func, num, p) -> str:
     return base_name + name_suffix
 
 
+def is_ci_nightly() -> bool:
+    """Whether this is the nightly full run (``CI_NIGHTLY=true``)."""
+    return os.environ.get("CI_NIGHTLY", "false").lower() == "true"
+
+
 class hypothesis_settings(_settings):
     """Hypothesis settings for TorchEasyRec."""
 
@@ -135,7 +140,7 @@ class hypothesis_settings(_settings):
         derandomize: bool = _not_set,
         **kwargs: Any,
     ) -> None:
-        if os.environ.get("CI_NIGHTLY", "false").lower() == "true":
+        if is_ci_nightly():
             if derandomize == _not_set:
                 derandomize = False
         else:

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -135,14 +135,14 @@ class hypothesis_settings(_settings):
         derandomize: bool = _not_set,
         **kwargs: Any,
     ) -> None:
-        if os.environ.get("CI_HYPOTHESIS", "false").lower() == "true":
+        if os.environ.get("CI_NIGHTLY", "false").lower() == "true":
+            if derandomize == _not_set:
+                derandomize = False
+        else:
             if max_examples != _not_set:
                 max_examples = max(1, max_examples // 5)
             if derandomize == _not_set:
                 derandomize = True
-        else:
-            if derandomize == _not_set:
-                derandomize = False
         super().__init__(
             parent, max_examples=max_examples, derandomize=derandomize, **kwargs
         )

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -11,6 +11,7 @@
 
 import importlib.util
 import os
+import tempfile
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -125,6 +126,14 @@ def parameterized_name_func(func, num, p) -> str:
 def is_ci_nightly() -> bool:
     """Whether this is the nightly full run (``CI_NIGHTLY=true``)."""
     return os.environ.get("CI_NIGHTLY", "false").lower() == "true"
+
+
+def make_test_dir(prefix: str = "tzrec_") -> str:
+    """Create a fresh, world-readable ``./tmp/<prefix>*`` dir; return its path."""
+    os.makedirs("./tmp", exist_ok=True)
+    test_dir = tempfile.mkdtemp(prefix=prefix, dir="./tmp")
+    os.chmod(test_dir, 0o755)
+    return test_dir
 
 
 class hypothesis_settings(_settings):


### PR DESCRIPTION
## Problem
The GPU unit-test lanes run ~2× over a 1-hour target: **GPU lane ≈ 127 min**, **H20 lane (`--scope h20`) ≈ 115 min**. Each fix below was measured (instrumented runner + cold/warm experiments on the real A10 CI host and an H20 box), not guessed.

## What this changes (3 independent levers)

**1. Persist the Triton/Inductor cache outside `_temp` (both lanes).**
The caches lived under `/github/home` = `$WORK_ROOT/_temp/_github_home`, which the runner wipes every job, so every run recompiles every kernel cold. Moved to `/__w/TorchEasyRec/tzrec-ci-cache` (the `RUNNER_WORKSPACE` mount, one level above the per-run `run_<id>` checkout): persists across jobs, already bind-mounted, untouched by `actions/checkout`, outside `_temp`.
*Measured end-to-end (`run.py --scope h20`): cold 110.2 min → warm 32.7 min (−70%).*

**2. Derandomize the HSTU/GR hypothesis tests.**
Five test files used plain `from hypothesis import settings` (non-derandomized), so they drew fresh kernel shapes every run and recompiled even with a warm cache. Switched to tzrec's `hypothesis_settings` (the helper the other ops/gr tests already use), which sets `derandomize=True` under CI.
*Measured: `stu_test.test_triton` 192 s → 63 s (−67%); reducing `max_examples` was separately shown to be neutral.*

**3. Run only GPU-needed tests on the default GPU lane.**
The CPU CI lane already runs every CPU-runnable test on CPU; the GPU lane was re-running the whole suite on GPU. Marked the GPU-exercising tests `@mark_ci_scope("gpu")` and run the GPU lane with `--scope gpu`. Verified: **gpu = 122 tests, h20 = 94 (unchanged), full = 1133**, and every `gpu_unavailable`/cutlass/device-gated test is `gpu`-scoped (0 tests run nowhere).

## Verifying in CI
The **first** run on this PR is cold — it *populates* the new cache dir, so it won't show the speedup (and may be slow). The win appears on the **second** run onward (warm cache), which is the real per-PR state. Please re-run the GPU/H20 lanes once to see warm timings.

## Note / open decision
The 3 CPU-vs-GPU *consistency-branch* integration tests run fully on CPU CI but only assert cpu/gpu equality under `if torch.cuda.is_available()`. They are **not** marked `gpu` (marking them re-adds heavy pipelines to the GPU lane, against the time goal; they are not coverage holes). Easy to flip if you'd rather keep that consistency check on GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Y1GtMDUPZG66aXiz5K4M