### PR TITLE
[feat] allow pandas>=3

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -10,7 +10,7 @@ graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn-1.
 grpcio-tools<1.63.0
 numpy<2
 packaging
-pandas<3
+pandas
 psutil
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"

--- a/tzrec/tests/utils.py
+++ b/tzrec/tests/utils.py
@@ -324,7 +324,10 @@ class SeqMockInput(MockInput):
         data = {}
         for name, arr in zip(t.column_names, t.columns):
             if name in self.side_infos:
-                data[f"{self.name}{self.sequence_underline}{name}"] = arr
+                # pandas>=3 `from_pandas` yields large_string; cast back to string.
+                data[f"{self.name}{self.sequence_underline}{name}"] = arr.cast(
+                    pa.string()
+                )
 
         return data
 


### PR DESCRIPTION
## What
- Drop the `pandas<3` upper bound in `requirements/runtime.txt` (now unpinned `pandas`) so TorchEasyRec installs and runs on pandas 3.x as well as 2.x.
- Fix a pandas-3 incompatibility in the test data generator so the integration suite passes under pandas 3.

## Why
pandas 3.0 is now the pip default, and the `<3` cap blocks fresh installs. TorchEasyRec's data pipeline is pure pyarrow (it reads `pa.string()` natively from parquet/ODPS — no pandas). pandas is only used in a test util (`tzrec/utils/test_util.py`), the feature-selection tool (`tzrec/tools/feature_selection.py`), and an HSTU benchmark (`tzrec/ops/benchmarks/hstu_attention_bench.py`), all of which rely on stable APIs unchanged under pandas 3. `numpy<2` is left untouched (numpy 1.26.4 satisfies pandas 3.0's minimum).

## The pandas-3 fix
Under pandas ≥ 3, `pa.Table.from_pandas()` maps the new default string dtype to arrow `large_string` (not `string`). `SeqMockInput.create_sequence_data` builds the mock fg-encoded sequence columns via `from_pandas`, so the generated test parquet carried `large_string` columns — which the dataset reader (`AVAILABLE_PA_TYPES` / `_init_input_fields`) and pyfg reject (`column ... with dtype large_string is not supported now` / `Unsupported arrow type`). This made every train/eval/export integration test that uses mock sequence features fail.

The fix casts those columns back to `pa.string()` in `SeqMockInput.create_sequence_data`, so the mock data matches real fg-encoded parquet. It is a no-op under pandas < 3.

## Validation
The CI matrix (CPU + GPU unit tests, buildtest, codestyle, pytyping) passes with pandas 3.x installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BaFDY7dEBSNYsWerjaSGC
