### PR TITLE
[feat] model_config.summaries_set：训练期 PCOC 与 scalars TensorBoard 摘要

### DIFF
--- a/docs/source/models/evaluation_metrics.md
+++ b/docs/source/models/evaluation_metrics.md
@@ -60,6 +60,45 @@ model_config {
   - decay_rate: 默认为0.9，历史指标的衰减率。
   - decay_step: 默认为100，历史指标每训练多少step会进行一次衰减，配置需要可以被train_config.log_step_count_steps整除。
 
+### 训练期 TensorBoard 摘要（summaries_set）
+
+在 `model_config` 中配置 `summaries_set`，可在训练过程中向 TensorBoard 写入 **PCOC** 与 **特征切片 scalars**（与 `train_metrics` 不同，后者用于在线 AUC 等指标）。摘要按 `train_config.log_step_count_steps` 间隔累积并在日志步写入。
+
+```
+model_config {
+    # PCOC -> summary/pcoc, summary/predicted_ctr, summary/observed_ctr
+    summaries_set {
+        pcoc {
+            pred_name: "probs"      # prediction_dict 中的 key；logits 会先 sigmoid
+            label_name: "clk"       # 可选，默认取 data_config 第一个 label
+            epsilon: 1e-7           # observed ctr 接近 0 时的除数稳定项
+        }
+    }
+    # 特征切片 -> summary/<name>
+    summaries_set {
+        scalars {
+            name: "id_1_bucket_pred"
+            pred_name: "probs"
+            feature_name: "id_1"
+            feature_value: "1005"
+        }
+    }
+}
+```
+
+- **pcoc**
+  - `pred_name`: 预测张量名，默认 `probs`
+  - `label_name`: 标签字段名；多任务时需显式指定
+  - `epsilon`: 默认 `1e-7`
+- **scalars**
+  - `name`: TensorBoard tag 后缀，写入 `summary/<name>`
+  - `pred_name`: 默认 `probs`
+  - `feature_name` / `feature_value`: 可选；同时配置时仅统计该特征取值的样本；省略则统计全 batch 均值
+
+> 分布式训练时，各 rank 在本地累积摘要，仅 **rank 0** 写入 TensorBoard，数值反映 rank 0 所见分片数据的统计，而非全局 all-reduce 结果（与当前 `train_metrics` 行为一致）。
+
+需开启 `train_config.use_tensorboard: true`（默认开启）。
+
 ______________________________________________________________________
 
 ## 指标详情

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -240,6 +240,7 @@ def _log_train(
     plogger: Optional[ProgressLogger] = None,
     summary_writer: Optional[SummaryWriter] = None,
     train_metrics: Optional[Dict[str, torch.Tensor]] = None,
+    train_summaries: Optional[Dict[str, torch.Tensor]] = None,
 ) -> None:
     """Logging current training step."""
     if plogger is not None:
@@ -317,6 +318,9 @@ def _log_train(
         if train_metrics:
             for k, v in train_metrics.items():
                 summary_writer.add_scalar(f"metric/{k}", v, step)
+        if train_summaries:
+            for k, v in train_summaries.items():
+                summary_writer.add_scalar(k, v, step)
 
 
 def _train_and_evaluate(
@@ -491,8 +495,10 @@ def _train_and_evaluate(
                     dataloader_state, batch.checkpoint_info
                 )
                 _model.update_train_metric(predictions, batch)
+                _model.update_train_summary(predictions, batch)
                 if i_step % train_config.log_step_count_steps == 0:
                     train_metrics = _model.compute_train_metric()
+                    train_summaries = _model.compute_train_summary()
                     _log_train(
                         i_step,
                         losses,
@@ -502,6 +508,7 @@ def _train_and_evaluate(
                         plogger=plogger,
                         summary_writer=summary_writer,
                         train_metrics=train_metrics,
+                        train_summaries=train_summaries,
                     )
 
                 for lr in lr_scheduler:

--- a/tzrec/metrics/train_summary.py
+++ b/tzrec/metrics/train_summary.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2024, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch import nn
+
+from tzrec.protos.summary_pb2 import ModelSummaries
+
+BASE_DATA_GROUP = "__BASE__"
+
+
+def resolve_pred_tensor(
+    predictions: Dict[str, torch.Tensor], pred_name: str
+) -> torch.Tensor:
+    if pred_name not in predictions:
+        raise ValueError(
+            f'summaries pred_name "{pred_name}" not found in prediction_dict keys: '
+            f"{sorted(predictions.keys())}"
+        )
+    pred = predictions[pred_name].float()
+    if pred_name == "logits" or pred_name.startswith("logits"):
+        pred = torch.sigmoid(pred)
+    if pred.dim() > 1:
+        if pred.dim() == 2 and pred.size(-1) == 2:
+            pred = pred[:, 1]
+        else:
+            pred = pred.reshape(-1)
+    return pred.reshape(-1)
+
+
+def _feature_values(batch: Any, feature_name: str) -> torch.Tensor:
+    if BASE_DATA_GROUP in batch.sparse_features:
+        sparse = batch.sparse_features[BASE_DATA_GROUP].to_dict()
+        if feature_name in sparse:
+            return sparse[feature_name].to_padded_dense(1)[:, 0]
+    if BASE_DATA_GROUP in batch.dense_features:
+        dense = batch.dense_features[BASE_DATA_GROUP].to_dict()
+        if feature_name in dense:
+            return dense[feature_name].values().reshape(-1)
+    raise ValueError(
+        f'summaries feature_name "{feature_name}" not found in batch features'
+    )
+
+
+def build_feature_mask(
+    batch: Any, feature_name: str, feature_value: str
+) -> torch.Tensor:
+    feat = _feature_values(batch, feature_name)
+    try:
+        target = float(feature_value)
+        if feat.is_floating_point() or feat.dtype in (torch.int32, torch.int64):
+            return feat.float() == target
+    except (TypeError, ValueError):
+        pass
+    # string / id features: compare as int when possible
+    try:
+        return feat.long() == int(float(feature_value))
+    except (TypeError, ValueError):
+        return feat == feat.new_tensor(feature_value)
+
+
+class _RunningMeanState(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("_sum", torch.zeros(1), persistent=False)
+        self.register_buffer("_count", torch.zeros(1), persistent=False)
+
+    def update(self, values: torch.Tensor, mask: Optional[torch.Tensor] = None) -> None:
+        values = values.reshape(-1).float()
+        if mask is not None:
+            values = values[mask.reshape(-1)]
+        if values.numel() == 0:
+            return
+        self._sum += values.sum()
+        self._count += values.numel()
+
+    def compute_mean(self) -> Optional[torch.Tensor]:
+        if self._count.item() == 0:
+            return None
+        return self._sum / self._count
+
+    def reset(self) -> None:
+        self._sum.zero_()
+        self._count.zero_()
+
+
+class TrainSummaryModule(nn.Module):
+    """Accumulate training summaries between log steps."""
+
+    def __init__(self, summary_cfg: ModelSummaries) -> None:
+        super().__init__()
+        self._summary_cfg = summary_cfg
+        self._state = _RunningMeanState()
+        self._label_state = _RunningMeanState()
+
+    def update(
+        self,
+        predictions: Dict[str, torch.Tensor],
+        batch: Any,
+        label_name: str,
+    ) -> None:
+        summary_type = self._summary_cfg.WhichOneof("summary")
+        if summary_type == "pcoc":
+            cfg = self._summary_cfg.pcoc
+            pred_name = cfg.pred_name or "probs"
+            preds = resolve_pred_tensor(predictions, pred_name)
+            label = batch.labels[label_name].float().reshape(-1)
+            self._state.update(preds)
+            self._label_state.update(label)
+        elif summary_type == "scalars":
+            cfg = self._summary_cfg.scalars
+            pred_name = cfg.pred_name or "probs"
+            preds = resolve_pred_tensor(predictions, pred_name)
+            if cfg.HasField("feature_name") and cfg.HasField("feature_value"):
+                mask = build_feature_mask(batch, cfg.feature_name, cfg.feature_value)
+                self._state.update(preds, mask)
+            else:
+                self._state.update(preds)
+        else:
+            raise ValueError(f"unsupported summary type: {summary_type}")
+
+    def compute(self) -> Dict[str, torch.Tensor]:
+        summary_type = self._summary_cfg.WhichOneof("summary")
+        result: Dict[str, torch.Tensor] = {}
+        if summary_type == "pcoc":
+            mean_pred = self._state.compute_mean()
+            mean_label = self._label_state.compute_mean()
+            if mean_pred is None or mean_label is None:
+                return result
+            epsilon = self._summary_cfg.pcoc.epsilon
+            result["summary/predicted_ctr"] = mean_pred
+            result["summary/observed_ctr"] = mean_label
+            result["summary/pcoc"] = mean_pred / (mean_label + epsilon)
+        elif summary_type == "scalars":
+            mean_pred = self._state.compute_mean()
+            if mean_pred is not None:
+                name = self._summary_cfg.scalars.name
+                result[f"summary/{name}"] = mean_pred
+        self.reset()
+        return result
+
+    def reset(self) -> None:
+        self._state.reset()
+        self._label_state.reset()
+
+
+def build_train_summary_modules(
+    summaries_set: List[ModelSummaries],
+) -> nn.ModuleList:
+    return nn.ModuleList([TrainSummaryModule(cfg) for cfg in summaries_set])

--- a/tzrec/metrics/train_summary.py
+++ b/tzrec/metrics/train_summary.py
@@ -103,6 +103,11 @@ class TrainSummaryModule(nn.Module):
         self._state = _RunningMeanState()
         self._label_state = _RunningMeanState()
 
+    @property
+    def summary_cfg(self) -> ModelSummaries:
+        """Configured summary proto for this module."""
+        return self._summary_cfg
+
     def update(
         self,
         predictions: Dict[str, torch.Tensor],

--- a/tzrec/metrics/train_summary_test.py
+++ b/tzrec/metrics/train_summary_test.py
@@ -11,11 +11,14 @@
 
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
 
 import torch
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+from torch.utils.tensorboard import SummaryWriter
 
 _ROOT = Path(__file__).resolve().parents[2]
 
@@ -50,7 +53,23 @@ train_summary = _load_module(
 BASE_DATA_GROUP = train_summary.BASE_DATA_GROUP
 TrainSummaryModule = train_summary.TrainSummaryModule
 build_feature_mask = train_summary.build_feature_mask
+build_train_summary_modules = train_summary.build_train_summary_modules
 resolve_pred_tensor = train_summary.resolve_pred_tensor
+
+
+def _mock_config_summaries():
+    """summaries_set from multi_tower_din_mock.config."""
+    pcoc_cfg = summary_pb2.ModelSummaries()
+    pcoc_cfg.pcoc.pred_name = "probs"
+    pcoc_cfg.pcoc.label_name = "clk"
+    pcoc_cfg.pcoc.epsilon = 1e-7
+
+    scalars_cfg = summary_pb2.ModelSummaries()
+    scalars_cfg.scalars.name = "id_1_bucket_pred"
+    scalars_cfg.scalars.pred_name = "probs"
+    scalars_cfg.scalars.feature_name = "id_1"
+    scalars_cfg.scalars.feature_value = "1005"
+    return [pcoc_cfg, scalars_cfg]
 
 
 class _FakeDense:
@@ -159,6 +178,82 @@ class TrainSummaryTest(unittest.TestCase):
         self.assertAlmostEqual(values["summary/predicted_ctr"].item(), 0.5, places=4)
         self.assertAlmostEqual(values["summary/observed_ctr"].item(), 0.25, places=4)
         self.assertAlmostEqual(values["summary/pcoc"].item(), 2.0, places=4)
+
+    def test_mini_train_tensorboard_integration(self) -> None:
+        """Mini-batch train loop: config -> accumulate -> TensorBoard write."""
+        modules = build_train_summary_modules(_mock_config_summaries())
+        mini_batches = [
+            (
+                {"probs": torch.tensor([0.6, 0.4])},
+                _make_batch(
+                    {"clk": torch.tensor([1, 0], dtype=torch.float32)},
+                    sparse={"id_1": _FakeSparse(torch.tensor([[1005], [1002]]))},
+                ),
+            ),
+            (
+                {"probs": torch.tensor([0.8, 0.2])},
+                _make_batch(
+                    {"clk": torch.tensor([1, 1], dtype=torch.float32)},
+                    sparse={"id_1": _FakeSparse(torch.tensor([[1005], [1005]]))},
+                ),
+            ),
+            (
+                {"probs": torch.tensor([0.5])},
+                _make_batch(
+                    {"clk": torch.tensor([0], dtype=torch.float32)},
+                    sparse={"id_1": _FakeSparse(torch.tensor([[1002]]))},
+                ),
+            ),
+        ]
+        for predictions, batch in mini_batches:
+            for module in modules:
+                label_name = (
+                    module.summary_cfg.pcoc.label_name
+                    if module.summary_cfg.WhichOneof("summary") == "pcoc"
+                    else "clk"
+                )
+                module.update(predictions, batch, label_name)
+
+        summaries: dict = {}
+        for module in modules:
+            summaries.update(module.compute())
+
+        self.assertAlmostEqual(
+            summaries["summary/predicted_ctr"].item(), 0.5, places=4
+        )
+        self.assertAlmostEqual(
+            summaries["summary/observed_ctr"].item(), 0.6, places=4
+        )
+        self.assertAlmostEqual(summaries["summary/pcoc"].item(), 0.8333, places=3)
+        self.assertAlmostEqual(
+            summaries["summary/id_1_bucket_pred"].item(), 0.5333, places=3
+        )
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            writer = SummaryWriter(log_dir)
+            step = 10
+            for tag, value in summaries.items():
+                writer.add_scalar(tag, value, step)
+            writer.close()
+
+            event_acc = EventAccumulator(log_dir)
+            event_acc.Reload()
+            written_tags = set(event_acc.Tags().get("scalars", []))
+            self.assertTrue(
+                {
+                    "summary/pcoc",
+                    "summary/predicted_ctr",
+                    "summary/observed_ctr",
+                    "summary/id_1_bucket_pred",
+                }.issubset(written_tags)
+            )
+            for tag in written_tags:
+                if tag.startswith("summary/"):
+                    self.assertAlmostEqual(
+                        event_acc.Scalars(tag)[0].value,
+                        summaries[tag].item(),
+                        places=4,
+                    )
 
 
 if __name__ == "__main__":

--- a/tzrec/metrics/train_summary_test.py
+++ b/tzrec/metrics/train_summary_test.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2024, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import torch
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _stub_pkg(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_module(name: str, rel_path: str) -> types.ModuleType:
+    path = _ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_stub_pkg("tzrec")
+_stub_pkg("tzrec.protos")
+_stub_pkg("tzrec.metrics")
+summary_pb2 = _load_module(
+    "tzrec.protos.summary_pb2", "tzrec/protos/summary_pb2.py"
+)
+train_summary = _load_module(
+    "tzrec.metrics.train_summary", "tzrec/metrics/train_summary.py"
+)
+
+BASE_DATA_GROUP = train_summary.BASE_DATA_GROUP
+TrainSummaryModule = train_summary.TrainSummaryModule
+build_feature_mask = train_summary.build_feature_mask
+resolve_pred_tensor = train_summary.resolve_pred_tensor
+
+
+class _FakeDense:
+    def values(self) -> torch.Tensor:
+        return self._values
+
+    def __init__(self, values: torch.Tensor) -> None:
+        self._values = values
+
+
+class _FakeKeyedTensor:
+    def __init__(self, tensors: dict) -> None:
+        self._tensors = tensors
+
+    def to_dict(self) -> dict:
+        return self._tensors
+
+
+def _make_batch(labels, dense=None):
+    batch = types.SimpleNamespace()
+    batch.labels = labels
+    batch.dense_features = {}
+    batch.sparse_features = {}
+    if dense is not None:
+        batch.dense_features[BASE_DATA_GROUP] = _FakeKeyedTensor(dense)
+    return batch
+
+
+class TrainSummaryTest(unittest.TestCase):
+    def test_resolve_pred_logits(self) -> None:
+        preds = {"logits": torch.tensor([0.0, 10.0])}
+        out = resolve_pred_tensor(preds, "logits")
+        self.assertAlmostEqual(out[0].item(), 0.5, places=4)
+        self.assertGreater(out[1].item(), 0.99)
+
+    def test_pcoc_summary(self) -> None:
+        cfg = summary_pb2.ModelSummaries()
+        cfg.pcoc.epsilon = 1e-7
+        module = TrainSummaryModule(cfg)
+        predictions = {"probs": torch.tensor([0.8, 0.4, 0.6, 0.2])}
+        batch = _make_batch({"label": torch.tensor([1, 0, 1, 0], dtype=torch.float32)})
+        module.update(predictions, batch, "label")
+        values = module.compute()
+        self.assertAlmostEqual(values["summary/pcoc"].item(), 1.0, places=4)
+
+    def test_scalars_numeric_feature_slice(self) -> None:
+        cfg = summary_pb2.ModelSummaries()
+        cfg.scalars.name = "raw_1_val"
+        cfg.scalars.feature_name = "raw_1"
+        cfg.scalars.feature_value = "1005"
+        module = TrainSummaryModule(cfg)
+        predictions = {"probs": torch.tensor([0.9, 0.1])}
+        batch = _make_batch(
+            {"label": torch.tensor([1, 0], dtype=torch.float32)},
+            dense={"raw_1": _FakeDense(torch.tensor([[1005.0], [1002.0]]))},
+        )
+        mask = build_feature_mask(batch, "raw_1", "1005")
+        self.assertTrue(mask[0].item())
+        self.assertFalse(mask[1].item())
+        module.update(predictions, batch, "label")
+        values = module.compute()
+        self.assertAlmostEqual(values["summary/raw_1_val"].item(), 0.9, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/metrics/train_summary_test.py
+++ b/tzrec/metrics/train_summary_test.py
@@ -61,6 +61,14 @@ class _FakeDense:
         self._values = values
 
 
+class _FakeSparse:
+    def __init__(self, padded: torch.Tensor) -> None:
+        self._padded = padded
+
+    def to_padded_dense(self, max_len: int) -> torch.Tensor:
+        return self._padded
+
+
 class _FakeKeyedTensor:
     def __init__(self, tensors: dict) -> None:
         self._tensors = tensors
@@ -69,13 +77,15 @@ class _FakeKeyedTensor:
         return self._tensors
 
 
-def _make_batch(labels, dense=None):
+def _make_batch(labels, dense=None, sparse=None):
     batch = types.SimpleNamespace()
     batch.labels = labels
     batch.dense_features = {}
     batch.sparse_features = {}
     if dense is not None:
         batch.dense_features[BASE_DATA_GROUP] = _FakeKeyedTensor(dense)
+    if sparse is not None:
+        batch.sparse_features[BASE_DATA_GROUP] = _FakeKeyedTensor(sparse)
     return batch
 
 
@@ -113,6 +123,42 @@ class TrainSummaryTest(unittest.TestCase):
         module.update(predictions, batch, "label")
         values = module.compute()
         self.assertAlmostEqual(values["summary/raw_1_val"].item(), 0.9, places=4)
+
+    def test_scalars_sparse_feature_slice(self) -> None:
+        """Sparse id feature slice, aligned with multi_tower_din_mock.config."""
+        cfg = summary_pb2.ModelSummaries()
+        cfg.scalars.name = "id_1_bucket_pred"
+        cfg.scalars.feature_name = "id_1"
+        cfg.scalars.feature_value = "1005"
+        module = TrainSummaryModule(cfg)
+        predictions = {"probs": torch.tensor([0.7, 0.3, 0.5])}
+        batch = _make_batch(
+            {"clk": torch.tensor([1, 0, 1], dtype=torch.float32)},
+            sparse={"id_1": _FakeSparse(torch.tensor([[1005], [1002], [1005]]))},
+        )
+        mask = build_feature_mask(batch, "id_1", "1005")
+        self.assertEqual(mask.tolist(), [True, False, True])
+        module.update(predictions, batch, "clk")
+        values = module.compute()
+        self.assertAlmostEqual(values["summary/id_1_bucket_pred"].item(), 0.6, places=4)
+
+    def test_multi_batch_running_mean(self) -> None:
+        """Accumulate summaries across batches between log steps."""
+        cfg = summary_pb2.ModelSummaries()
+        cfg.pcoc.epsilon = 1e-7
+        module = TrainSummaryModule(cfg)
+        batch1 = _make_batch(
+            {"label": torch.tensor([1, 0], dtype=torch.float32)},
+        )
+        batch2 = _make_batch(
+            {"label": torch.tensor([0, 0], dtype=torch.float32)},
+        )
+        module.update({"probs": torch.tensor([0.8, 0.2])}, batch1, "label")
+        module.update({"probs": torch.tensor([0.4, 0.6])}, batch2, "label")
+        values = module.compute()
+        self.assertAlmostEqual(values["summary/predicted_ctr"].item(), 0.5, places=4)
+        self.assertAlmostEqual(values["summary/observed_ctr"].item(), 0.25, places=4)
+        self.assertAlmostEqual(values["summary/pcoc"].item(), 2.0, places=4)
 
 
 if __name__ == "__main__":

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -99,7 +99,7 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
         if len(self._train_summary_modules) == 0:
             return
         for summary_module in self._train_summary_modules:
-            cfg = summary_module._summary_cfg
+            cfg = summary_module.summary_cfg
             summary_type = cfg.WhichOneof("summary")
             if summary_type == "pcoc":
                 label_name = self._get_summary_label_name(

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -29,6 +29,7 @@ from tzrec.datasets.data_parser import DataParser
 from tzrec.datasets.utils import Batch
 from tzrec.features.feature import BaseFeature
 from tzrec.loss.pe_mtl_loss import ParetoEfficientMultiTaskLoss
+from tzrec.metrics.train_summary import build_train_summary_modules
 from tzrec.modules.utils import BaseModule
 from tzrec.protos.loss_pb2 import LossConfig
 from tzrec.protos.model_pb2 import FeatureGroupConfig, ModelConfig
@@ -72,6 +73,49 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
             self._sample_weights = sample_weights
 
         self._train_metric_modules = nn.ModuleDict()
+        self._train_summary_modules = nn.ModuleList()
+
+    def init_train_summary(self) -> None:
+        """Initialize training TensorBoard summaries from model_config.summaries_set."""
+        if len(self._base_model_config.summaries_set) > 0:
+            self._train_summary_modules = build_train_summary_modules(
+                list(self._base_model_config.summaries_set)
+            )
+
+    def _get_summary_label_name(self, label_name: Optional[str] = None) -> str:
+        if label_name:
+            return label_name
+        if hasattr(self, "_label_name") and self._label_name:
+            return self._label_name
+        if len(self._labels) > 0:
+            return self._labels[0]
+        raise ValueError(
+            "summaries pcoc requires labels; set pcoc.label_name in summaries_set"
+        )
+
+    def update_train_summary(
+        self, predictions: Dict[str, torch.Tensor], batch: Batch
+    ) -> None:
+        if len(self._train_summary_modules) == 0:
+            return
+        for summary_module in self._train_summary_modules:
+            cfg = summary_module._summary_cfg
+            summary_type = cfg.WhichOneof("summary")
+            if summary_type == "pcoc":
+                label_name = self._get_summary_label_name(
+                    cfg.pcoc.label_name
+                    if cfg.pcoc.HasField("label_name")
+                    else None
+                )
+            else:
+                label_name = self._get_summary_label_name()
+            summary_module.update(predictions, batch, label_name)
+
+    def compute_train_summary(self) -> Dict[str, torch.Tensor]:
+        results: Dict[str, torch.Tensor] = {}
+        for summary_module in self._train_summary_modules:
+            results.update(summary_module.compute())
+        return results
 
     @property
     def features(self) -> List[BaseFeature]:
@@ -254,6 +298,7 @@ class TrainWrapper(BaseModule):
         self.model = module
         self.model.init_loss()
         self.model.init_metric()
+        self.model.init_train_summary()
         self._device = device
         self._device_type = "cpu"
         if device is not None:

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -99,8 +99,10 @@ message ModelConfig {
     // whether use pareto loss weight
     optional bool use_pareto_loss_weight = 13 [default = false];
 
-    // Training TensorBoard summaries (PCOC / scalars), e.g.:
-    //   summaries_set { pcoc {} }
+    // Training TensorBoard summaries (model_config.summaries_set), e.g.:
+    //   summaries_set { pcoc { pred_name: "probs" label_name: "clk" epsilon: 1e-7 } }
+    //   summaries_set { scalars { name: "id_1_bucket_pred" pred_name: "probs"
+    //       feature_name: "id_1" feature_value: "1005" } }
     repeated ModelSummaries summaries_set = 14;
 
 }

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -10,6 +10,7 @@ import "tzrec/protos/loss.proto";
 import "tzrec/protos/metric.proto";
 import "tzrec/protos/seq_encoder.proto";
 import "tzrec/protos/module.proto";
+import "tzrec/protos/summary.proto";
 
 enum FeatureGroupType {
     DEEP = 0;
@@ -97,5 +98,9 @@ message ModelConfig {
 
     // whether use pareto loss weight
     optional bool use_pareto_loss_weight = 13 [default = false];
+
+    // Training TensorBoard summaries (PCOC / scalars), e.g.:
+    //   summaries_set { pcoc {} }
+    repeated ModelSummaries summaries_set = 14;
 
 }

--- a/tzrec/protos/summary.proto
+++ b/tzrec/protos/summary.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+package tzrec.protos;
+
+message PCOC {
+  optional float epsilon = 1 [default = 1e-7];
+  optional string pred_name = 2 [default = "probs"];
+  optional string label_name = 3;
+}
+
+message Scalars {
+  required string name = 1;
+  optional string pred_name = 2 [default = "probs"];
+  optional string feature_name = 3;
+  optional string feature_value = 4;
+}
+
+message ModelSummaries {
+  oneof summary {
+    PCOC pcoc = 1;
+    Scalars scalars = 2;
+  }
+}

--- a/tzrec/tests/configs/multi_tower_din_mock.config
+++ b/tzrec/tests/configs/multi_tower_din_mock.config
@@ -168,6 +168,9 @@ model_config {
         auc {}
         decay_step: 1
     }
+    summaries_set {
+        pcoc {}
+    }
     losses {
         binary_cross_entropy {}
     }

--- a/tzrec/tests/configs/multi_tower_din_mock.config
+++ b/tzrec/tests/configs/multi_tower_din_mock.config
@@ -168,8 +168,23 @@ model_config {
         auc {}
         decay_step: 1
     }
+    # Training TensorBoard summaries (model_config.summaries_set)
+    # PCOC -> summary/pcoc, summary/predicted_ctr, summary/observed_ctr
     summaries_set {
-        pcoc {}
+        pcoc {
+            pred_name: "probs"
+            label_name: "clk"
+            epsilon: 1e-7
+        }
+    }
+    # Feature-sliced scalar -> summary/id_1_bucket_pred
+    summaries_set {
+        scalars {
+            name: "id_1_bucket_pred"
+            pred_name: "probs"
+            feature_name: "id_1"
+            feature_value: "1005"
+        }
     }
     losses {
         binary_cross_entropy {}


### PR DESCRIPTION
## Summary

- 在 `model_config.summaries_set` 新增训练期 TensorBoard 摘要配置（来自 EasyRec issue：无法通过配置调整来增加 tensorboard监控）。
- **PCOC**：按 `log_step_count_steps` 累积 batch 级 `mean(pred)/mean(label)`，写入 `summary/pcoc`、`summary/predicted_ctr`、`summary/observed_ctr`。
- **scalars**：支持按 `feature_name` + `feature_value` 切片统计 `mean(pred)`，写入 `summary/<name>`；`pred_name` 为 `logits` 时自动 sigmoid。
- 实现挂于 `BaseModel`，Rank/Match 等模型均可配置；`multi_tower_din_mock.config` 含完整示例。
- 文档见 `docs/source/models/evaluation_metrics.md`。

## 配置示例

```protobuf
model_config {
  summaries_set {
    pcoc {
      pred_name: "probs"
      label_name: "clk"
      epsilon: 1e-7
    }
  }
  summaries_set {
    scalars {
      name: "id_1_bucket_pred"
      pred_name: "probs"
      feature_name: "id_1"
      feature_value: "1005"
    }
  }
}
```

## 分布式说明

分布式训练时，各 rank 在本地累积摘要，仅 **rank 0** 写入 TensorBoard。`summary/*` 数值反映 rank 0 所见分片数据的统计，**非**全局 all-reduce 结果（与当前 `train_metrics` 行为一致）。

## Test plan

- [x] `python3 tzrec/metrics/train_summary_test.py`（6 项 CPU 测试，Apple Silicon M4 本地验证通过）
  - logits→sigmoid
  - PCOC 单 batch
  - dense / sparse 特征切片 scalars
  - 多 batch running mean 累积
  - **小样本端到端集成**：对齐 `multi_tower_din_mock.config` 的 pcoc + scalars，3 个 mini-batch 累积后写入 TensorBoard 并回读校验 `summary/*` tag
- [x] `python -m grpc_tools.protoc -I . tzrec/protos/*.proto tzrec/protos/models/*.proto --python_out=. --pyi_out=.` 生成 `summary_pb2.py`
