### PR TITLE
[bugfix] avoid tensor-sized temporaries when trunc_normal_ inits large embedding tables

### DIFF
--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -14,14 +14,14 @@ import os
 import shutil
 from collections import OrderedDict
 from copy import copy
-from functools import partial  # NOQA
+from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
 import pyfg
 import torch
-from torch import nn  # NOQA
+from torch import nn
 from torchrec.distributed.planner.types import ParameterConstraints
 from torchrec.modules.embedding_configs import (
     BaseEmbeddingConfig,
@@ -35,9 +35,9 @@ from torchrec.modules.mc_modules import (
     LRU_EvictionPolicy,
     ManagedCollisionModule,
     MCHManagedCollisionModule,
-    average_threshold_filter,  # NOQA
-    dynamic_threshold_filter,  # NOQA
-    probabilistic_threshold_filter,  # NOQA
+    average_threshold_filter,
+    dynamic_threshold_filter,
+    probabilistic_threshold_filter,
 )
 from torchrec.types import DataType
 
@@ -60,7 +60,7 @@ from tzrec.modules.dense_embedding_collection import (
 from tzrec.protos import feature_pb2
 from tzrec.protos.data_pb2 import FgMode
 from tzrec.protos.feature_pb2 import FeatureConfig, SequenceFeature
-from tzrec.utils import config_util, dynamicemb_util, env_util
+from tzrec.utils import config_util, dynamicemb_util, env_util, init_util
 from tzrec.utils.load_class import get_register_class_meta
 from tzrec.utils.logging_util import logger
 
@@ -615,7 +615,7 @@ class BaseFeature(object, metaclass=_meta_cls):
             embedding_name = self.config.embedding_name or f"{self.name}_emb"
             init_fn = None
             if self.config.HasField("init_fn"):
-                init_fn = eval(f"partial({self.config.init_fn})")
+                init_fn = init_util.create_init_fn(self.config.init_fn)
             emb_bag_config = EmbeddingBagConfig(
                 num_embeddings=self.num_embeddings,
                 embedding_dim=self._embedding_dim,
@@ -642,7 +642,7 @@ class BaseFeature(object, metaclass=_meta_cls):
             embedding_name = self.config.embedding_name or f"{self.name}_emb"
             init_fn = None
             if self.config.HasField("init_fn"):
-                init_fn = eval(f"partial({self.config.init_fn})")
+                init_fn = init_util.create_init_fn(self.config.init_fn)
             emb_config = EmbeddingConfig(
                 num_embeddings=self.num_embeddings,
                 embedding_dim=self._embedding_dim,
@@ -699,7 +699,17 @@ class BaseFeature(object, metaclass=_meta_cls):
                 threshold_filtering_func = None
                 if self.config.zch.HasField("threshold_filtering_func"):
                     threshold_filtering_func = eval(
-                        self.config.zch.threshold_filtering_func
+                        self.config.zch.threshold_filtering_func,
+                        {
+                            "partial": partial,
+                            "nn": nn,
+                            "torch": torch,
+                            "average_threshold_filter": average_threshold_filter,
+                            "dynamic_threshold_filter": dynamic_threshold_filter,
+                            "probabilistic_threshold_filter": (
+                                probabilistic_threshold_filter
+                            ),
+                        },
                     )
                 if evict_type == "lfu":
                     eviction_policy = LFU_EvictionPolicy(

--- a/tzrec/features/id_feature_test.py
+++ b/tzrec/features/id_feature_test.py
@@ -100,6 +100,7 @@ class IdFeatureTest(unittest.TestCase):
         [
             ["lambda x: probabilistic_threshold_filter(x,0.05)"],
             ["lambda x: (x > 10, 10)"],
+            ["partial(dynamic_threshold_filter, threshold_skew_multiplier=1.0)"],
         ],
         name_func=test_util.parameterized_name_func,
     )

--- a/tzrec/modules/embedding.py
+++ b/tzrec/modules/embedding.py
@@ -11,7 +11,6 @@
 
 import os
 from collections import OrderedDict, defaultdict
-from functools import partial  # NOQA
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union, cast
 
 import torch
@@ -42,6 +41,7 @@ from tzrec.modules.dense_embedding_collection import (
 from tzrec.modules.sequence import create_seq_encoder
 from tzrec.protos import model_pb2
 from tzrec.protos.model_pb2 import FeatureGroupConfig, SeqGroupConfig
+from tzrec.utils import init_util
 from tzrec.utils.fx_util import (
     fx_int_item,
     fx_mark_keyed_tensor,
@@ -725,7 +725,9 @@ class EmbeddingGroupImpl(nn.Module):
                             wide_embedding_dim or 4
                         )
                         if wide_init_fn:
-                            emb_bag_config.init_fn = eval(f"partial({wide_init_fn})")
+                            emb_bag_config.init_fn = init_util.create_init_fn(
+                                wide_init_fn
+                            )
                     # we may modify ebc name at feat_to_group_to_emb_name, e.g., wide
                     emb_bag_config.name = feat_to_group_to_emb_name[name][group_name]
                     const = feature.parameter_constraints(emb_bag_config)

--- a/tzrec/utils/env_util.py
+++ b/tzrec/utils/env_util.py
@@ -55,3 +55,14 @@ def enable_tma() -> bool:
 def force_load_sharding_plan() -> bool:
     """Force load sharding plan in checkpoint or not."""
     return os.environ.get("FORCE_LOAD_SHARDING_PLAN", "0") == "1"
+
+
+def use_inplace_trunc_normal() -> bool:
+    """Use the in-place inverse-CDF trunc_normal_ initialization or not.
+
+    nn.init.trunc_normal_ in torch>=2.12 materializes several temporaries as
+    large as the tensor itself and can OOM when initializing a very large
+    embedding table at sharding time; enabling this flag initializes with the
+    in-place implementation of torch<=2.11 instead.
+    """
+    return os.environ.get("USE_INPLACE_TRUNC_NORMAL", "0") == "1"

--- a/tzrec/utils/init_util.py
+++ b/tzrec/utils/init_util.py
@@ -16,9 +16,7 @@ from typing import Callable, Optional
 import torch
 from torch import nn
 
-# Above this many elements, trunc_normal_ switches to the in-place
-# inverse-CDF implementation to avoid tensor-sized temporaries.
-_INPLACE_NUMEL_THRESHOLD: int = 2**27
+from tzrec.utils import env_util
 
 
 def _inplace_trunc_normal_(
@@ -34,7 +32,9 @@ def _inplace_trunc_normal_(
     Reimplements the torch<=2.11 torch.nn.init._no_grad_trunc_normal_,
     which allocates no tensor-sized temporaries. torch>=2.12 switched to
     rejection sampling (pytorch/pytorch#174997) whose boolean masks and
-    resampling buffers are as large as the tensor itself.
+    resampling buffers are as large as the tensor itself. Like torch<=2.11,
+    a uniform sample landing exactly on an interval endpoint clamps to a or
+    b (~2**-24 probability per element in fp32, more in lower precision).
 
     Args:
         tensor (torch.Tensor): an n-dimensional tensor filled in place.
@@ -70,13 +70,14 @@ def trunc_normal_(
     b: float = 2.0,
     generator: Optional[torch.Generator] = None,
 ) -> torch.Tensor:
-    """Memory-aware drop-in replacement for nn.init.trunc_normal_.
+    """Drop-in replacement for nn.init.trunc_normal_ with an in-place fallback.
 
     nn.init.trunc_normal_ in torch>=2.12 materializes several temporaries
     as large as the tensor itself, which OOMs when torchrec initializes a
     very large embedding table (e.g. a 150M-row ZCH table) at sharding
-    time. Params above _INPLACE_NUMEL_THRESHOLD elements are filled with
-    the in-place inverse-CDF implementation instead.
+    time. Set USE_INPLACE_TRUNC_NORMAL=1 to initialize with the in-place
+    inverse-CDF implementation of torch<=2.11 instead, which allocates no
+    temporaries.
 
     Args:
         tensor (torch.Tensor): an n-dimensional tensor filled in place.
@@ -89,7 +90,7 @@ def trunc_normal_(
     Returns:
         the input tensor.
     """
-    if tensor.numel() > _INPLACE_NUMEL_THRESHOLD:
+    if env_util.use_inplace_trunc_normal():
         return _inplace_trunc_normal_(tensor, mean, std, a, b, generator=generator)
     return nn.init.trunc_normal_(tensor, mean, std, a, b, generator=generator)
 
@@ -99,8 +100,9 @@ def create_init_fn(init_fn_expr: str) -> Callable[..., torch.Tensor]:
 
     Evaluates an init_fn expression such as "nn.init.uniform_,a=-0.01,b=0.01"
     into partial(nn.init.uniform_, a=-0.01, b=0.01). nn.init.trunc_normal_ is
-    replaced by the memory-aware trunc_normal_ above so that very large
-    embedding tables do not OOM at sharding time on torch>=2.12.
+    replaced by the env-switchable trunc_normal_ above so that very large
+    embedding tables can be initialized without OOM at sharding time on
+    torch>=2.12 by setting USE_INPLACE_TRUNC_NORMAL=1.
 
     Args:
         init_fn_expr (str): comma-separated init function expression.

--- a/tzrec/utils/init_util.py
+++ b/tzrec/utils/init_util.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from functools import partial
+from typing import Callable, Optional
+
+import torch
+from torch import nn
+
+# Above this many elements, trunc_normal_ switches to the in-place
+# inverse-CDF implementation to avoid tensor-sized temporaries.
+_INPLACE_NUMEL_THRESHOLD: int = 2**27
+
+
+def _inplace_trunc_normal_(
+    tensor: torch.Tensor,
+    mean: float,
+    std: float,
+    a: float,
+    b: float,
+    generator: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    """Fill the tensor in place with a truncated normal via inverse CDF.
+
+    Reimplements the torch<=2.11 torch.nn.init._no_grad_trunc_normal_,
+    which allocates no tensor-sized temporaries. torch>=2.12 switched to
+    rejection sampling (pytorch/pytorch#174997) whose boolean masks and
+    resampling buffers are as large as the tensor itself.
+
+    Args:
+        tensor (torch.Tensor): an n-dimensional tensor filled in place.
+        mean (float): the mean of the normal distribution.
+        std (float): the standard deviation of the normal distribution.
+        a (float): the minimum cutoff value.
+        b (float): the maximum cutoff value.
+        generator (torch.Generator, optional): the sampling generator.
+
+    Returns:
+        the input tensor.
+    """
+
+    def norm_cdf(x: float) -> float:
+        return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
+
+    with torch.no_grad():
+        low = norm_cdf((a - mean) / std)
+        up = norm_cdf((b - mean) / std)
+        tensor.uniform_(2 * low - 1, 2 * up - 1, generator=generator)
+        tensor.erfinv_()
+        tensor.mul_(std * math.sqrt(2.0))
+        tensor.add_(mean)
+        tensor.clamp_(min=a, max=b)
+        return tensor
+
+
+def trunc_normal_(
+    tensor: torch.Tensor,
+    mean: float = 0.0,
+    std: float = 1.0,
+    a: float = -2.0,
+    b: float = 2.0,
+    generator: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    """Memory-aware drop-in replacement for nn.init.trunc_normal_.
+
+    nn.init.trunc_normal_ in torch>=2.12 materializes several temporaries
+    as large as the tensor itself, which OOMs when torchrec initializes a
+    very large embedding table (e.g. a 150M-row ZCH table) at sharding
+    time. Params above _INPLACE_NUMEL_THRESHOLD elements are filled with
+    the in-place inverse-CDF implementation instead.
+
+    Args:
+        tensor (torch.Tensor): an n-dimensional tensor filled in place.
+        mean (float): the mean of the normal distribution.
+        std (float): the standard deviation of the normal distribution.
+        a (float): the minimum cutoff value.
+        b (float): the maximum cutoff value.
+        generator (torch.Generator, optional): the sampling generator.
+
+    Returns:
+        the input tensor.
+    """
+    if tensor.numel() > _INPLACE_NUMEL_THRESHOLD:
+        return _inplace_trunc_normal_(tensor, mean, std, a, b, generator=generator)
+    return nn.init.trunc_normal_(tensor, mean, std, a, b, generator=generator)
+
+
+def create_init_fn(init_fn_expr: str) -> Callable[..., torch.Tensor]:
+    """Create an embedding init_fn from its config expression.
+
+    Evaluates an init_fn expression such as "nn.init.uniform_,a=-0.01,b=0.01"
+    into partial(nn.init.uniform_, a=-0.01, b=0.01). nn.init.trunc_normal_ is
+    replaced by the memory-aware trunc_normal_ above so that very large
+    embedding tables do not OOM at sharding time on torch>=2.12.
+
+    Args:
+        init_fn_expr (str): comma-separated init function expression.
+
+    Returns:
+        a callable that initializes a tensor in place.
+    """
+    init_fn: Callable[..., torch.Tensor] = eval(
+        f"partial({init_fn_expr})", {"partial": partial, "nn": nn, "torch": torch}
+    )
+    if isinstance(init_fn, partial) and init_fn.func is nn.init.trunc_normal_:
+        init_fn = partial(trunc_normal_, *init_fn.args, **init_fn.keywords)
+    return init_fn

--- a/tzrec/utils/init_util_test.py
+++ b/tzrec/utils/init_util_test.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from functools import partial
+from unittest import mock
+
+import torch
+from torch import nn
+
+from tzrec.utils import init_util
+
+
+class InitUtilTest(unittest.TestCase):
+    def test_create_init_fn_swaps_trunc_normal(self):
+        init_fn = init_util.create_init_fn("nn.init.trunc_normal_,mean=0.0,std=0.0125")
+        self.assertIsInstance(init_fn, partial)
+        self.assertIs(init_fn.func, init_util.trunc_normal_)
+        self.assertEqual(init_fn.keywords, {"mean": 0.0, "std": 0.0125})
+
+    def test_create_init_fn_keeps_other_init(self):
+        init_fn = init_util.create_init_fn("nn.init.uniform_,a=-0.01,b=0.01")
+        self.assertIsInstance(init_fn, partial)
+        self.assertIs(init_fn.func, nn.init.uniform_)
+        self.assertEqual(init_fn.keywords, {"a": -0.01, "b": 0.01})
+
+    def test_trunc_normal_dispatches_on_numel(self):
+        with mock.patch.object(
+            init_util, "_inplace_trunc_normal_", wraps=init_util._inplace_trunc_normal_
+        ) as mock_inplace:
+            with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 1023):
+                init_util.trunc_normal_(torch.empty(1023), std=0.1)
+                mock_inplace.assert_not_called()
+                t = torch.empty(1024)
+                init_util.trunc_normal_(t, mean=0.5, std=0.1, a=-1.0, b=1.0)
+                mock_inplace.assert_called_once_with(
+                    t, 0.5, 0.1, -1.0, 1.0, generator=None
+                )
+
+    def test_trunc_normal_large_statistics(self):
+        t = torch.empty(1000, 1000)
+        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
+            init_util.trunc_normal_(t, mean=0.0, std=0.0125)
+        self.assertAlmostEqual(t.mean().item(), 0.0, delta=1e-4)
+        self.assertAlmostEqual(t.std().item(), 0.0125, delta=1e-4)
+        self.assertGreaterEqual(t.min().item(), -2.0)
+        self.assertLessEqual(t.max().item(), 2.0)
+
+    def test_trunc_normal_large_truncates(self):
+        t = torch.empty(1000, 1000)
+        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
+            init_util.trunc_normal_(t, mean=0.0, std=1.0, a=-1.0, b=1.0)
+        self.assertGreaterEqual(t.min().item(), -1.0)
+        self.assertLessEqual(t.max().item(), 1.0)
+        self.assertLess(t.std().item(), 0.6)
+
+    def test_trunc_normal_large_reproducible(self):
+        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
+            t1 = init_util.trunc_normal_(
+                torch.empty(1000),
+                std=0.1,
+                generator=torch.Generator().manual_seed(42),
+            )
+            t2 = init_util.trunc_normal_(
+                torch.empty(1000),
+                std=0.1,
+                generator=torch.Generator().manual_seed(42),
+            )
+        torch.testing.assert_close(t1, t2, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/utils/init_util_test.py
+++ b/tzrec/utils/init_util_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from functools import partial
 from unittest import mock
@@ -32,38 +33,50 @@ class InitUtilTest(unittest.TestCase):
         self.assertIs(init_fn.func, nn.init.uniform_)
         self.assertEqual(init_fn.keywords, {"a": -0.01, "b": 0.01})
 
-    def test_trunc_normal_dispatches_on_numel(self):
-        with mock.patch.object(
-            init_util, "_inplace_trunc_normal_", wraps=init_util._inplace_trunc_normal_
-        ) as mock_inplace:
-            with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 1023):
-                init_util.trunc_normal_(torch.empty(1023), std=0.1)
-                mock_inplace.assert_not_called()
+    def test_trunc_normal_default_native(self):
+        with mock.patch.dict(os.environ):
+            os.environ.pop("USE_INPLACE_TRUNC_NORMAL", None)
+            with mock.patch.object(
+                nn.init, "trunc_normal_", wraps=nn.init.trunc_normal_
+            ) as mock_native:
+                t = torch.empty(1024)
+                init_util.trunc_normal_(t, mean=0.5, std=0.1, a=-1.0, b=1.0)
+                mock_native.assert_called_once_with(
+                    t, 0.5, 0.1, -1.0, 1.0, generator=None
+                )
+
+    def test_trunc_normal_env_inplace(self):
+        with mock.patch.dict(os.environ, {"USE_INPLACE_TRUNC_NORMAL": "1"}):
+            with mock.patch.object(
+                init_util,
+                "_inplace_trunc_normal_",
+                wraps=init_util._inplace_trunc_normal_,
+            ) as mock_inplace:
                 t = torch.empty(1024)
                 init_util.trunc_normal_(t, mean=0.5, std=0.1, a=-1.0, b=1.0)
                 mock_inplace.assert_called_once_with(
                     t, 0.5, 0.1, -1.0, 1.0, generator=None
                 )
 
-    def test_trunc_normal_large_statistics(self):
+    def test_trunc_normal_inplace_statistics(self):
         t = torch.empty(1000, 1000)
-        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
-            init_util.trunc_normal_(t, mean=0.0, std=0.0125)
-        self.assertAlmostEqual(t.mean().item(), 0.0, delta=1e-4)
+        with mock.patch.dict(os.environ, {"USE_INPLACE_TRUNC_NORMAL": "1"}):
+            init_util.trunc_normal_(t, mean=0.5, std=0.0125)
+        self.assertAlmostEqual(t.mean().item(), 0.5, delta=1e-4)
         self.assertAlmostEqual(t.std().item(), 0.0125, delta=1e-4)
         self.assertGreaterEqual(t.min().item(), -2.0)
         self.assertLessEqual(t.max().item(), 2.0)
 
-    def test_trunc_normal_large_truncates(self):
+    def test_trunc_normal_inplace_truncates(self):
         t = torch.empty(1000, 1000)
-        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
+        with mock.patch.dict(os.environ, {"USE_INPLACE_TRUNC_NORMAL": "1"}):
             init_util.trunc_normal_(t, mean=0.0, std=1.0, a=-1.0, b=1.0)
         self.assertGreaterEqual(t.min().item(), -1.0)
         self.assertLessEqual(t.max().item(), 1.0)
         self.assertLess(t.std().item(), 0.6)
 
-    def test_trunc_normal_large_reproducible(self):
-        with mock.patch.object(init_util, "_INPLACE_NUMEL_THRESHOLD", 0):
+    def test_trunc_normal_inplace_reproducible(self):
+        with mock.patch.dict(os.environ, {"USE_INPLACE_TRUNC_NORMAL": "1"}):
             t1 = init_util.trunc_normal_(
                 torch.empty(1000),
                 std=0.1,

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"


### PR DESCRIPTION
## Problem

`nn.init.trunc_normal_` in torch>=2.12 was rewritten with rejection sampling (pytorch/pytorch#174997). The new implementation materializes several temporaries as large as the tensor itself: the bounds check `mask = (result < lo) | (result > hi)` alone allocates up to three tensor-sized bool masks, and any resample iteration adds two fp32 buffers of full tensor size.

torchrec applies a table's `init_fn` to the full local shard at DMP sharding time (`ShardedEmbeddingBagCollection._initialize_torch_state -> reset_parameters`). For a very large table this transient allocation is huge — e.g. a 150M-row x dim-64 ZCH table with a `fused_uvm_caching` kernel needs an 8.94 GiB first mask (and ~27 GiB peak at that line) — and it OOMs GPUs that ran the exact same config fine on torch<=2.11, where `trunc_normal_` was fully in-place (`uniform_ -> erfinv_ -> mul_ -> add_ -> clamp_`, ~0 extra bytes).

## Fix

- Add `tzrec/utils/init_util.py`:
  - `create_init_fn(expr)` centralizes the eval of config `init_fn` expressions (previously inline `eval(f"partial({expr})")` at three sites) with an explicit `{partial, nn, torch}` namespace, and swaps `nn.init.trunc_normal_` for an env-switchable `trunc_normal_`.
  - `trunc_normal_` defers to native `nn.init.trunc_normal_` by default. Setting `USE_INPLACE_TRUNC_NORMAL=1` initializes with the in-place inverse-CDF implementation of torch<=2.11 (~0 transient HBM), restoring for memory-constrained huge-table jobs exactly the initialization their configs trained with on torch<=2.11.
- The `zch.threshold_filtering_func` eval in `feature.py` previously resolved `partial`/`nn` from module globals kept alive by `# NOQA` imports; it now gets an explicit namespace (`partial`, `nn`, `torch`, and the three `*_threshold_filter` helpers) instead of leaking module globals into config eval.
- Bump version to 1.3.4.

An earlier revision dispatched on a `numel > 2**27` threshold; review correctly noted that a fixed element cutoff neither bounds native temporaries just below it (~1.4 GiB possible) nor avoids silently reintroducing the torch<=2.11 endpoint-clamp tail defect above it (a `uniform_` sample landing exactly on an interval endpoint clamps to a/b after `erfinv_`; measured ~2^-24 per element, ~450 exact -2.0 outliers on a 150M x 64 table). The explicit opt-in keeps native statistics for everyone by default and makes the memory/statistics trade a deliberate per-job choice.

## Test Plan

- `tzrec/utils/init_util_test.py` (7 tests): expression parsing and `trunc_normal_` swap (kwargs preserved, non-trunc-normal init fns untouched), default path calls native `nn.init.trunc_normal_` with exact argument forwarding, `USE_INPLACE_TRUNC_NORMAL=1` path calls the in-place implementation with exact argument forwarding, statistics through the public API with nonzero mean (mean=0.5, std=0.0125), truncation at ±1σ, and generator reproducibility.
- `tzrec/features/id_feature_test.py`: added a `partial(dynamic_threshold_filter, ...)` case for `zch.threshold_filtering_func` to guard the explicit eval namespace.
- Ran `tzrec.utils.init_util_test` (7), `tzrec.features.id_feature_test` (58), `tzrec.modules.embedding_test` (52), `tzrec.models.wide_and_deep_test` (3, covers `wide_init_fn`) — all pass; `pre-commit` clean.
- End-to-end: built an `IdFeature` with `init_fn: "nn.init.trunc_normal_,mean=0.0,std=0.0125"` and verified the config-created init_fn calls native torch by default and the in-place path with `USE_INPLACE_TRUNC_NORMAL=1`, with correct statistics on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lu52Dws7J8GLgr7Hzviisn