### PR TITLE
[ci] opt in to fork PR checkout in code review workflow

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -113,13 +113,15 @@ jobs:
             scripts/ci
           path: trusted-claude
 
-      # Checkout PR code for review
+      # Checkout PR code for review. Fork checkout is intentional here: trusted
+      # agent files come from github.sha above and the model runs sandboxed.
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           path: pr-code
+          allow-unsafe-pr-checkout: true
 
       - name: Use trusted agent files
         run: bash trusted-claude/scripts/ci/use_trusted_agent_files.sh trusted-claude pr-code
@@ -178,13 +180,15 @@ jobs:
             scripts/ci
           path: trusted-claude
 
-      # Checkout PR code for review
+      # Checkout PR code for review. Fork checkout is intentional here: trusted
+      # agent files come from github.sha above and the model runs sandboxed.
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           path: pr-code
+          allow-unsafe-pr-checkout: true
 
       # Same trusted-file setup as the claude job, plus generated codex agents as an overlay
       - name: Use trusted agent files


### PR DESCRIPTION
## What

The `Code Review` workflow (`pull_request_target`) started failing on every fork PR:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

Example failure: https://github.com/alibaba/TorchEasyRec/actions/runs/29808008826/job/88562535542

## Why

GitHub shipped [safer `pull_request_target` defaults for `actions/checkout`](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) and backported the change to the v4/v5/v6 tags, so workflows on the floating `@v4` tag inherited the new refusal without any change on our side.

Checking out fork code is intentional in this workflow: the trusted agent files (`.claude/`, `scripts/ci/`) are checked out separately at `github.sha`, and the review model runs in a no-network sandbox with a small `gh` allowlist. So we opt in explicitly with `allow-unsafe-pr-checkout: true` on the two "Checkout PR code" steps only; the trusted-file checkouts are untouched. An alternative would be pinning checkout to a pre-backport SHA, but that just hides the (deliberate) opt-in instead of stating it.

Other workflows (`unittest_ci`, `codestyle_ci`, etc.) also check out `head.sha` but trigger on `pull_request`, not `pull_request_target`, so they are unaffected.

## Test Plan

- `pre-commit run --files .github/workflows/code_review.yml` passes (yaml check included).
- The trigger (`pull_request_target: labeled`) only fires on the base repo's workflow file, so the real verification is post-merge: add the `claude-review` / `codex-review` label to any fork PR and confirm the "Checkout PR code" step succeeds.
