### PR TITLE
[ci] re-enable H20 unit tests on pull requests

### DIFF
--- a/.github/workflows/unittest_h20_ci.yml
+++ b/.github/workflows/unittest_h20_ci.yml
@@ -1,6 +1,8 @@
 name: Unit Test H20 CI
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Re-enable the H20 unit test lane on pull requests. #595 had switched the H20 workflow to `workflow_dispatch`-only (manual) by dropping its `pull_request` trigger; this restores that trigger so the lane runs automatically on every PR again, while keeping the manual `workflow_dispatch` entry.

This is an exact revert of #595 — the workflow blob is restored to its pre-#595 content.

## Test Plan

- `python -c "import yaml; yaml.safe_load(...)"` confirms the workflow parses.
- Opening this PR against the main repo exercises the change directly: the "Unit Test H20 CI" lane should now trigger on the self-hosted `tzrec-h20-runner`. (The branch lives on the main repo rather than a fork because GitHub does not schedule self-hosted runners for fork `pull_request` events; a same-repo PR is required for the H20 lane to actually run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ac3J8EdpdrTfTtrSwewAx4