### PR TITLE
[ci] run H20 unit tests via manual dispatch only

### DIFF
--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -1,8 +1,6 @@
 name: Unit Test H20 CI
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from the H20 unit-test workflow; it now runs only via `workflow_dispatch`. The single H20 runner is a scarce resource, and per-PR H20 runs are no longer needed now that the A10 GPU lane covers PRs — H20-scoped tests can be dispatched on demand for branches that touch Hopper-specific paths.

The remaining `github.event.pull_request.*` expressions in the job were already empty on manual runs and keep their existing dispatch behavior: checkout falls back to the dispatched ref, and the constant concurrency group serializes manual runs on the runner.

## Test Plan

- `check-yaml` (pre-commit) passes on the workflow file.
- Existing `workflow_dispatch` path is unchanged — manual runs already execute with an empty PR context today.
- Post-merge: confirm the next PR does not schedule "Unit Test H20 CI", and a manual dispatch from master still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kea7UR6xJw8yMPQ55FX62f