### PR TITLE
[ci] code review: add Codex review job triggered by codex-review label

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -14,7 +14,7 @@ Perform a comprehensive code review using subagents for key areas:
 Instruct each to only provide noteworthy feedback. Once they finish, review
 the feedback and post only the feedback that you also deem noteworthy.
 
-Use `mcp__github_inline_comment__create_inline_comment` for inline comments on specific lines.
+Use the `create_inline_comment` tool of the `github_inline_comment` MCP server for inline comments on specific lines.
 Use top-level comments for general observations or praise.
 Use `gh pr comment` for top-level summary comments.
 Do NOT use `gh api` — it is not available.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -3,6 +3,9 @@ allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 
+Fetch the PR context with `gh pr view` and the changes with `gh pr diff`.
+Review statically — do not run tests or builds.
+
 Perform a comprehensive code review using subagents for key areas:
 
 - code-quality-reviewer

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -191,8 +191,7 @@ jobs:
             --out-dir "${{ runner.temp }}/codex-gen" \
             --repo ${{ github.repository }} \
             --pr-number ${{ github.event.pull_request.number }} \
-            --prompt-out "${{ runner.temp }}/codex-prompt.md" \
-            --agents-md trusted-claude/AGENTS.md
+            --prompt-out "${{ runner.temp }}/codex-prompt.md"
           bash trusted-claude/scripts/ci/use_trusted_agent_files.sh \
             trusted-claude pr-code "${{ runner.temp }}/codex-gen"
 
@@ -226,12 +225,13 @@ jobs:
 
           # Sandbox has no network; only the gh pr view/diff/comment rules allowlist
           # escapes it (claude-job parity). Unstripped TOKEN env so gh can auth.
+          # Every AGENTS.md codex can see is trusted: the workspace one is restored by
+          # use_trusted_agent_files.sh and the per-run CODEX_HOME has none.
           codex exec \
             --ignore-user-config \
             --ephemeral \
             --sandbox workspace-write \
             -c shell_environment_policy.ignore_default_excludes=true \
-            -c project_doc_max_bytes=0 \
             -c model_reasoning_effort='"medium"' \
             -c mcp_servers.github_inline_comment.command="\"${BUN_PATH}\"" \
             -c 'mcp_servers.github_inline_comment.args=["run","/opt/claude-code-action/src/mcp/github-inline-comment-server.ts"]' \

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -58,7 +58,8 @@
 #   codex login --device-auth
 #   codex login status
 #
-#   # Optionally pin the model in ~/.codex/config.toml, e.g. model = "gpt-5-codex"
+#   # The job runs with --ignore-user-config (~/.codex/config.toml is not loaded);
+#   # to pin a model, add `-c model=...` to the codex exec call below.
 #
 #   # Verify headless mode
 #   echo "Say hello" | codex exec - --sandbox read-only
@@ -178,18 +179,21 @@ jobs:
           fetch-depth: 1
           path: pr-code
 
-      # Codex reads .codex/agents/ and AGENTS.md from the workspace: generate both
-      # from trusted base-branch files, dropping whatever the PR author shipped.
+      # Codex reads .codex/agents/, .agents/ and AGENTS.md from the workspace: generate
+      # agents from trusted base-branch files, dropping whatever the PR author shipped.
+      # Commit the swap so `git status/diff` inside the review shows the PR, not our setup.
       - name: Use trusted agent files
         run: |
-          rm -rf pr-code/.claude pr-code/.codex pr-code/AGENTS.md
+          rm -rf pr-code/.claude pr-code/.codex pr-code/.agents pr-code/AGENTS.md
           python3 trusted-claude/scripts/ci/gen_codex_review.py \
             --claude-dir trusted-claude/.claude \
             --out-dir pr-code \
             --repo ${{ github.repository }} \
             --pr-number ${{ github.event.pull_request.number }} \
             --prompt-out "${{ runner.temp }}/codex-prompt.md"
-          cp trusted-claude/CLAUDE.md pr-code/AGENTS.md
+          git -C pr-code add -A
+          git -C pr-code -c user.name=ci -c user.email=ci@localhost \
+            commit -q -m "ci: trusted review setup"
 
       - name: RunCodexReview
         working-directory: pr-code
@@ -208,13 +212,28 @@ jobs:
           echo "bun path: $BUN_PATH ($("$BUN_PATH" --version))"
           codex --version
 
+          # HOME shim hides the runner user's personal ~/.agents skills from codex;
+          # CODEX_HOME stays real so stored OAuth keeps working
+          export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+          export HOME="${RUNNER_TEMP}/codex-home-shim"
+          mkdir -p "$HOME"
+
           # gh needs network: workspace-write + network_access (never danger-full-access)
           # mcp env_vars forwards the named job env vars to the MCP server process
+          # ignore-user-config keeps the runner user's personal config/hooks/MCP out of CI
+          # ignore_default_excludes lets gh see GITHUB_TOKEN/GH_TOKEN (stripped by default)
+          # project_doc_max_bytes=0 blocks AGENTS.md injection (user-global and PR-authored)
           codex exec \
+            --ignore-user-config \
+            --ephemeral \
             --sandbox workspace-write \
             -c sandbox_workspace_write.network_access=true \
+            -c shell_environment_policy.ignore_default_excludes=true \
+            -c project_doc_max_bytes=0 \
+            -c model_reasoning_effort='"medium"' \
             -c mcp_servers.github_inline_comment.command="\"${BUN_PATH}\"" \
             -c 'mcp_servers.github_inline_comment.args=["run","/opt/claude-code-action/src/mcp/github-inline-comment-server.ts"]' \
             -c 'mcp_servers.github_inline_comment.env_vars=["GITHUB_TOKEN","REPO_OWNER","REPO_NAME","PR_NUMBER"]' \
+            -c 'mcp_servers.github_inline_comment.default_tools_approval_mode="approve"' \
             --output-last-message "${RUNNER_TEMP}/codex-review-last.md" \
             - < "${RUNNER_TEMP}/codex-prompt.md"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -58,8 +58,8 @@
 #   codex login --device-auth
 #   codex login status
 #
-#   # The job runs with --ignore-user-config (~/.codex/config.toml is not loaded);
-#   # to pin a model, add `-c model=...` to the codex exec call below.
+#   # The job builds a per-run CODEX_HOME (auth + rules + generated config.toml), so
+#   # personal ~/.codex config never loads; to pin a model, edit the config heredoc.
 #
 #   # Verify headless mode
 #   echo "Say hello" | codex exec - --sandbox read-only
@@ -212,31 +212,48 @@ jobs:
           echo "bun path: $BUN_PATH ($("$BUN_PATH" --version))"
           codex --version
 
-          # Per-run CODEX_HOME carries only stored auth + the trusted exec-policy rules;
-          # HOME shim hides the runner user's personal ~/.agents skills
+          # Per-run CODEX_HOME: stored auth, trusted exec-policy rules, and a generated
+          # config.toml; the runner user's personal ~/.codex never loads.
+          # HOME shim hides the runner user's personal ~/.agents skills.
           REAL_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
           export CODEX_HOME="${RUNNER_TEMP}/codex-home"
           rm -rf "$CODEX_HOME" && mkdir -p "$CODEX_HOME/rules"
           cp "$REAL_CODEX_HOME/auth.json" "$CODEX_HOME/auth.json"
           cp "$GITHUB_WORKSPACE/trusted-claude/scripts/ci/codex_review.rules" \
             "$CODEX_HOME/rules/default.rules"
+
+          # The MCP server gets its token here (config file, not argv or codex env)
+          cat > "$CODEX_HOME/config.toml" << EOF
+          model_reasoning_effort = "medium"
+
+          [mcp_servers.github_inline_comment]
+          command = "${BUN_PATH}"
+          args = ["run", "/opt/claude-code-action/src/mcp/github-inline-comment-server.ts"]
+          default_tools_approval_mode = "approve"
+
+          [mcp_servers.github_inline_comment.env]
+          GITHUB_TOKEN = "${GITHUB_TOKEN}"
+          REPO_OWNER = "${REPO_OWNER}"
+          REPO_NAME = "${REPO_NAME}"
+          PR_NUMBER = "${PR_NUMBER}"
+          EOF
+          chmod 600 "$CODEX_HOME/config.toml"
+
           export HOME="${RUNNER_TEMP}/codex-home-shim"
-          mkdir -p "$HOME"
+          rm -rf "$HOME" && mkdir -p "$HOME"
+
+          # gh authenticates from a stored login in the shim HOME: codex runs with the
+          # token env removed, so model-run commands cannot even read it (tighter than
+          # the claude job, where the allowlisted Bash still sees GITHUB_TOKEN)
+          echo "$GITHUB_TOKEN" | env -u GITHUB_TOKEN -u GH_TOKEN gh auth login --with-token
 
           # Sandbox has no network; only the gh pr view/diff/comment rules allowlist
-          # escapes it (claude-job parity). Unstripped TOKEN env so gh can auth.
+          # escapes it (claude-job parity).
           # Every AGENTS.md codex can see is trusted: the workspace one is restored by
           # use_trusted_agent_files.sh and the per-run CODEX_HOME has none.
-          codex exec \
-            --ignore-user-config \
+          env -u GITHUB_TOKEN -u GH_TOKEN codex exec \
             --ephemeral \
             --sandbox workspace-write \
-            -c shell_environment_policy.ignore_default_excludes=true \
-            -c model_reasoning_effort='"medium"' \
-            -c mcp_servers.github_inline_comment.command="\"${BUN_PATH}\"" \
-            -c 'mcp_servers.github_inline_comment.args=["run","/opt/claude-code-action/src/mcp/github-inline-comment-server.ts"]' \
-            -c 'mcp_servers.github_inline_comment.env_vars=["GITHUB_TOKEN","REPO_OWNER","REPO_NAME","PR_NUMBER"]' \
-            -c 'mcp_servers.github_inline_comment.default_tools_approval_mode="approve"' \
             --output-last-message "${RUNNER_TEMP}/codex-review-last.md" \
             - < "${RUNNER_TEMP}/codex-prompt.md"
 

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -101,11 +101,13 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label claude-review
 
-      # Checkout trusted agent files from base branch; cone mode also includes root-level files
+      # Checkout trusted agent files; cone mode also includes root-level files.
+      # github.sha = base-branch head the workflow definition came from — never the
+      # PR's frozen base.sha, which can predate trusted assets this workflow calls.
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
           sparse-checkout: |
             .claude
             scripts/ci
@@ -165,11 +167,12 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label codex-review
 
-      # Checkout trusted .claude/ + converter from base branch (not the PR author's code)
+      # Checkout trusted .claude/ + scripts (not the PR author's code); github.sha =
+      # base-branch head the workflow definition came from, never the frozen base.sha
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
           sparse-checkout: |
             .claude
             scripts/ci

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -68,9 +68,9 @@
 # If the runner lacks direct OpenAI egress, set HTTPS_PROXY for the runner service.
 #
 # Trust model: the collaborator-added label gates every run (review before labeling).
-# The sandbox confines writes to the workspace but not reads, and gh needs network,
-# so injected instructions in PR file contents could read+exfiltrate runner files —
-# keep this runner single-purpose and its stored credentials minimal.
+# Model commands run in a no-network sandbox; only the gh pr view/diff/comment
+# allowlist (scripts/ci/codex_review.rules) runs outside it — as with the claude
+# job's --allowedTools, a PR comment is the only exfil path for injected content.
 # ---- End Codex Setup ----
 
 name: Code Review
@@ -213,19 +213,23 @@ jobs:
           echo "bun path: $BUN_PATH ($("$BUN_PATH" --version))"
           codex --version
 
-          # HOME shim hides the runner user's personal ~/.agents skills from codex;
-          # CODEX_HOME stays real so stored OAuth keeps working
-          export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+          # Per-run CODEX_HOME carries only stored auth + the trusted exec-policy rules;
+          # HOME shim hides the runner user's personal ~/.agents skills
+          REAL_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+          export CODEX_HOME="${RUNNER_TEMP}/codex-home"
+          rm -rf "$CODEX_HOME" && mkdir -p "$CODEX_HOME/rules"
+          cp "$REAL_CODEX_HOME/auth.json" "$CODEX_HOME/auth.json"
+          cp "$GITHUB_WORKSPACE/trusted-claude/scripts/ci/codex_review.rules" \
+            "$CODEX_HOME/rules/default.rules"
           export HOME="${RUNNER_TEMP}/codex-home-shim"
           mkdir -p "$HOME"
 
-          # Network + unstripped TOKEN env for gh; ambient AGENTS.md and personal config
-          # kept out (the trusted guide is embedded in the prompt instead)
+          # Sandbox has no network; only the gh pr view/diff/comment rules allowlist
+          # escapes it (claude-job parity). Unstripped TOKEN env so gh can auth.
           codex exec \
             --ignore-user-config \
             --ephemeral \
             --sandbox workspace-write \
-            -c sandbox_workspace_write.network_access=true \
             -c shell_environment_policy.ignore_default_excludes=true \
             -c project_doc_max_bytes=0 \
             -c model_reasoning_effort='"medium"' \
@@ -235,3 +239,7 @@ jobs:
             -c 'mcp_servers.github_inline_comment.default_tools_approval_mode="approve"' \
             --output-last-message "${RUNNER_TEMP}/codex-review-last.md" \
             - < "${RUNNER_TEMP}/codex-prompt.md"
+
+          # Persist token refreshes back to the runner's stored auth
+          cmp -s "$CODEX_HOME/auth.json" "$REAL_CODEX_HOME/auth.json" || \
+            cp "$CODEX_HOME/auth.json" "$REAL_CODEX_HOME/auth.json"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -106,7 +106,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          sparse-checkout: .claude
+          sparse-checkout: |
+            .claude
+            scripts/ci
           path: trusted-claude
 
       # Checkout PR code for review
@@ -117,17 +119,8 @@ jobs:
           fetch-depth: 1
           path: pr-code
 
-      # rm first: cp -r into an existing dir nests instead of replacing (GHSA-f9x3-9rgg-92p7).
-      # Strip at every depth: nested CLAUDE.md files are auto-loaded too.
       - name: Use trusted agent files
-        run: |
-          find pr-code \( -name .claude -o -name CLAUDE.md -o -name CLAUDE.local.md -o -name AGENTS.md \) -prune -exec rm -rf {} +
-          cp -r trusted-claude/.claude pr-code/.claude
-          for f in CLAUDE.md AGENTS.md; do
-            if [ -f "trusted-claude/$f" ]; then
-              cp "trusted-claude/$f" "pr-code/$f"
-            fi
-          done
+        run: bash trusted-claude/scripts/ci/use_trusted_agent_files.sh trusted-claude pr-code
 
       - name: RunCodeReview
         working-directory: pr-code
@@ -190,20 +183,18 @@ jobs:
           fetch-depth: 1
           path: pr-code
 
-      # Swap in agents generated from trusted base .claude/; commit so git diff shows only the PR
+      # Same trusted-file setup as the claude job, plus generated codex agents as an overlay
       - name: Use trusted agent files
         run: |
-          rm -rf pr-code/.claude pr-code/.codex pr-code/.agents pr-code/AGENTS.md
           python3 trusted-claude/scripts/ci/gen_codex_review.py \
             --claude-dir trusted-claude/.claude \
-            --out-dir pr-code \
+            --out-dir "${{ runner.temp }}/codex-gen" \
             --repo ${{ github.repository }} \
             --pr-number ${{ github.event.pull_request.number }} \
             --prompt-out "${{ runner.temp }}/codex-prompt.md" \
             --agents-md trusted-claude/AGENTS.md
-          git -C pr-code add -A
-          git -C pr-code -c user.name=ci -c user.email=ci@localhost \
-            commit -q -m "ci: trusted review setup"
+          bash trusted-claude/scripts/ci/use_trusted_agent_files.sh \
+            trusted-claude pr-code "${{ runner.temp }}/codex-gen"
 
       - name: RunCodexReview
         working-directory: pr-code

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,13 +1,16 @@
-# Claude Code Review Workflow
+# AI Code Review Workflow (Claude Code / OpenAI Codex)
 #
-# Triggered by adding the "claude-review" label to a PR.
-# Uses stored OAuth credentials on self-hosted runner (no ANTHROPIC_API_KEY needed).
+# Triggered by adding the "claude-review" or "codex-review" label to a PR.
+# Uses stored OAuth credentials on self-hosted runner (no API keys needed).
 #
 # Usage:
 #   1. Contributor opens PR
-#   2. Collaborator adds "claude-review" label when ready for review
-#   3. Workflow triggers, removes the label, runs Claude review
+#   2. Collaborator adds "claude-review" or "codex-review" label when ready for review
+#   3. Workflow triggers, removes the label, runs the review
 #   4. Want to re-review after changes? Add the label again
+#
+# Review instructions live only in .claude/ (commands/review-pr.md + agents/*.md);
+# the Codex job converts them at runtime via scripts/ci/gen_codex_review.py.
 #
 # ---- Runner One-Time Setup ----
 # SSH into tzrec-codereview-runner as the runner user and run:
@@ -44,6 +47,25 @@
 # If auth fails after a long period, re-run `claude /login` on the runner.
 # Do NOT use --bare flag — it disables OAuth/keychain reads.
 # ---- End Setup ----
+#
+# ---- Codex Runner One-Time Setup ----
+# Shares bun + /opt/claude-code-action from the Claude setup above.
+#
+#   # Install Codex CLI (keep current: subagents + mcp env_vars need a recent version)
+#   npm install -g @openai/codex
+#
+#   # Login with ChatGPT account (device-code flow, no browser needed on runner)
+#   codex login --device-auth
+#   codex login status
+#
+#   # Optionally pin the model in ~/.codex/config.toml, e.g. model = "gpt-5-codex"
+#
+#   # Verify headless mode
+#   echo "Say hello" | codex exec - --sandbox read-only
+#
+# If auth goes stale, re-run `codex login --device-auth` on the runner.
+# If the runner lacks direct OpenAI egress, set HTTPS_PROXY for the runner service.
+# ---- End Codex Setup ----
 
 name: Code Review
 
@@ -51,8 +73,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+# Group by label so a codex run does not cancel an in-flight claude run
 concurrency:
-  group: codereview-${{ github.event.pull_request.number }}
+  group: codereview-${{ github.event.label.name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -120,3 +143,78 @@ jobs:
             --mcp-config "$MCP_CONFIG" \
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent" \
             -- "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${PR_NUMBER}"
+
+  codex-review:
+    if: github.event.label.name == 'codex-review'
+    runs-on: tzrec-codereview-runner
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Remove label to allow re-triggering later
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label codex-review
+
+      # Checkout trusted .claude/ + converter from base branch (not the PR author's code)
+      - name: Checkout trusted agent files
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .claude
+            scripts/ci
+          path: trusted-claude
+
+      # Checkout PR code for review
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          path: pr-code
+
+      # Codex reads .codex/agents/ and AGENTS.md from the workspace: generate both
+      # from trusted base-branch files, dropping whatever the PR author shipped.
+      - name: Use trusted agent files
+        run: |
+          rm -rf pr-code/.claude pr-code/.codex pr-code/AGENTS.md
+          python3 trusted-claude/scripts/ci/gen_codex_review.py \
+            --claude-dir trusted-claude/.claude \
+            --out-dir pr-code \
+            --repo ${{ github.repository }} \
+            --pr-number ${{ github.event.pull_request.number }} \
+            --prompt-out "${{ runner.temp }}/codex-prompt.md"
+          cp trusted-claude/CLAUDE.md pr-code/AGENTS.md
+
+      - name: RunCodexReview
+        working-directory: pr-code
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # No OPENAI_API_KEY — uses stored OAuth from `codex login` on the runner
+        run: |
+          set -euo pipefail
+
+          # Resolve full bun path (bun installed to ~/.bun/bin/ — not in subprocess PATH)
+          BUN_PATH="$(which bun 2>/dev/null || echo "$HOME/.bun/bin/bun")"
+          echo "bun path: $BUN_PATH ($("$BUN_PATH" --version))"
+          codex --version
+
+          # gh needs network: workspace-write + network_access (never danger-full-access)
+          # mcp env_vars forwards the named job env vars to the MCP server process
+          codex exec \
+            --sandbox workspace-write \
+            -c sandbox_workspace_write.network_access=true \
+            -c mcp_servers.github_inline_comment.command="\"${BUN_PATH}\"" \
+            -c 'mcp_servers.github_inline_comment.args=["run","/opt/claude-code-action/src/mcp/github-inline-comment-server.ts"]' \
+            -c 'mcp_servers.github_inline_comment.env_vars=["GITHUB_TOKEN","REPO_OWNER","REPO_NAME","PR_NUMBER"]' \
+            --output-last-message "${RUNNER_TEMP}/codex-review-last.md" \
+            - < "${RUNNER_TEMP}/codex-prompt.md"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -199,7 +199,8 @@ jobs:
             --out-dir pr-code \
             --repo ${{ github.repository }} \
             --pr-number ${{ github.event.pull_request.number }} \
-            --prompt-out "${{ runner.temp }}/codex-prompt.md"
+            --prompt-out "${{ runner.temp }}/codex-prompt.md" \
+            --agents-md trusted-claude/AGENTS.md
           git -C pr-code add -A
           git -C pr-code -c user.name=ci -c user.email=ci@localhost \
             commit -q -m "ci: trusted review setup"
@@ -227,7 +228,8 @@ jobs:
           export HOME="${RUNNER_TEMP}/codex-home-shim"
           mkdir -p "$HOME"
 
-          # Network + unstripped TOKEN env for gh; personal config and all AGENTS.md kept out
+          # Network + unstripped TOKEN env for gh; ambient AGENTS.md and personal config
+          # kept out (the trusted guide is embedded in the prompt instead)
           codex exec \
             --ignore-user-config \
             --ephemeral \

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -184,9 +184,7 @@ jobs:
           fetch-depth: 1
           path: pr-code
 
-      # Codex reads .codex/agents/, .agents/ and AGENTS.md from the workspace: generate
-      # agents from trusted base-branch files, dropping whatever the PR author shipped.
-      # Commit the swap so `git status/diff` inside the review shows the PR, not our setup.
+      # Swap in agents generated from trusted base .claude/; commit so git diff shows only the PR
       - name: Use trusted agent files
         run: |
           rm -rf pr-code/.claude pr-code/.codex pr-code/.agents pr-code/AGENTS.md
@@ -223,11 +221,7 @@ jobs:
           export HOME="${RUNNER_TEMP}/codex-home-shim"
           mkdir -p "$HOME"
 
-          # gh needs network: workspace-write + network_access (never danger-full-access)
-          # mcp env_vars forwards the named job env vars to the MCP server process
-          # ignore-user-config keeps the runner user's personal config/hooks/MCP out of CI
-          # ignore_default_excludes lets gh see GITHUB_TOKEN/GH_TOKEN (stripped by default)
-          # project_doc_max_bytes=0 blocks AGENTS.md injection (user-global and PR-authored)
+          # Network + unstripped TOKEN env for gh; personal config and all AGENTS.md kept out
           codex exec \
             --ignore-user-config \
             --ephemeral \

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -225,8 +225,10 @@ jobs:
           cp "$GITHUB_WORKSPACE/trusted-claude/scripts/ci/codex_review.rules" \
             "$CODEX_HOME/rules/default.rules"
 
-          # The MCP server gets its token here (config file, not argv or codex env)
+          # The MCP server gets its token here (config file, not argv or codex env).
+          # model must be explicit: subagent spawn cannot resolve a default child model.
           cat > "$CODEX_HOME/config.toml" << EOF
+          model = "gpt-5.5"
           model_reasoning_effort = "medium"
 
           [mcp_servers.github_inline_comment]

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -66,6 +66,11 @@
 #
 # If auth goes stale, re-run `codex login --device-auth` on the runner.
 # If the runner lacks direct OpenAI egress, set HTTPS_PROXY for the runner service.
+#
+# Trust model: the collaborator-added label gates every run (review before labeling).
+# The sandbox confines writes to the workspace but not reads, and gh needs network,
+# so injected instructions in PR file contents could read+exfiltrate runner files —
+# keep this runner single-purpose and its stored credentials minimal.
 # ---- End Codex Setup ----
 
 name: Code Review

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -58,8 +58,9 @@
 #   codex login --device-auth
 #   codex login status
 #
-#   # The job builds a per-run CODEX_HOME (auth + rules + generated config.toml), so
-#   # personal ~/.codex config never loads; to pin a model, edit the config heredoc.
+#   # REQUIRED: set the review model (the job copies top-level model* keys; no other
+#   # personal config loads)
+#   echo 'model = "gpt-5.5"' >> ~/.codex/config.toml
 #
 #   # Verify headless mode
 #   echo "Say hello" | codex exec - --sandbox read-only
@@ -102,8 +103,7 @@ jobs:
             --remove-label claude-review
 
       # Checkout trusted agent files; cone mode also includes root-level files.
-      # github.sha = base-branch head the workflow definition came from — never the
-      # PR's frozen base.sha, which can predate trusted assets this workflow calls.
+      # github.sha = the workflow's own commit; the PR's base.sha is frozen and can lag
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
@@ -167,8 +167,8 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label codex-review
 
-      # Checkout trusted .claude/ + scripts (not the PR author's code); github.sha =
-      # base-branch head the workflow definition came from, never the frozen base.sha
+      # Trusted .claude/ + scripts at github.sha (the workflow's own commit, never the
+      # PR's frozen base.sha)
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
@@ -215,9 +215,7 @@ jobs:
           echo "bun path: $BUN_PATH ($("$BUN_PATH" --version))"
           codex --version
 
-          # Per-run CODEX_HOME: stored auth, trusted exec-policy rules, and a generated
-          # config.toml; the runner user's personal ~/.codex never loads.
-          # HOME shim hides the runner user's personal ~/.agents skills.
+          # Per-run CODEX_HOME (stored auth + trusted rules + generated config only)
           REAL_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
           export CODEX_HOME="${RUNNER_TEMP}/codex-home"
           rm -rf "$CODEX_HOME" && mkdir -p "$CODEX_HOME/rules"
@@ -225,11 +223,14 @@ jobs:
           cp "$GITHUB_WORKSPACE/trusted-claude/scripts/ci/codex_review.rules" \
             "$CODEX_HOME/rules/default.rules"
 
-          # The MCP server gets its token here (config file, not argv or codex env).
-          # model must be explicit: subagent spawn cannot resolve a default child model.
-          cat > "$CODEX_HOME/config.toml" << EOF
-          model = "gpt-5.5"
-          model_reasoning_effort = "medium"
+          # Copy the runner's top-level model* settings; subagent spawn needs explicit model=
+          awk '/^\[/{exit} /^model[a-z_]* *=/{print}' "$REAL_CODEX_HOME/config.toml" \
+            > "$CODEX_HOME/config.toml"
+          grep -q '^model *=' "$CODEX_HOME/config.toml" || {
+            echo "::error::set model = \"...\" in the runner's ~/.codex/config.toml"; exit 1; }
+
+          # The MCP server gets its token here (config file, not argv or codex env)
+          cat >> "$CODEX_HOME/config.toml" << EOF
 
           [mcp_servers.github_inline_comment]
           command = "${BUN_PATH}"
@@ -244,18 +245,14 @@ jobs:
           EOF
           chmod 600 "$CODEX_HOME/config.toml"
 
+          # HOME shim hides the runner user's personal ~/.agents skills
           export HOME="${RUNNER_TEMP}/codex-home-shim"
           rm -rf "$HOME" && mkdir -p "$HOME"
 
-          # gh authenticates from a stored login in the shim HOME: codex runs with the
-          # token env removed, so model-run commands cannot even read it (tighter than
-          # the claude job, where the allowlisted Bash still sees GITHUB_TOKEN)
+          # Store gh login in the shim HOME; codex runs token-free so model commands can't read it
           echo "$GITHUB_TOKEN" | env -u GITHUB_TOKEN -u GH_TOKEN gh auth login --with-token
 
-          # Sandbox has no network; only the gh pr view/diff/comment rules allowlist
-          # escapes it (claude-job parity).
-          # Every AGENTS.md codex can see is trusted: the workspace one is restored by
-          # use_trusted_agent_files.sh and the per-run CODEX_HOME has none.
+          # No-network sandbox; only the gh pr view/diff/comment rules allowlist escapes it
           env -u GITHUB_TOKEN -u GH_TOKEN codex exec \
             --ephemeral \
             --sandbox workspace-write \

--- a/scripts/ci/codex_review.rules
+++ b/scripts/ci/codex_review.rules
@@ -1,0 +1,22 @@
+# Execpolicy allowlist for the codex-review CI job: only these gh commands run
+# outside the sandbox (with network); everything else stays in the no-network
+# sandbox, so posting a PR comment is the only path out — same as the claude
+# job's --allowedTools Bash(gh pr ...) allowlist.
+prefix_rule(
+    pattern = ["gh", "pr", "view"],
+    decision = "allow",
+    justification = "fetch PR metadata",
+    match = ["gh pr view 20 --repo owner/name --json title"],
+)
+prefix_rule(
+    pattern = ["gh", "pr", "diff"],
+    decision = "allow",
+    justification = "fetch PR diff",
+    match = ["gh pr diff 20 --repo owner/name"],
+)
+prefix_rule(
+    pattern = ["gh", "pr", "comment"],
+    decision = "allow",
+    justification = "post the review summary",
+    match = ["gh pr comment 20 --repo owner/name --body-file -"],
+)

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate Codex review inputs from the .claude/ review files.
+
+Keeps .claude/commands/review-pr.md and .claude/agents/*.md as the single
+source of truth for AI code review: converts each Claude agent markdown into
+a Codex subagent TOML (<out_dir>/.codex/agents/<name>.toml) and emits the
+review prompt for `codex exec`. Used by .github/workflows/code_review.yml.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+def split_front_matter(text: str) -> Tuple[Dict[str, str], str]:
+    """Split markdown into front-matter fields and body.
+
+    Args:
+        text (str): markdown text, optionally starting with a `---` block.
+
+    Returns:
+        A (fields, body) tuple, fields parsed as flat `key: value` pairs.
+    """
+    fields = {}
+    body = text
+    if text.startswith("---"):
+        _, front, body = text.split("---", 2)
+        for line in front.splitlines():
+            key, sep, value = line.partition(":")
+            if sep:
+                fields[key.strip()] = value.strip()
+    return fields, body.strip() + "\n"
+
+
+def gen_agent_toml(agent_md: Path, agents_dir: Path) -> None:
+    """Convert one Claude agent markdown into a Codex subagent TOML.
+
+    Args:
+        agent_md (Path): path to a .claude/agents/*.md file.
+        agents_dir (Path): output .codex/agents directory.
+    """
+    fields, body = split_front_matter(agent_md.read_text())
+    name = fields.get("name", agent_md.stem)
+    # json.dumps escaping is valid for TOML basic strings.
+    lines = [
+        f"name = {json.dumps(name)}",
+        f"description = {json.dumps(fields.get('description', ''))}",
+        # Claude agents are read-only (tools: Glob, Grep, Read).
+        'sandbox_mode = "read-only"',
+        f"developer_instructions = {json.dumps(body)}",
+    ]
+    (agents_dir / f"{name}.toml").write_text("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    """Generate Codex subagent TOMLs and the review prompt."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--claude-dir", required=True, help="trusted .claude dir")
+    parser.add_argument("--out-dir", required=True, help="dir to write .codex/agents")
+    parser.add_argument("--repo", required=True, help="owner/repo of the PR")
+    parser.add_argument("--pr-number", required=True, help="PR number to review")
+    parser.add_argument("--prompt-out", required=True, help="review prompt file")
+    args = parser.parse_args()
+
+    claude_dir = Path(args.claude_dir)
+    agents_dir = Path(args.out_dir) / ".codex" / "agents"
+    agents_dir.mkdir(parents=True)
+    for agent_md in sorted((claude_dir / "agents").glob("*.md")):
+        gen_agent_toml(agent_md, agents_dir)
+
+    _, prompt_body = split_front_matter(
+        (claude_dir / "commands" / "review-pr.md").read_text()
+    )
+    Path(args.prompt_out).write_text(
+        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{prompt_body}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -50,7 +50,7 @@ def gen_agent_toml(agent_md: Path, agents_dir: Path) -> None:
         agent_md (Path): path to a .claude/agents/*.md file.
         agents_dir (Path): output .codex/agents directory.
     """
-    fields, body = split_front_matter(agent_md.read_text())
+    fields, body = split_front_matter(agent_md.read_text(encoding="utf-8"))
     name = fields.get("name", agent_md.stem)
     # json.dumps escaping is valid for TOML basic strings.
     lines = [
@@ -60,7 +60,7 @@ def gen_agent_toml(agent_md: Path, agents_dir: Path) -> None:
         'sandbox_mode = "read-only"',
         f"developer_instructions = {json.dumps(body)}",
     ]
-    (agents_dir / f"{name}.toml").write_text("\n".join(lines) + "\n")
+    (agents_dir / f"{name}.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def main() -> None:
@@ -75,15 +75,16 @@ def main() -> None:
 
     claude_dir = Path(args.claude_dir)
     agents_dir = Path(args.out_dir) / ".codex" / "agents"
-    agents_dir.mkdir(parents=True)
+    agents_dir.mkdir(parents=True, exist_ok=True)
     for agent_md in sorted((claude_dir / "agents").glob("*.md")):
         gen_agent_toml(agent_md, agents_dir)
 
     _, prompt_body = split_front_matter(
-        (claude_dir / "commands" / "review-pr.md").read_text()
+        (claude_dir / "commands" / "review-pr.md").read_text(encoding="utf-8")
     )
     Path(args.prompt_out).write_text(
-        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{prompt_body}"
+        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{prompt_body}",
+        encoding="utf-8",
     )
 
 

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -52,13 +52,18 @@ def gen_agent_toml(agent_md: Path, agents_dir: Path) -> None:
     """
     fields, body = split_front_matter(agent_md.read_text(encoding="utf-8"))
     name = fields.get("name", agent_md.stem)
-    # json.dumps escaping is valid for TOML basic strings.
+
+    def toml_str(value: str) -> str:
+        # json.dumps escaping is valid for TOML basic strings; ensure_ascii=False
+        # keeps non-BMP chars raw instead of TOML-invalid surrogate escapes.
+        return json.dumps(value, ensure_ascii=False)
+
     lines = [
-        f"name = {json.dumps(name)}",
-        f"description = {json.dumps(fields.get('description', ''))}",
+        f"name = {toml_str(name)}",
+        f"description = {toml_str(fields.get('description', ''))}",
         # Claude agents are read-only (tools: Glob, Grep, Read).
         'sandbox_mode = "read-only"',
-        f"developer_instructions = {json.dumps(body)}",
+        f"developer_instructions = {toml_str(body)}",
     ]
     (agents_dir / f"{name}.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -71,7 +71,6 @@ def main() -> None:
     parser.add_argument("--repo", required=True, help="owner/repo of the PR")
     parser.add_argument("--pr-number", required=True, help="PR number to review")
     parser.add_argument("--prompt-out", required=True, help="review prompt file")
-    parser.add_argument("--agents-md", help="trusted agent guide, embedded if present")
     args = parser.parse_args()
 
     claude_dir = Path(args.claude_dir)
@@ -83,13 +82,8 @@ def main() -> None:
     _, prompt_body = split_front_matter(
         (claude_dir / "commands" / "review-pr.md").read_text(encoding="utf-8")
     )
-    # Codex runs with project docs disabled, so the trusted guide goes in the prompt
-    # (guarded like the claude job's restore: older base branches lack AGENTS.md).
-    guide = ""
-    if args.agents_md and Path(args.agents_md).is_file():
-        guide = Path(args.agents_md).read_text(encoding="utf-8").strip() + "\n\n"
     Path(args.prompt_out).write_text(
-        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{guide}{prompt_body}",
+        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{prompt_body}",
         encoding="utf-8",
     )
 

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -71,6 +71,7 @@ def main() -> None:
     parser.add_argument("--repo", required=True, help="owner/repo of the PR")
     parser.add_argument("--pr-number", required=True, help="PR number to review")
     parser.add_argument("--prompt-out", required=True, help="review prompt file")
+    parser.add_argument("--agents-md", help="trusted agent guide, embedded if present")
     args = parser.parse_args()
 
     claude_dir = Path(args.claude_dir)
@@ -82,8 +83,13 @@ def main() -> None:
     _, prompt_body = split_front_matter(
         (claude_dir / "commands" / "review-pr.md").read_text(encoding="utf-8")
     )
+    # Codex runs with project docs disabled, so the trusted guide goes in the prompt
+    # (guarded like the claude job's restore: older base branches lack AGENTS.md).
+    guide = ""
+    if args.agents_md and Path(args.agents_md).is_file():
+        guide = Path(args.agents_md).read_text(encoding="utf-8").strip() + "\n\n"
     Path(args.prompt_out).write_text(
-        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{prompt_body}",
+        f"REPO: {args.repo} PR_NUMBER: {args.pr_number}\n\n{guide}{prompt_body}",
         encoding="utf-8",
     )
 

--- a/scripts/ci/use_trusted_agent_files.sh
+++ b/scripts/ci/use_trusted_agent_files.sh
@@ -24,6 +24,9 @@ if [ -n "$overlay" ]; then
   cp -r "$overlay/." "$pr/"
 fi
 
+# The swap is a no-op when the PR touches no instruction files; commit only real changes
 git -C "$pr" add -A
-git -C "$pr" -c user.name=ci -c user.email=ci@localhost \
-  commit -q -m "ci: trusted review setup"
+if ! git -C "$pr" diff --cached --quiet; then
+  git -C "$pr" -c user.name=ci -c user.email=ci@localhost \
+    commit -q -m "ci: trusted review setup"
+fi

--- a/scripts/ci/use_trusted_agent_files.sh
+++ b/scripts/ci/use_trusted_agent_files.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install trusted agent files into a PR checkout for AI code review
+# (GHSA-f9x3-9rgg-92p7): strip PR-authored instruction files at every depth
+# (nested CLAUDE.md/AGENTS.md auto-load; .agents can carry skills), restore
+# trusted base-branch copies, overlay optional generated files, and commit
+# the swap so git status/diff inside the review shows only the PR.
+#
+# Usage: use_trusted_agent_files.sh TRUSTED_DIR PR_DIR [OVERLAY_DIR]
+set -euo pipefail
+
+trusted="$1"
+pr="$2"
+overlay="${3:-}"
+
+find "$pr" \( -name .claude -o -name .codex -o -name .agents \
+  -o -name CLAUDE.md -o -name CLAUDE.local.md -o -name AGENTS.md \) -prune -exec rm -rf {} +
+cp -r "$trusted/.claude" "$pr/.claude"
+for f in CLAUDE.md AGENTS.md; do
+  if [ -f "$trusted/$f" ]; then
+    cp "$trusted/$f" "$pr/$f"
+  fi
+done
+if [ -n "$overlay" ]; then
+  cp -r "$overlay/." "$pr/"
+fi
+
+git -C "$pr" add -A
+git -C "$pr" -c user.name=ci -c user.email=ci@localhost \
+  commit -q -m "ci: trusted review setup"


### PR DESCRIPTION
## Summary

Adds an OpenAI Codex PR-review path to `code_review.yml`, alongside the existing Claude flow: a collaborator adds the `codex-review` label and the same self-hosted runner runs a headless `codex exec` review, posting inline comments through the existing bun MCP server and a summary via `gh pr comment`.

**Single source of truth for review content.** No second set of review markdowns: `scripts/ci/gen_codex_review.py` converts the trusted base-branch `.claude/agents/*.md` into Codex subagent TOMLs (`.codex/agents/<name>.toml`, `sandbox_mode = "read-only"` mirroring the Claude agents' read-only tools) and turns `.claude/commands/review-pr.md` into the exec prompt at runtime. The one shared wording change makes the inline-comment instruction tool-neutral so both CLIs resolve their own MCP tool naming.

**Design notes**
- Same trusted-file pattern as the Claude job (GHSA-f9x3-9rgg-92p7): `.claude/` + converter are checked out from `base.sha`; the PR's `.claude/`, `.codex/`, and `AGENTS.md` are dropped, and trusted `CLAUDE.md` is installed as `AGENTS.md` (Codex auto-reads it — supplies project context and blocks a PR-authored injection file).
- Sandbox is `workspace-write` with `sandbox_workspace_write.network_access=true` (gh needs network), never `danger-full-access`, so runner home / stored credentials stay unreadable to the model.
- MCP server config is passed per-run via `-c` overrides; `env_vars` forwards `GITHUB_TOKEN`/`REPO_OWNER`/`REPO_NAME`/`PR_NUMBER` to the server by name only — no secret values in argv or on-disk config.
- Auth is stored ChatGPT OAuth from a one-time `codex login --device-auth` on the runner (mirrors `claude /login`); no `OPENAI_API_KEY` secret.
- Concurrency groups now include the label name, so codex and claude reviews of the same PR no longer cancel each other (previously any label event shared one group).

## Known limitations / follow-ups
- `pull_request_target` runs the base-branch workflow definition, so this job can only be exercised after merge: do the one-time runner setup in the yml header (install Codex CLI, `codex login --device-auth`), then add the `codex-review` label to a test PR. Requires a recent Codex CLI (subagents + `mcp_servers.*.env_vars`).
- The `codex-review` label must exist in the repo before first use.

## Verification
- Converter run against the repo's real `.claude/`: 5 agent TOMLs generated, all parse with `tomllib`, prompt assembles with REPO/PR header.
- Workflow YAML parses; both jobs and label-scoped concurrency verified.
- `pre-commit` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lbq87BJ7AiDFqs7srcP6v