### PR TITLE
[doc] update ultra_hstu, dynamicemb and serving docs

### DIFF
--- a/docs/source/feature/dynamicemb.md
+++ b/docs/source/feature/dynamicemb.md
@@ -2,14 +2,16 @@
 
 DynamicEmbedding 是特征零Hash冲突Id化的一种方式，它相比设置`hash_bucket_size`的方式能避免hash冲突，相比设置`vocab_dict`和`vocab_list`的方式能更灵活动态地进行id的准入和驱逐。DynamicEmbedding 常用于user id，item id，combo feature等超大id枚举数的特征配置中。DynamicEmbedding 相比 ZCH 能外接PS，支撑十亿百亿甚至更多的Id枚举数，Id准入和淘汰无需攒Batch，可以更加及时。
 
-注：目前使用DynamicEmbedding还处于实验阶段，配置和接口都可能调整，暂只支持训练和评估，暂不包含在官方提供的镜像环境中，使用前需要额外安装如下whl包
-
-注：同一个 FeatureGroup 中若存在多个配置了 DynamicEmbedding 的特征，底层 dynamicemb 会自动将这些表融合到同一份存储里（table fusion），共享 cache/admission counter，降低显存占用并减少内存碎片，无需额外配置。
+使用 DynamicEmbedding 前需安装如下whl包
 
 ```bash
 # DEVICE 可选: cu126/cu129/cu130 (支持 Python 3.10/3.11/3.12)
 pip install dynamicemb==0.1.0+20260630.5dc46a2.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/${DEVICE}/repo.html
 ```
+
+注：同一个 FeatureGroup 中若存在多个配置了 DynamicEmbedding 的特征，底层 dynamicemb 会自动将这些表融合到同一份存储里（table fusion），共享 cache/admission counter，降低显存占用并减少内存碎片，无需额外配置。
+
+注：配置了 DynamicEmbedding 的模型导出时需设置环境变量 `USE_DISTRIBUTED_EMBEDDING=1`，使用分布式 embedding 导出模式，详见[模型导出](../usage/export.md)的环境变量章节。
 
 以id_feature的配置为例，DynamicEmbedding 只需在id_feature新增一个dynamicemb的配置字段
 

--- a/docs/source/models/ultra_hstu.md
+++ b/docs/source/models/ultra_hstu.md
@@ -141,12 +141,12 @@ model_config {
 
 - **`hstu`**：`repeated HSTU`。≥ 2 个时每个 entry 必须设置唯一非空 `name`。各 channel 的 STU `embedding_dim` 不要求一致；item 侧 MLP 与 `FusionMTLTower` 的输入维度自动取所有 channel `embedding_dim` 之和。
 - **`HSTU.name`**：MoT 通道名。非空时通道名 *替换* 默认 `uih` 前缀，preprocessor 据此从 `grouped_features` 读取 `<name>.sequence` / `<name>_action.sequence` / `<name>_watchtime.sequence` / `<name>_timestamp.sequence`。
-- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。
+- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。CUTLASS 为基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（DEVICE可选cu126/cu129/cu130：`pip install fbgemm_gpu_hstu==0.1.0+20260626.9fd44403.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/${DEVICE}/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU。
 - **`HSTU.attn_truncation_split_layer` / `attn_truncation_tail_len`**：mid-stack truncation 的分裂 layer 索引与 UIH 尾部保留长度。两者都必须 `> 0` 才启用，单独设置其一会被拒绝。
 
 ### Embedding 表共享
 
-只要多个通道在同一物理特征上声明同名 `embedding_name`，`EmbeddingGroup` 就会 dedupe 成一张表（详见 `tzrec/modules/embedding.py:EmbeddingGroup._add_embedding_config`）。**默认应当共享**；只在需要每通道独立 embedding 表的特殊场景才使用每通道独立的 `embedding_name`，否则 sparse 参数量、TBE forward/backward 计算量和 all-to-all 通信量都会按通道数线性放大。
+在多个通道对应的同一特征上声明同名 `embedding_name`，embedding 就会共享成一张表。默认不共享，**建议共享**，否则 sparse 参数量、TBE forward/backward 计算量和 all-to-all 通信量都会按通道数线性放大。
 
 ## 示例Config
 

--- a/docs/source/usage/serving.md
+++ b/docs/source/usage/serving.md
@@ -43,7 +43,7 @@ cat << EOF > tzrec_rank.json
       }
     }
   ],
-  "processor":"easyrec-torch-2.2"
+  "processor":"easyrec-torch-2.4"
 }
 EOF
 


### PR DESCRIPTION
## What

Documentation-only updates:

- **ultra_hstu.md**: correct the embedding-sharing note — embeddings are shared only when the same `embedding_name` is declared on the corresponding feature across channels; sharing is recommended but NOT the default. Also add the CUTLASS op (fbgemm_gpu_hstu) install guide from dlrm_hstu.md next to the SLA fields that require it.
- **dynamicemb.md**: drop the experimental-stage caveat (train/eval-only, not in official image); keep the whl install instructions with a plain intro. Add a note that models with DynamicEmbedding must be exported with `USE_DISTRIBUTED_EMBEDDING=1` (distributed embedding export mode).
- **serving.md**: bump the EAS processor to `easyrec-torch-2.4`.

## Test Plan

Docs-only change. `pre-commit run` (mdformat, codespell, whitespace hooks) passes on the three files; verified the relative link `../usage/export.md` in dynamicemb.md points at the existing export doc that documents `USE_DISTRIBUTED_EMBEDDING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DM8zcZauQN5VrRdzrGZA6Y