### PR TITLE
[doc] add canonical AGENTS.md agent guide and trusted-restore it in code review CI

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -72,9 +72,7 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label claude-review
 
-      # Checkout trusted agent files from base branch (not the PR author's code).
-      # Cone-mode sparse checkout of .claude also includes root-level files
-      # such as CLAUDE.md and AGENTS.md.
+      # Checkout trusted agent files from base branch; cone mode also includes root-level files
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
@@ -91,14 +89,12 @@ jobs:
           path: pr-code
 
       # rm first: cp -r into an existing dir nests instead of replacing (GHSA-f9x3-9rgg-92p7).
+      # Strip at every depth: nested CLAUDE.md files are auto-loaded too.
       - name: Use trusted agent files
         run: |
-          rm -rf pr-code/.claude
+          find pr-code \( -name .claude -o -name CLAUDE.md -o -name CLAUDE.local.md -o -name AGENTS.md \) -prune -exec rm -rf {} +
           cp -r trusted-claude/.claude pr-code/.claude
-          # Drop the PR's root instruction files; restore from base when present
-          # (tolerates base branches that don't have them yet).
           for f in CLAUDE.md AGENTS.md; do
-            rm -f "pr-code/$f"
             if [ -f "trusted-claude/$f" ]; then
               cp "trusted-claude/$f" "pr-code/$f"
             fi

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -72,7 +72,9 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label claude-review
 
-      # Checkout trusted .claude/ files from base branch (not the PR author's code)
+      # Checkout trusted agent files from base branch (not the PR author's code).
+      # Cone-mode sparse checkout of .claude also includes root-level files
+      # such as CLAUDE.md and AGENTS.md.
       - name: Checkout trusted agent files
         uses: actions/checkout@v4
         with:
@@ -93,6 +95,14 @@ jobs:
         run: |
           rm -rf pr-code/.claude
           cp -r trusted-claude/.claude pr-code/.claude
+          # Drop the PR's root instruction files; restore from base when present
+          # (tolerates base branches that don't have them yet).
+          for f in CLAUDE.md AGENTS.md; do
+            rm -f "pr-code/$f"
+            if [ -f "trusted-claude/$f" ]; then
+              cp "trusted-claude/$f" "pr-code/$f"
+            fi
+          done
 
       - name: RunCodeReview
         working-directory: pr-code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# TorchEasyRec Agent Guide
+
+Canonical instructions for AI coding agents in this repository. `CLAUDE.md` imports this file; keep shared agent guidance here.
+
+## Protobuf
+
+- After editing any `.proto` under `tzrec/protos/`, regenerate bindings with `bash scripts/gen_proto.sh`. `_pb2.py` / `_pb2.pyi` files are generated (gitignored); never edit them.
+
+## Environment
+
+- If a tool you need (python, pip, pre-commit, protoc) is missing, look for a project conda env or venv and activate it; otherwise stop and ask. Do NOT install substitutes or new toolchains on your own.
+- There is no editable install: run from the repo root with `PYTHONPATH=.`.
+- One-time dev setup: `pip install -r requirements.txt`, then `pre-commit install`.
+
+## Scratch Space
+
+Use the gitignored `experiments/` directory at the repo root for scratch scripts, throwaway configs, and experiment outputs; tests write temp data under `tmp/`. Never commit files from either.
+
+## Testing
+
+- Framework: `unittest`; tests live next to the code as `<module>_test.py`.
+- Full suite: `python tzrec/tests/run.py` (`--list_tests`, `--scope gpu|h20`). Single test: `python -m tzrec.modules.fm_test FactorizationMachineTest.test_fm_0`.
+- Parameterize case tables with `@parameterized.expand(..., name_func=parameterized_name_func)` from `tzrec/utils/test_util.py`; create scratch dirs with its `make_test_dir()`.
+- Declare CI lanes with `@mark_ci_scope("gpu")` / `@mark_ci_scope("h20", "gpu")` at class or method level only; module-level tagging is unsupported.
+
+## Linting and Type Checking
+
+- Before committing: run `pre-commit run -a` (ruff lint+format at line 88, license header insertion, codespell, mdformat, LF endings) and fix everything it reports; type-check with `python scripts/pyre_check.py` (Pyre strict; proto-generated files and tests are excluded).
+- Never `# noqa` a line-length violation; let ruff-format decide layout and do not fight it.
+
+## Commits and Pull Requests
+
+- Commit subject: `[tag] short imperative subject`, tag one of `feat`, `bugfix`, `refactor`, `ci`, `doc`, `chore`, `perf`. The `(#123)` suffix is added by squash merge; do not add it yourself.
+- Keep commit bodies minimal: no bullet lists of changes. A `[bugfix]` commit message must explain the root cause of the bug and how the fix works.
+- The PR body should be clear and informative, with a Test Plan section that describes how you tested the change. If there were multiple potential paths you could have taken, call them out succinctly and justify the one you took.
+- Never include customer names or internal resource IDs in branch names, commit messages, or PR bodies.
+- Unless specified otherwise, push the branch to a fork and open the PR against the main repository.
+
+## Coding Style
+
+Docstrings and inline comments follow different rules; do not confuse them:
+
+- **Docstrings are mandatory** (ruff-enforced): Google style on public and private classes, functions, and methods; `*_test.py` and `tzrec/ops/` are exempt, as are modules, packages, `__init__`, and dunders. Never strip or skimp docstrings to "minimize comments".
+- **Inline `#` comments are minimized**: code should be self-explanatory; comment only non-obvious "why" context, one short line. No commented-out code, no change-history or tombstone comments. Use `# TODO(username): ...` and `# NOTE: ...`; do not introduce FIXME/XXX/HACK. Denser math commentary is fine in `tzrec/ops/` kernels.
+- Code, comments, and docstrings are English-only (Chinese belongs in `docs/`); prefer plain ASCII in new comments outside `tzrec/ops/`.
+- Naming: `fg` means feature generator (`fg_mode`, `fg_handler`, `pyfg`), never feature group.
+- Don't create trivial 1-2 line single-use helpers unless they significantly improve readability.
+- Use the repo logger (`from tzrec.utils.logging_util import logger`), not `print()`, in library code; `print()` is acceptable only in CLI tools and benchmarks.
+- Assume the reader knows PyTorch and TorchRec. Match existing patterns; if uncertain, choose the simpler, more concise implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Adds a canonical `AGENTS.md` agent guide at the repo root and reduces `CLAUDE.md` to a one-line `@AGENTS.md` import, so all coding agents (Claude Code and tools that read the cross-tool AGENTS.md standard) share a single source of instructions.

The guide codifies this repo's enforced conventions: environment/scratch-space rules, testing (`parameterized.expand`, `@mark_ci_scope` at class/method level), lint/type-check workflow, commit/PR conventions, and a coding-style section that distinguishes docstrings from inline comments — Google-style docstrings are ruff-enforced and mandatory (never "minimized"), while inline `#` comments stay short and why-only, with no commented-out code or change-history comments.

Since a committed `CLAUDE.md`/`AGENTS.md` would be auto-loaded by the headless reviewer in `code_review.yml`, the trusted-restore step now also restores these two root files from the base branch (previously only `.claude/`). PR edits to agent-instruction files therefore take effect only after merging.

Alternatives considered: an `AGENTS.md -> CLAUDE.md` symlink (rejected: awkward on Windows checkouts and inverts the cross-tool standard) and maintaining full content in both files (rejected: drift). The one-line `@AGENTS.md` import is the documented Claude Code bridge and keeps a single source of truth.

Note: the workflow change is inert until merged (`pull_request_target` executes the base branch's workflow), and this PR's own claude-review intentionally runs without the new files since the base branch does not have them yet — the restore loop tolerates that.

## Test Plan

- `pre-commit run -a` passes with no modifications (ruff/codespell/check-yaml clean; the markdown is mdformat-stable across repeated runs).
- Verified the `@AGENTS.md` import resolves: headless `claude -p` in this branch answers commit-tag conventions from AGENTS.md content.
- Simulated the trusted-restore loop for both base-branch states: base has the files -> PR copies replaced with base copies; base lacks them -> PR copies removed.
- Post-merge check: label a follow-up PR `claude-review` and confirm the "Use trusted agent files" step restores `CLAUDE.md`/`AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kea7UR6xJw8yMPQ55FX62f