### PR TITLE
[bugfix] track delta embeddings by owner-qualified FQN

### DIFF
--- a/tzrec/utils/delta_embedding_dump.py
+++ b/tzrec/utils/delta_embedding_dump.py
@@ -492,9 +492,20 @@ class ModelDeltaTracker(TorchRecModelDeltaTracker):
         index_start = max(self.per_consumer_batch_idx.values())
         if index_start < index_end:
             self.store.compact(index_start, index_end)
-        tracker_rows = self.store.get_unique(
-            from_idx=self.per_consumer_batch_idx[consumer]
-        )
+
+        tracker_rows: Dict[str, UniqueRows] = {}
+        from_idx = self.per_consumer_batch_idx[consumer]
+        for fqn, lookups in self.store.per_fqn_lookups.items():
+            compact_ids = [
+                lookup.ids for lookup in lookups if lookup.batch_idx >= from_idx
+            ]
+            if not compact_ids:
+                continue
+            tracker_rows[fqn] = UniqueRows(
+                ids=torch.cat(compact_ids).unique(),
+                states=None,
+            )
+
         self.per_consumer_batch_idx[consumer] = index_end
         if self._delete_on_read:
             self.store.delete(up_to_idx=min(self.per_consumer_batch_idx.values()))

--- a/tzrec/utils/delta_embedding_dump.py
+++ b/tzrec/utils/delta_embedding_dump.py
@@ -10,29 +10,56 @@
 # limitations under the License.
 
 import os
-import re
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
+from google.protobuf.message import Message
 from torch import nn
+from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._shard.sharding_spec import EnumerableShardingSpec
+from torch.distributed.tensor import DTensor
+from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.embedding_lookup import (
+    GroupedEmbeddingsLookup,
+    GroupedPooledEmbeddingsLookup,
+)
+from torchrec.distributed.embedding_types import ShardedEmbeddingTable
 from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
 from torchrec.distributed.model_tracker.delta_store import DeltaStoreTrec
 from torchrec.distributed.model_tracker.model_delta_tracker import (
     ModelDeltaTracker as TorchRecModelDeltaTracker,
 )
 from torchrec.distributed.model_tracker.types import UniqueRows, UpdateMode
+from torchrec.distributed.types import ParameterSharding
+from torchrec.modules.embedding_configs import BaseEmbeddingConfig
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
+from tzrec.protos.feature_pb2 import FeatureConfig
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig
 from tzrec.utils.logging_util import logger
 
 _CONSUMER = "delta_embedding_dump"
+_ShardedEmbeddingModule = Union[
+    ShardedEmbeddingCollection, ShardedEmbeddingBagCollection
+]
+_EmbeddingLookup = Union[GroupedEmbeddingsLookup, GroupedPooledEmbeddingsLookup]
 _DELTA_DUMP_SCHEMA = pa.schema(
     [
         ("global_step", pa.int64()),
@@ -93,18 +120,13 @@ def validate_delta_embedding_dump_config(
         raise ValueError("delta_embedding_dump_config.dump_interval_steps must be > 0.")
 
 
-def _has_proto_field(config: Any, field_name: str) -> bool:
-    descriptor = getattr(config, "DESCRIPTOR", None)
-    if descriptor is None or field_name not in descriptor.fields_by_name:
+def _has_proto_field(config: Message, field_name: str) -> bool:
+    if field_name not in config.DESCRIPTOR.fields_by_name:
         return False
     return config.HasField(field_name)
 
 
-def _feature_config_name(config: Any) -> str:
-    return getattr(config, "feature_name", "")
-
-
-def _zch_feature_names(feature_configs: Iterable[Any]) -> Set[str]:
+def _zch_feature_names(feature_configs: Iterable[FeatureConfig]) -> Set[str]:
     zch_feature_names: Set[str] = set()
     for feature_config in feature_configs:
         feature_type = feature_config.WhichOneof("feature")
@@ -112,13 +134,13 @@ def _zch_feature_names(feature_configs: Iterable[Any]) -> Set[str]:
             continue
         config = getattr(feature_config, feature_type)
         if _has_proto_field(config, "zch"):
-            feature_name = _feature_config_name(config) or feature_type
+            feature_name = config.feature_name or feature_type
             zch_feature_names.add(feature_name)
     return zch_feature_names
 
 
 def validate_delta_embedding_dump_no_zch_features(
-    feature_configs: Iterable[Any],
+    feature_configs: Iterable[FeatureConfig],
 ) -> None:
     """Validate that delta embedding dump is not used with MC/ZCH features.
 
@@ -141,16 +163,11 @@ def _feature_name(feature_names: Iterable[str]) -> str:
     return ",".join(names)
 
 
-def _int_attr(value: Any, name: str) -> int:
-    attr = getattr(value, name, 0)
-    return int(attr) if attr is not None else 0
-
-
-def _metadata_shard_info(metadata: Any) -> _TableShardInfo:
-    if metadata is None or not hasattr(metadata, "shard_offsets"):
+def _metadata_shard_info(metadata: Optional[ShardMetadata]) -> _TableShardInfo:
+    if metadata is None:
         return _TableShardInfo()
-    offsets = getattr(metadata, "shard_offsets", [])
-    sizes = getattr(metadata, "shard_sizes", [])
+    offsets = metadata.shard_offsets
+    sizes = metadata.shard_sizes
     return _TableShardInfo(
         row_offset=int(offsets[0]) if len(offsets) > 0 else 0,
         column_offset=int(offsets[1]) if len(offsets) > 1 else 0,
@@ -160,38 +177,26 @@ def _metadata_shard_info(metadata: Any) -> _TableShardInfo:
     )
 
 
-def _placement_rank(placement: Any) -> Optional[int]:
-    if placement is None:
-        return None
-    rank_fn = getattr(placement, "rank", None)
-    if callable(rank_fn):
-        rank = rank_fn()
-        if rank is not None:
-            return int(rank)
-    match = re.search(r"rank:(\d+)", str(placement))
-    if match is None:
-        return None
-    return int(match.group(1))
-
-
 def _table_shard_info_from_parameter_sharding(
-    parameter_sharding: Any, rank: int
+    parameter_sharding: ParameterSharding, rank: int
 ) -> _TableShardInfo:
-    sharding_spec = getattr(parameter_sharding, "sharding_spec", None)
-    shards = getattr(sharding_spec, "shards", None)
-    if not shards:
+    sharding_spec = parameter_sharding.sharding_spec
+    if (
+        not isinstance(sharding_spec, EnumerableShardingSpec)
+        or not sharding_spec.shards
+    ):
         return _TableShardInfo()
 
-    ranks = getattr(parameter_sharding, "ranks", None)
-    for idx, shard in enumerate(shards):
-        placement_rank = _placement_rank(getattr(shard, "placement", None))
+    ranks = parameter_sharding.ranks
+    for idx, shard in enumerate(sharding_spec.shards):
+        placement_rank = shard.placement.rank() if shard.placement is not None else None
         if placement_rank == rank:
             return _metadata_shard_info(shard)
         if ranks is not None and idx < len(ranks) and ranks[idx] == rank:
             return _metadata_shard_info(shard)
 
-    if ranks is None and 0 <= rank < len(shards):
-        return _metadata_shard_info(shards[rank])
+    if ranks is None and 0 <= rank < len(sharding_spec.shards):
+        return _metadata_shard_info(sharding_spec.shards[rank])
     return _TableShardInfo()
 
 
@@ -212,13 +217,22 @@ def _merge_shard_info(
     )
 
 
-def _table_shard_info_from_config(table_config: Any) -> _TableShardInfo:
-    metadata_info = _metadata_shard_info(getattr(table_config, "local_metadata", None))
+def _table_shard_info_from_config(
+    table_config: BaseEmbeddingConfig,
+) -> _TableShardInfo:
+    local_rows = 0
+    local_cols = 0
+    local_metadata = None
+    if isinstance(table_config, ShardedEmbeddingTable):
+        local_rows = table_config.local_rows
+        local_cols = table_config.local_cols
+        local_metadata = table_config.local_metadata
+    metadata_info = _metadata_shard_info(local_metadata)
     config_info = _TableShardInfo(
-        local_rows=_int_attr(table_config, "local_rows"),
-        local_cols=_int_attr(table_config, "local_cols"),
-        global_rows=_int_attr(table_config, "num_embeddings"),
-        global_cols=_int_attr(table_config, "embedding_dim"),
+        local_rows=local_rows,
+        local_cols=local_cols,
+        global_rows=table_config.num_embeddings,
+        global_cols=table_config.embedding_dim,
     )
     return _merge_shard_info(config_info, metadata_info)
 
@@ -273,7 +287,8 @@ def _merge_table_shard_info(
 
 
 def _local_table_weight(
-    value: Any, shard_info: Optional[_TableShardInfo] = None
+    value: Union[ShardedTensor, DTensor, torch.Tensor],
+    shard_info: Optional[_TableShardInfo] = None,
 ) -> _TableWeight:
     if isinstance(value, ShardedTensor):
         shards = value.local_shards()
@@ -283,34 +298,39 @@ def _local_table_weight(
             )
         info = _merge_shard_info(
             shard_info or _TableShardInfo(),
-            _metadata_shard_info(getattr(shards[0], "metadata", None)),
+            _metadata_shard_info(shards[0].metadata),
         )
         info = _table_shard_info_from_tensor(shards[0].tensor, info)
         return _TableWeight(tensor=shards[0].tensor, shard_info=info)
-    if hasattr(value, "to_local"):
+    if isinstance(value, DTensor):
         local_value = value.to_local()
-        if hasattr(local_value, "local_shards"):
-            shards = local_value.local_shards()
-            if len(shards) != 1:
-                raise ValueError(
-                    "delta embedding dump only supports one local shard per table."
-                )
-            info = _merge_shard_info(
-                shard_info or _TableShardInfo(),
-                _metadata_shard_info(getattr(shards[0], "metadata", None)),
-            )
-            info = _table_shard_info_from_tensor(shards[0].tensor, info)
-            return _TableWeight(tensor=shards[0].tensor, shard_info=info)
-        if isinstance(local_value, torch.Tensor):
-            info = _table_shard_info_from_tensor(local_value, shard_info)
-            return _TableWeight(tensor=local_value, shard_info=info)
+        info = _table_shard_info_from_tensor(local_value, shard_info)
+        return _TableWeight(tensor=local_value, shard_info=info)
     if isinstance(value, torch.Tensor):
         info = _table_shard_info_from_tensor(value, shard_info)
         return _TableWeight(tensor=value, shard_info=info)
     raise TypeError(f"Unsupported embedding table value type: {type(value)}")
 
 
-def _embedding_table_fqn(module_fqn: str, module: nn.Module, table_name: str) -> str:
+def _embedding_lookups(
+    module: _ShardedEmbeddingModule,
+) -> Iterator[_EmbeddingLookup]:
+    """Yield the supported grouped lookups owned by a sharded sparse module."""
+    for lookup in module._lookups:
+        while isinstance(lookup, DistributedDataParallel):
+            lookup = lookup.module
+        if not isinstance(
+            lookup, (GroupedEmbeddingsLookup, GroupedPooledEmbeddingsLookup)
+        ):
+            raise TypeError(
+                f"Unsupported embedding lookup for delta embedding dump: {type(lookup)}"
+            )
+        yield lookup
+
+
+def _embedding_table_fqn(
+    module_fqn: str, module: _ShardedEmbeddingModule, table_name: str
+) -> str:
     """Build a state-dict-style table FQN for a sharded sparse module.
 
     Args:
@@ -355,9 +375,11 @@ class ModelDeltaTracker(TorchRecModelDeltaTracker):
         self.per_consumer_batch_idx = {consumer: -1 for consumer in consumer_names}
         self.curr_batch_idx = 0
         self.curr_compact_index = 0
-        self.tracked_modules: Dict[str, nn.Module] = {}
+        self.tracked_modules: Dict[str, _ShardedEmbeddingModule] = {}
         self.fqn_to_feature_names: Dict[str, List[str]] = {}
-        self._feature_to_fqn_by_module: Dict[nn.Module, Dict[str, str]] = {}
+        self._feature_to_fqn_by_module: Dict[
+            _ShardedEmbeddingModule, Dict[str, str]
+        ] = {}
         self.store = DeltaStoreTrec(UpdateMode.NONE)
 
         for named_fqn, module in model.named_modules():
@@ -366,7 +388,7 @@ class ModelDeltaTracker(TorchRecModelDeltaTracker):
             ):
                 continue
 
-            module_fqn = getattr(module, "_module_fqn", None)
+            module_fqn = module._module_fqn
             if not module_fqn:
                 module_fqn = self._clean_module_fqn(named_fqn)
             self.tracked_modules[module_fqn] = module
@@ -526,7 +548,7 @@ class DeltaEmbeddingDumper:
         config: DeltaEmbeddingDumpConfig,
         model_dir: str,
         device: torch.device,
-        feature_configs: Iterable[Any],
+        feature_configs: Iterable[FeatureConfig],
     ) -> None:
         validate_delta_embedding_dump_config(config, device)
         validate_delta_embedding_dump_no_zch_features(feature_configs)
@@ -682,23 +704,16 @@ class DeltaEmbeddingDumper:
         )
 
     def _install_tracking_pause_guard(self) -> None:
-        guarded_modules = getattr(self, "_guarded_tracking_modules", set())
         for module in self._tracker.tracked_modules.values():
-            if id(module) in guarded_modules:
-                continue
-            has_tracker_fn = False
-            post_lookup_fn = getattr(module, "post_lookup_tracker_fn", None)
-            if post_lookup_fn is not None:
-                module.post_lookup_tracker_fn = self._wrap_tracker_fn(post_lookup_fn)
-                has_tracker_fn = True
-            post_odist_fn = getattr(module, "post_odist_tracker_fn", None)
-            if post_odist_fn is not None:
-                module.post_odist_tracker_fn = self._wrap_tracker_fn(post_odist_fn)
-                has_tracker_fn = True
-            if not has_tracker_fn:
-                continue
-            guarded_modules.add(id(module))
-        self._guarded_tracking_modules = guarded_modules
+            post_lookup_fn = module.post_lookup_tracker_fn
+            post_odist_fn = module.post_odist_tracker_fn
+            if post_lookup_fn is None or post_odist_fn is None:
+                raise RuntimeError(
+                    "Delta embedding tracker callbacks were not registered for "
+                    f"sharded embedding module {module._module_fqn}."
+                )
+            module.post_lookup_tracker_fn = self._wrap_tracker_fn(post_lookup_fn)
+            module.post_odist_tracker_fn = self._wrap_tracker_fn(post_odist_fn)
 
     def _wrap_tracker_fn(self, tracker_fn: Callable[..., Any]) -> Callable[..., Any]:
         def guarded_tracker_fn(*args: Any, **kwargs: Any) -> Any:
@@ -825,55 +840,32 @@ class DeltaEmbeddingDumper:
     def _collect_table_shard_infos(self) -> Dict[str, _TableShardInfo]:
         table_shard_infos: Dict[str, _TableShardInfo] = {}
         for module_fqn, module in self._tracker.tracked_modules.items():
-            for child_module in module.modules():
-                table_name_to_config = getattr(
-                    child_module, "_table_name_to_config", None
+            for table_name, table_config in module._table_name_to_config.items():
+                table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                table_shard_infos[table_fqn] = _merge_table_shard_info(
+                    table_shard_infos.get(table_fqn),
+                    _table_shard_info_from_config(table_config),
                 )
-                if table_name_to_config is not None:
-                    for table_name, table_config in table_name_to_config.items():
+            for lookup in _embedding_lookups(module):
+                for grouped_config in lookup.grouped_configs:
+                    for table_config in grouped_config.embedding_tables:
+                        table_name = table_config.name
+                        if not table_name:
+                            continue
                         table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
                         table_shard_infos[table_fqn] = _merge_table_shard_info(
                             table_shard_infos.get(table_fqn),
                             _table_shard_info_from_config(table_config),
                         )
-                for table_config in self._grouped_embedding_table_configs(child_module):
-                    table_name = getattr(table_config, "name", "")
-                    if not table_name:
-                        continue
-                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
-                    table_shard_infos[table_fqn] = _merge_table_shard_info(
-                        table_shard_infos.get(table_fqn),
-                        _table_shard_info_from_config(table_config),
-                    )
-                module_sharding_plan = getattr(
-                    child_module, "module_sharding_plan", None
+            for table_name, parameter_sharding in module.module_sharding_plan.items():
+                table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                table_shard_infos[table_fqn] = _merge_table_shard_info(
+                    table_shard_infos.get(table_fqn),
+                    _table_shard_info_from_parameter_sharding(
+                        parameter_sharding, self._rank
+                    ),
                 )
-                if module_sharding_plan is None:
-                    continue
-                for table_name, parameter_sharding in module_sharding_plan.items():
-                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
-                    table_shard_infos[table_fqn] = _merge_table_shard_info(
-                        table_shard_infos.get(table_fqn),
-                        _table_shard_info_from_parameter_sharding(
-                            parameter_sharding, self._rank
-                        ),
-                    )
         return table_shard_infos
-
-    def _grouped_embedding_table_configs(self, module: nn.Module) -> Iterable[Any]:
-        grouped_configs = []
-        module_config = getattr(module, "config", None)
-        if module_config is not None:
-            grouped_configs.append(module_config)
-        private_config = getattr(module, "_config", None)
-        if private_config is not None and private_config is not module_config:
-            grouped_configs.append(private_config)
-
-        for grouped_config in grouped_configs:
-            embedding_tables = getattr(grouped_config, "embedding_tables", None)
-            if embedding_tables is None:
-                continue
-            yield from embedding_tables
 
     def _validate_supported_table_sharding(
         self, table_shard_infos: Dict[str, _TableShardInfo]
@@ -901,17 +893,8 @@ class DeltaEmbeddingDumper:
         table_weights: Dict[str, _TableWeight] = {}
         table_shard_infos = self._table_shard_infos
         for module_fqn, module in self._tracker.tracked_modules.items():
-            lookups = getattr(module, "_lookups", None)
-            if lookups is None:
-                continue
-            for lookup in lookups:
-                lookup = getattr(lookup, "module", lookup)
-                named_parameters_by_table = getattr(
-                    lookup, "named_parameters_by_table", None
-                )
-                if named_parameters_by_table is None:
-                    continue
-                for table_name, table_value in named_parameters_by_table():
+            for lookup in _embedding_lookups(module):
+                for table_name, table_value in lookup.named_parameters_by_table():
                     table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
                     table_weights[table_fqn] = _local_table_weight(
                         table_value,

--- a/tzrec/utils/delta_embedding_dump.py
+++ b/tzrec/utils/delta_embedding_dump.py
@@ -11,7 +11,6 @@
 
 import os
 import re
-from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
@@ -23,10 +22,11 @@ from torch import nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
+from torchrec.distributed.model_tracker.delta_store import DeltaStoreTrec
 from torchrec.distributed.model_tracker.model_delta_tracker import (
-    ModelDeltaTrackerTrec,
+    ModelDeltaTracker as TorchRecModelDeltaTracker,
 )
-from torchrec.distributed.model_tracker.types import TrackingMode
+from torchrec.distributed.model_tracker.types import UniqueRows, UpdateMode
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig
@@ -330,12 +330,11 @@ def _embedding_table_fqn(module_fqn: str, module: nn.Module, table_name: str) ->
     return ".".join(filter(None, (module_fqn, table_segment, table_name)))
 
 
-class ModelDeltaTracker(ModelDeltaTrackerTrec):
+class ModelDeltaTracker(TorchRecModelDeltaTracker):
     """Track touched embedding IDs by owner-qualified table FQN.
 
-    TorchRec's tracker maps raw table names to FQNs globally, which collapses
-    same-named tables owned by different sharded modules. This specialization
-    uses the callback's owning module to keep their ID streams independent.
+    This ID-only tracker uses the lookup callback's owning module to keep
+    same-named tables in different sharded modules independent.
 
     Args:
         model: Sharded model whose sparse lookups should be tracked.
@@ -351,48 +350,50 @@ class ModelDeltaTracker(ModelDeltaTrackerTrec):
         delete_on_read: bool = True,
         auto_compact: bool = False,
     ) -> None:
-        self._feature_to_fqn_by_module: Dict[int, Dict[str, str]] = {}
-        super().__init__(
-            model,
-            consumers=consumers,
-            delete_on_read=delete_on_read,
-            auto_compact=auto_compact,
-            mode=TrackingMode.ID_ONLY,
-        )
+        consumer_names = consumers or [self.DEFAULT_CONSUMER]
+        self._delete_on_read = delete_on_read
+        self.per_consumer_batch_idx = {consumer: -1 for consumer in consumer_names}
+        self.curr_batch_idx = 0
+        self.curr_compact_index = 0
+        self.tracked_modules: Dict[str, nn.Module] = {}
+        self.fqn_to_feature_names: Dict[str, List[str]] = {}
+        self._feature_to_fqn_by_module: Dict[nn.Module, Dict[str, str]] = {}
+        self.store = DeltaStoreTrec(UpdateMode.NONE)
 
-    def fqn_to_feature_names(self) -> Dict[str, List[str]]:
-        """Return feature names keyed by owner-qualified table FQN."""
-        if self._fqn_to_feature_map:
-            return self._fqn_to_feature_map
-
-        fqn_to_feature_names: Dict[str, List[str]] = OrderedDict()
-        for named_fqn, module in self._model.named_modules():
+        for named_fqn, module in model.named_modules():
             if not isinstance(
                 module, (ShardedEmbeddingCollection, ShardedEmbeddingBagCollection)
             ):
                 continue
-            split_fqn = named_fqn.split(".")
-            if any(fqn_to_skip in split_fqn for fqn_to_skip in self._fqns_to_skip):
-                continue
 
             module_fqn = getattr(module, "_module_fqn", None)
             if not module_fqn:
-                module_fqn = self._clean_fqn_fn(named_fqn)
+                module_fqn = self._clean_module_fqn(named_fqn)
             self.tracked_modules[module_fqn] = module
 
             feature_to_fqn: Dict[str, str] = {}
             for table_name, config in module._table_name_to_config.items():
                 table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
-                if table_fqn in fqn_to_feature_names:
+                if table_fqn in self.fqn_to_feature_names:
                     raise ValueError(f"Duplicate embedding table FQN: {table_fqn}")
                 feature_names = list(config.feature_names)
-                fqn_to_feature_names[table_fqn] = feature_names
+                self.fqn_to_feature_names[table_fqn] = feature_names
                 for feature_name in feature_names:
                     feature_to_fqn[feature_name] = table_fqn
-            self._feature_to_fqn_by_module[id(module)] = feature_to_fqn
+            self._feature_to_fqn_by_module[module] = feature_to_fqn
 
-        self._fqn_to_feature_map = fqn_to_feature_names
-        return fqn_to_feature_names
+        for module in self.tracked_modules.values():
+            module.register_post_lookup_tracker_fn(self.record_lookup)
+            if auto_compact:
+                module.register_post_odist_tracker_fn(self.trigger_compaction)
+
+    @staticmethod
+    def _clean_module_fqn(fqn: str) -> str:
+        """Strip wrapper prefixes from a sharded module FQN."""
+        for prefix in ("_dmp_wrapped_module.module.", "module."):
+            if fqn.startswith(prefix):
+                return fqn[len(prefix) :]
+        return fqn
 
     def record_lookup(
         self,
@@ -411,7 +412,7 @@ class ModelDeltaTracker(ModelDeltaTrackerTrec):
         """
         if emb_module is None:
             raise ValueError("Embedding module is required for FQN delta tracking.")
-        feature_to_fqn = self._feature_to_fqn_by_module.get(id(emb_module))
+        feature_to_fqn = self._feature_to_fqn_by_module.get(emb_module)
         if feature_to_fqn is None:
             raise ValueError(
                 f"Unrecognized embedding module for FQN delta tracking: {emb_module}"
@@ -428,6 +429,83 @@ class ModelDeltaTracker(ModelDeltaTrackerTrec):
                 ids=torch.cat(ids),
                 states=None,
             )
+
+    def get_unique_ids(self, consumer: Optional[str] = None) -> Dict[str, torch.Tensor]:
+        """Return unique touched IDs keyed by table FQN.
+
+        Args:
+            consumer: Consumer whose unread IDs should be returned.
+
+        Returns:
+            Unique touched IDs keyed by table FQN.
+        """
+        return {
+            fqn: rows.ids for fqn, rows in self.get_unique(consumer=consumer).items()
+        }
+
+    def get_unique(
+        self,
+        consumer: Optional[str] = None,
+        top_percentage: Optional[float] = 1.0,
+        per_table_percentage: Optional[Dict[str, Tuple[float, str]]] = None,
+        sorted_by_indices: Optional[bool] = True,
+    ) -> Dict[str, UniqueRows]:
+        """Return unread unique touched IDs keyed by table FQN.
+
+        Args:
+            consumer: Consumer whose unread IDs should be returned.
+            top_percentage: Unused compatibility argument.
+            per_table_percentage: Unused compatibility argument.
+            sorted_by_indices: Unused compatibility argument.
+
+        Returns:
+            Unique touched rows keyed by table FQN.
+        """
+        consumer = consumer or self.DEFAULT_CONSUMER
+        assert consumer in self.per_consumer_batch_idx, (
+            f"consumer {consumer} not present in {self.per_consumer_batch_idx.values()}"
+        )
+
+        index_end = self.curr_batch_idx + 1
+        index_start = max(self.per_consumer_batch_idx.values())
+        if index_start < index_end:
+            self.store.compact(index_start, index_end)
+        tracker_rows = self.store.get_unique(
+            from_idx=self.per_consumer_batch_idx[consumer]
+        )
+        self.per_consumer_batch_idx[consumer] = index_end
+        if self._delete_on_read:
+            self.store.delete(up_to_idx=min(self.per_consumer_batch_idx.values()))
+        return tracker_rows
+
+    def step(self) -> None:
+        """Advance the current tracking batch."""
+        self.curr_batch_idx += 1
+
+    def trigger_compaction(self) -> None:
+        """Compact newly recorded IDs once per completed batch."""
+        if self.curr_compact_index >= self.curr_batch_idx:
+            return
+        start_idx = max(self.per_consumer_batch_idx.values())
+        end_idx = self.curr_batch_idx
+        if start_idx < end_idx:
+            self.store.compact(start_idx, end_idx)
+            self.curr_compact_index = end_idx
+
+    def clear(self, consumer: Optional[str] = None) -> None:
+        """Clear tracked IDs using TorchRec's consumer semantics.
+
+        Args:
+            consumer: Consumer to clear, or None to clear the whole store.
+        """
+        if consumer is None:
+            self.store.delete()
+            return
+        assert consumer in self.per_consumer_batch_idx, (
+            f"consumer {consumer} not found in {self.per_consumer_batch_idx.values()}"
+        )
+        if len(self.per_consumer_batch_idx) == 1:
+            self.store.delete()
 
 
 class DeltaEmbeddingDumper:
@@ -472,9 +550,6 @@ class DeltaEmbeddingDumper:
         self._table_shard_infos = self._collect_table_shard_infos()
         self._validate_supported_table_sharding(self._table_shard_infos)
         self._install_tracking_pause_guard()
-        self._fqn_to_feature_names: Dict[str, List[str]] = {}
-        self._fqn_to_feature_names.update(self._tracker.fqn_to_feature_names())
-
         logger.info(
             "Delta embedding dump enabled: interval=%s output_dir=%s "
             "rank=%s/%s tables=%s",
@@ -482,7 +557,7 @@ class DeltaEmbeddingDumper:
             self._output_dir,
             self._rank,
             self._world_size,
-            sorted(self._fqn_to_feature_names.keys()),
+            sorted(self._tracker.fqn_to_feature_names),
         )
 
     def clear(self) -> None:
@@ -608,7 +683,7 @@ class DeltaEmbeddingDumper:
 
     def _install_tracking_pause_guard(self) -> None:
         guarded_modules = getattr(self, "_guarded_tracking_modules", set())
-        for module in self._tracker.get_tracked_modules().values():
+        for module in self._tracker.tracked_modules.values():
             if id(module) in guarded_modules:
                 continue
             has_tracker_fn = False
@@ -657,7 +732,9 @@ class DeltaEmbeddingDumper:
                 dynamic_modules=dynamic_modules,
                 flushed_module_ids=flushed_module_ids,
             )
-            feature_name = _feature_name(self._fqn_to_feature_names.get(fqn, []))
+            feature_name = _feature_name(
+                self._tracker.fqn_to_feature_names.get(fqn, [])
+            )
             num_rows += self._append_table_chunk(
                 table_chunks,
                 global_step=global_step,
@@ -747,7 +824,7 @@ class DeltaEmbeddingDumper:
 
     def _collect_table_shard_infos(self) -> Dict[str, _TableShardInfo]:
         table_shard_infos: Dict[str, _TableShardInfo] = {}
-        for module_fqn, module in self._tracker.get_tracked_modules().items():
+        for module_fqn, module in self._tracker.tracked_modules.items():
             for child_module in module.modules():
                 table_name_to_config = getattr(
                     child_module, "_table_name_to_config", None
@@ -823,7 +900,7 @@ class DeltaEmbeddingDumper:
     def _collect_table_weights(self) -> Dict[str, _TableWeight]:
         table_weights: Dict[str, _TableWeight] = {}
         table_shard_infos = self._table_shard_infos
-        for module_fqn, module in self._tracker.get_tracked_modules().items():
+        for module_fqn, module in self._tracker.tracked_modules.items():
             lookups = getattr(module, "_lookups", None)
             if lookups is None:
                 continue
@@ -848,7 +925,7 @@ class DeltaEmbeddingDumper:
         except ImportError:
             return {}
         modules: Dict[str, nn.Module] = {}
-        for module_fqn, module in self._tracker.get_tracked_modules().items():
+        for module_fqn, module in self._tracker.tracked_modules.items():
             for dynamic_module in get_dynamic_emb_module(module):
                 for table_name in dynamic_module.table_names:
                     table_fqn = _embedding_table_fqn(module_fqn, module, table_name)

--- a/tzrec/utils/delta_embedding_dump.py
+++ b/tzrec/utils/delta_embedding_dump.py
@@ -11,6 +11,7 @@
 
 import os
 import re
+from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
@@ -20,10 +21,13 @@ import pyarrow.parquet as pq
 import torch
 from torch import nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
 from torchrec.distributed.model_tracker.model_delta_tracker import (
     ModelDeltaTrackerTrec,
 )
 from torchrec.distributed.model_tracker.types import TrackingMode
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig
 from tzrec.utils.logging_util import logger
@@ -306,6 +310,126 @@ def _local_table_weight(
     raise TypeError(f"Unsupported embedding table value type: {type(value)}")
 
 
+def _embedding_table_fqn(module_fqn: str, module: nn.Module, table_name: str) -> str:
+    """Build a state-dict-style table FQN for a sharded sparse module.
+
+    Args:
+        module_fqn: FQN of the owning sharded embedding collection.
+        module: Owning sharded embedding collection.
+        table_name: Raw table name within the collection.
+
+    Returns:
+        Owner-qualified table FQN.
+    """
+    if isinstance(module, ShardedEmbeddingBagCollection):
+        table_segment = "embedding_bags"
+    elif isinstance(module, ShardedEmbeddingCollection):
+        table_segment = "embeddings"
+    else:
+        raise TypeError(f"Unsupported tracked embedding module: {type(module)}")
+    return ".".join(filter(None, (module_fqn, table_segment, table_name)))
+
+
+class ModelDeltaTracker(ModelDeltaTrackerTrec):
+    """Track touched embedding IDs by owner-qualified table FQN.
+
+    TorchRec's tracker maps raw table names to FQNs globally, which collapses
+    same-named tables owned by different sharded modules. This specialization
+    uses the callback's owning module to keep their ID streams independent.
+
+    Args:
+        model: Sharded model whose sparse lookups should be tracked.
+        consumers: Independent consumers of the tracked ID stream.
+        delete_on_read: Whether to delete IDs after all consumers read them.
+        auto_compact: Whether to compact tracked IDs during communication.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        consumers: Optional[List[str]] = None,
+        delete_on_read: bool = True,
+        auto_compact: bool = False,
+    ) -> None:
+        self._feature_to_fqn_by_module: Dict[int, Dict[str, str]] = {}
+        super().__init__(
+            model,
+            consumers=consumers,
+            delete_on_read=delete_on_read,
+            auto_compact=auto_compact,
+            mode=TrackingMode.ID_ONLY,
+        )
+
+    def fqn_to_feature_names(self) -> Dict[str, List[str]]:
+        """Return feature names keyed by owner-qualified table FQN."""
+        if self._fqn_to_feature_map:
+            return self._fqn_to_feature_map
+
+        fqn_to_feature_names: Dict[str, List[str]] = OrderedDict()
+        for named_fqn, module in self._model.named_modules():
+            if not isinstance(
+                module, (ShardedEmbeddingCollection, ShardedEmbeddingBagCollection)
+            ):
+                continue
+            split_fqn = named_fqn.split(".")
+            if any(fqn_to_skip in split_fqn for fqn_to_skip in self._fqns_to_skip):
+                continue
+
+            module_fqn = getattr(module, "_module_fqn", None)
+            if not module_fqn:
+                module_fqn = self._clean_fqn_fn(named_fqn)
+            self.tracked_modules[module_fqn] = module
+
+            feature_to_fqn: Dict[str, str] = {}
+            for table_name, config in module._table_name_to_config.items():
+                table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                if table_fqn in fqn_to_feature_names:
+                    raise ValueError(f"Duplicate embedding table FQN: {table_fqn}")
+                feature_names = list(config.feature_names)
+                fqn_to_feature_names[table_fqn] = feature_names
+                for feature_name in feature_names:
+                    feature_to_fqn[feature_name] = table_fqn
+            self._feature_to_fqn_by_module[id(module)] = feature_to_fqn
+
+        self._fqn_to_feature_map = fqn_to_feature_names
+        return fqn_to_feature_names
+
+    def record_lookup(
+        self,
+        kjt: KeyedJaggedTensor,
+        states: torch.Tensor,
+        emb_module: Optional[nn.Module] = None,
+        raw_ids: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Record touched IDs using the owning module's table FQNs.
+
+        Args:
+            kjt: Sparse features used by the lookup.
+            states: Lookup output, unused in ID-only tracking mode.
+            emb_module: Sharded module that performed the lookup.
+            raw_ids: Optional unprocessed IDs, unused by delta embedding dump.
+        """
+        if emb_module is None:
+            raise ValueError("Embedding module is required for FQN delta tracking.")
+        feature_to_fqn = self._feature_to_fqn_by_module.get(id(emb_module))
+        if feature_to_fqn is None:
+            raise ValueError(
+                f"Unrecognized embedding module for FQN delta tracking: {emb_module}"
+            )
+
+        ids_by_fqn: Dict[str, List[torch.Tensor]] = {}
+        for feature_name in kjt.keys():
+            table_fqn = feature_to_fqn[feature_name]
+            ids_by_fqn.setdefault(table_fqn, []).append(kjt[feature_name].values())
+        for table_fqn, ids in ids_by_fqn.items():
+            self.store.append(
+                batch_idx=self.curr_batch_idx,
+                fqn=table_fqn,
+                ids=torch.cat(ids),
+                states=None,
+            )
+
+
 class DeltaEmbeddingDumper:
     """Dump touched embedding ids and latest embedding rows during training.
 
@@ -339,21 +463,15 @@ class DeltaEmbeddingDumper:
         self._tracking_pause_depth = 0
         os.makedirs(self._output_dir, exist_ok=True)
 
-        self._table_shard_infos = self._collect_table_shard_infos()
-        self._validate_supported_table_sharding(self._table_shard_infos)
-        self._tracker = ModelDeltaTrackerTrec(
+        self._tracker = ModelDeltaTracker(
             model,
             consumers=[_CONSUMER],
             delete_on_read=True,
             auto_compact=True,
-            mode=TrackingMode.ID_ONLY,
         )
+        self._table_shard_infos = self._collect_table_shard_infos()
+        self._validate_supported_table_sharding(self._table_shard_infos)
         self._install_tracking_pause_guard()
-        self._table_to_fqn: Dict[str, str] = {}
-        self._table_to_fqn.update(self._tracker.table_to_fqn)
-        self._fqn_to_table: Dict[str, str] = {
-            fqn: table for table, fqn in self._table_to_fqn.items()
-        }
         self._fqn_to_feature_names: Dict[str, List[str]] = {}
         self._fqn_to_feature_names.update(self._tracker.fqn_to_feature_names())
 
@@ -364,7 +482,7 @@ class DeltaEmbeddingDumper:
             self._output_dir,
             self._rank,
             self._world_size,
-            sorted(self._table_to_fqn.keys()),
+            sorted(self._fqn_to_feature_names.keys()),
         )
 
     def clear(self) -> None:
@@ -523,21 +641,17 @@ class DeltaEmbeddingDumper:
         dynamic_modules: Dict[str, nn.Module],
     ) -> int:
         num_rows = 0
-        # A dynamic module hosting multiple tables is shared across their
-        # table_name keys; flush() flushes the whole module, so track which
+        # A dynamic module hosting multiple tables is shared across their FQN
+        # keys; flush() flushes the whole module, so track which
         # modules were already flushed this dump and skip the redundant repeats.
         flushed_module_ids: Set[int] = set()
         for fqn, unique_rows in self._tracker.get_unique(_CONSUMER).items():
             ids = unique_rows.ids
             if ids.numel() == 0:
                 continue
-            table_name = self._fqn_to_table.get(fqn)
-            if table_name is None:
-                logger.warning("Skip delta rows for unknown table fqn: %s", fqn)
-                continue
             ids = ids.unique(sorted=True)
             embeddings, key_ids = self._lookup_embeddings(
-                table_name,
+                fqn,
                 ids,
                 table_weights=table_weights,
                 dynamic_modules=dynamic_modules,
@@ -557,22 +671,22 @@ class DeltaEmbeddingDumper:
 
     def _lookup_embeddings(
         self,
-        table_name: str,
+        fqn: str,
         ids: torch.Tensor,
         table_weights: Dict[str, _TableWeight],
         dynamic_modules: Dict[str, nn.Module],
         flushed_module_ids: Optional[Set[int]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        dynamic_module = dynamic_modules.get(table_name)
+        dynamic_module = dynamic_modules.get(fqn)
         if dynamic_module is not None:
             return self._lookup_dynamic_embeddings(
-                dynamic_module, table_name, ids, flushed_module_ids
+                dynamic_module, fqn, ids, flushed_module_ids
             )
-        if table_name not in table_weights:
-            raise KeyError(f"Embedding table {table_name} not found in sharded model.")
-        table_weight = table_weights[table_name]
-        _validate_table_shard_info(table_name, table_weight.shard_info)
-        self._validate_row_shard_metadata(table_name, table_weight.shard_info)
+        if fqn not in table_weights:
+            raise KeyError(f"Embedding table {fqn} not found in sharded model.")
+        table_weight = table_weights[fqn]
+        _validate_table_shard_info(fqn, table_weight.shard_info)
+        self._validate_row_shard_metadata(fqn, table_weight.shard_info)
         weight = table_weight.tensor
         ids = ids.to(weight.device, dtype=torch.long)
         if ids.numel() == 0:
@@ -587,7 +701,7 @@ class DeltaEmbeddingDumper:
             logger.warning(
                 "Skip %s ids outside table %s row range [0, %s).",
                 int((~valid_mask).sum().item()),
-                table_name,
+                fqn,
                 weight.size(0),
             )
         local_ids = ids[valid_mask]
@@ -597,7 +711,7 @@ class DeltaEmbeddingDumper:
     def _lookup_dynamic_embeddings(
         self,
         dynamic_module: nn.Module,
-        table_name: str,
+        fqn: str,
         ids: torch.Tensor,
         flushed_module_ids: Optional[Set[int]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -613,6 +727,7 @@ class DeltaEmbeddingDumper:
             dynamic_module.flush()
             if flushed_module_ids is not None:
                 flushed_module_ids.add(id(dynamic_module))
+        table_name = fqn.rsplit(".", maxsplit=1)[-1]
         table_id = dynamic_module.table_names.index(table_name)
         device = torch.device(f"cuda:{torch.cuda.current_device()}")
         ids = ids.to(device=device, dtype=torch.int64)
@@ -626,38 +741,46 @@ class DeltaEmbeddingDumper:
             logger.warning(
                 "Skip %s missing dynamic embedding ids for table %s.",
                 int((~founds).sum().item()),
-                table_name,
+                fqn,
             )
         return values[founds, :emb_dim].detach(), ids[founds]
 
     def _collect_table_shard_infos(self) -> Dict[str, _TableShardInfo]:
         table_shard_infos: Dict[str, _TableShardInfo] = {}
-        for module in self._model.modules():
-            table_name_to_config = getattr(module, "_table_name_to_config", None)
-            if table_name_to_config is not None:
-                for table_name, table_config in table_name_to_config.items():
-                    table_shard_infos[table_name] = _merge_table_shard_info(
-                        table_shard_infos.get(table_name),
+        for module_fqn, module in self._tracker.get_tracked_modules().items():
+            for child_module in module.modules():
+                table_name_to_config = getattr(
+                    child_module, "_table_name_to_config", None
+                )
+                if table_name_to_config is not None:
+                    for table_name, table_config in table_name_to_config.items():
+                        table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                        table_shard_infos[table_fqn] = _merge_table_shard_info(
+                            table_shard_infos.get(table_fqn),
+                            _table_shard_info_from_config(table_config),
+                        )
+                for table_config in self._grouped_embedding_table_configs(child_module):
+                    table_name = getattr(table_config, "name", "")
+                    if not table_name:
+                        continue
+                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                    table_shard_infos[table_fqn] = _merge_table_shard_info(
+                        table_shard_infos.get(table_fqn),
                         _table_shard_info_from_config(table_config),
                     )
-            for table_config in self._grouped_embedding_table_configs(module):
-                table_name = getattr(table_config, "name", "")
-                if not table_name:
+                module_sharding_plan = getattr(
+                    child_module, "module_sharding_plan", None
+                )
+                if module_sharding_plan is None:
                     continue
-                table_shard_infos[table_name] = _merge_table_shard_info(
-                    table_shard_infos.get(table_name),
-                    _table_shard_info_from_config(table_config),
-                )
-            module_sharding_plan = getattr(module, "module_sharding_plan", None)
-            if module_sharding_plan is None:
-                continue
-            for table_name, parameter_sharding in module_sharding_plan.items():
-                table_shard_infos[table_name] = _merge_table_shard_info(
-                    table_shard_infos.get(table_name),
-                    _table_shard_info_from_parameter_sharding(
-                        parameter_sharding, self._rank
-                    ),
-                )
+                for table_name, parameter_sharding in module_sharding_plan.items():
+                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                    table_shard_infos[table_fqn] = _merge_table_shard_info(
+                        table_shard_infos.get(table_fqn),
+                        _table_shard_info_from_parameter_sharding(
+                            parameter_sharding, self._rank
+                        ),
+                    )
         return table_shard_infos
 
     def _grouped_embedding_table_configs(self, module: nn.Module) -> Iterable[Any]:
@@ -678,11 +801,11 @@ class DeltaEmbeddingDumper:
     def _validate_supported_table_sharding(
         self, table_shard_infos: Dict[str, _TableShardInfo]
     ) -> None:
-        for table_name, shard_info in table_shard_infos.items():
-            _validate_table_shard_info(table_name, shard_info)
+        for table_fqn, shard_info in table_shard_infos.items():
+            _validate_table_shard_info(table_fqn, shard_info)
 
     def _validate_row_shard_metadata(
-        self, table_name: str, shard_info: _TableShardInfo
+        self, table_fqn: str, shard_info: _TableShardInfo
     ) -> None:
         if (
             self._world_size > 1
@@ -693,14 +816,14 @@ class DeltaEmbeddingDumper:
         ):
             raise ValueError(
                 "delta_embedding_dump_config cannot convert local row ids to "
-                f"global key ids for row-wise sharded table {table_name}, because "
+                f"global key ids for row-wise sharded table {table_fqn}, because "
                 "TorchRec shard metadata is missing."
             )
 
     def _collect_table_weights(self) -> Dict[str, _TableWeight]:
         table_weights: Dict[str, _TableWeight] = {}
         table_shard_infos = self._table_shard_infos
-        for module in self._model.modules():
+        for module_fqn, module in self._tracker.get_tracked_modules().items():
             lookups = getattr(module, "_lookups", None)
             if lookups is None:
                 continue
@@ -712,9 +835,10 @@ class DeltaEmbeddingDumper:
                 if named_parameters_by_table is None:
                     continue
                 for table_name, table_value in named_parameters_by_table():
-                    table_weights[table_name] = _local_table_weight(
+                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                    table_weights[table_fqn] = _local_table_weight(
                         table_value,
-                        table_shard_infos.get(table_name),
+                        table_shard_infos.get(table_fqn),
                     )
         return table_weights
 
@@ -724,13 +848,11 @@ class DeltaEmbeddingDumper:
         except ImportError:
             return {}
         modules: Dict[str, nn.Module] = {}
-        seen = set()
-        for dynamic_module in get_dynamic_emb_module(self._model):
-            if id(dynamic_module) in seen:
-                continue
-            seen.add(id(dynamic_module))
-            for table_name in dynamic_module.table_names:
-                modules[table_name] = dynamic_module
+        for module_fqn, module in self._tracker.get_tracked_modules().items():
+            for dynamic_module in get_dynamic_emb_module(module):
+                for table_name in dynamic_module.table_names:
+                    table_fqn = _embedding_table_fqn(module_fqn, module, table_name)
+                    modules[table_fqn] = dynamic_module
         return modules
 
     def _append_table_chunk(

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -22,10 +22,18 @@ import pyarrow.parquet as pq
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
 from torch import nn
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.sharding_spec import EnumerableShardingSpec
+from torch.distributed.tensor import DTensor
 from torchrec import KeyedJaggedTensor
 from torchrec.distributed import DistributedModelParallel, ShardingEnv
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
-from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
@@ -36,7 +44,7 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import ParameterSharding, ShardingType
 from torchrec.modules.embedding_configs import (
     EmbeddingBagConfig,
     EmbeddingConfig,
@@ -46,6 +54,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
     EmbeddingCollection,
 )
+from torchrec.types import DataType
 
 from tzrec.protos import feature_pb2
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig
@@ -55,6 +64,7 @@ from tzrec.utils.delta_embedding_dump import (
     _DELTA_DUMP_SCHEMA,
     DeltaEmbeddingDumper,
     ModelDeltaTracker,
+    _local_table_weight,
     _table_shard_info_from_config,
     _TableShardInfo,
     _TableWeight,
@@ -445,14 +455,16 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
                 )
 
     def test_row_wise_shard_info_uses_row_offset(self):
-        table_config = SimpleNamespace(
+        table_config = ShardedEmbeddingTable(
             local_rows=16,
             local_cols=8,
             num_embeddings=64,
             embedding_dim=8,
-            local_metadata=SimpleNamespace(
+            name="user_emb",
+            local_metadata=ShardMetadata(
                 shard_offsets=[32, 0],
                 shard_sizes=[16, 8],
+                placement="rank:1/cuda:1",
             ),
         )
         shard_info = _table_shard_info_from_config(table_config)
@@ -461,14 +473,16 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         self.assertEqual(shard_info.global_cols, 8)
 
     def test_column_wise_shard_info_fails_fast(self):
-        table_config = SimpleNamespace(
+        table_config = ShardedEmbeddingTable(
             local_rows=64,
             local_cols=4,
             num_embeddings=64,
             embedding_dim=8,
-            local_metadata=SimpleNamespace(
+            name="user_emb",
+            local_metadata=ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[64, 4],
+                placement="rank:0/cuda:0",
             ),
         )
         shard_info = _table_shard_info_from_config(table_config)
@@ -741,19 +755,19 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
     def test_collect_table_weights_uses_owner_fqn_keys(self):
         ebc_module = torch.nn.Module()
         ec_module = torch.nn.Module()
+        ebc_lookup = mock.Mock(spec=GroupedPooledEmbeddingsLookup)
+        ebc_lookup.named_parameters_by_table.return_value = [
+            ("shared", torch.tensor([[1.0, 2.0]]))
+        ]
+        ec_lookup = mock.Mock(spec=GroupedPooledEmbeddingsLookup)
+        ec_lookup.named_parameters_by_table.return_value = [
+            ("shared", torch.tensor([[3.0, 4.0]]))
+        ]
         ebc_module._lookups = [
-            SimpleNamespace(
-                named_parameters_by_table=lambda: [
-                    ("shared", torch.tensor([[1.0, 2.0]]))
-                ]
-            )
+            ebc_lookup,
         ]
         ec_module._lookups = [
-            SimpleNamespace(
-                named_parameters_by_table=lambda: [
-                    ("shared", torch.tensor([[3.0, 4.0]]))
-                ]
-            )
+            ec_lookup,
         ]
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._table_shard_infos = {}
@@ -784,6 +798,31 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
             table_weights["model.ec.shared"].tensor,
             torch.tensor([[3.0, 4.0]]),
         )
+
+    def test_collect_table_weights_rejects_unsupported_lookup(self):
+        sharded_module = torch.nn.Module()
+        sharded_module._lookups = [torch.nn.Identity()]
+        dumper = object.__new__(DeltaEmbeddingDumper)
+        dumper._table_shard_infos = {}
+        dumper._tracker = SimpleNamespace(tracked_modules={"model.ebc": sharded_module})
+
+        with self.assertRaisesRegex(TypeError, "Unsupported embedding lookup"):
+            dumper._collect_table_weights()
+
+    def test_local_table_weight_rejects_unsupported_weight(self):
+        with self.assertRaisesRegex(TypeError, "Unsupported embedding table value"):
+            _local_table_weight(object())
+
+    def test_local_table_weight_materializes_dtensor(self):
+        local_tensor = torch.tensor([[1.0, 2.0]])
+        dtensor = mock.Mock(spec=DTensor)
+        dtensor.to_local.return_value = local_tensor
+
+        table_weight = _local_table_weight(dtensor)
+
+        self.assertIs(table_weight.tensor, local_tensor)
+        self.assertEqual(table_weight.shard_info.local_rows, 1)
+        self.assertEqual(table_weight.shard_info.local_cols, 2)
 
     @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
     def test_collect_dynamic_modules_uses_owner_fqn_keys(self):
@@ -919,36 +958,41 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         self.assertEqual(odist_fn.call_args_list, [mock.call(), mock.call()])
 
     def test_collect_table_shard_infos_prefers_grouped_embedding_metadata(self):
-        original_config_module = torch.nn.Module()
-        original_config_module._table_name_to_config = {
-            "user_emb": SimpleNamespace(
-                local_rows=16,
-                local_cols=8,
-                num_embeddings=64,
-                embedding_dim=8,
-            )
-        }
-        grouped_config_module = torch.nn.Module()
-        grouped_config_module._config = SimpleNamespace(
+        grouped_config = GroupedEmbeddingConfig(
+            data_type=DataType.FP32,
+            pooling=PoolingType.SUM,
+            is_weighted=False,
+            has_feature_processor=False,
+            compute_kernel=EmbeddingComputeKernel.FUSED,
             embedding_tables=[
-                SimpleNamespace(
+                ShardedEmbeddingTable(
                     name="user_emb",
                     local_rows=16,
                     local_cols=8,
                     num_embeddings=64,
                     embedding_dim=8,
-                    local_metadata=SimpleNamespace(
+                    local_metadata=ShardMetadata(
                         shard_offsets=[32, 0],
                         shard_sizes=[16, 8],
+                        placement="rank:1/cuda:1",
                     ),
                 )
-            ]
+            ],
         )
+        grouped_lookup = mock.Mock(spec=GroupedPooledEmbeddingsLookup)
+        grouped_lookup.grouped_configs = [grouped_config]
+        owner_module = torch.nn.Module()
+        owner_module._table_name_to_config = {
+            "user_emb": EmbeddingBagConfig(
+                name="user_emb",
+                num_embeddings=64,
+                embedding_dim=8,
+                feature_names=["user_id"],
+            )
+        }
+        owner_module.module_sharding_plan = {}
+        owner_module._lookups = [grouped_lookup]
         dumper = object.__new__(DeltaEmbeddingDumper)
-        owner_module = torch.nn.Sequential(
-            original_config_module,
-            grouped_config_module,
-        )
         dumper._tracker = SimpleNamespace(tracked_modules={"model.ebc": owner_module})
         with mock.patch(
             "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
@@ -964,24 +1008,26 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
     def test_collect_table_shard_infos_falls_back_to_sharding_plan(self):
         sharded_module = torch.nn.Module()
         sharded_module._table_name_to_config = {
-            "adgroup_id_emb": SimpleNamespace(
-                local_rows=16,
-                local_cols=8,
+            "adgroup_id_emb": EmbeddingBagConfig(
+                name="adgroup_id_emb",
                 num_embeddings=64,
                 embedding_dim=8,
+                feature_names=["adgroup_id"],
             )
         }
         sharded_module.module_sharding_plan = {
-            "adgroup_id_emb": SimpleNamespace(
+            "adgroup_id_emb": ParameterSharding(
+                sharding_type=ShardingType.ROW_WISE.value,
+                compute_kernel=EmbeddingComputeKernel.FUSED.value,
                 ranks=None,
-                sharding_spec=SimpleNamespace(
-                    shards=[
-                        SimpleNamespace(
+                sharding_spec=EnumerableShardingSpec(
+                    [
+                        ShardMetadata(
                             shard_offsets=[0, 0],
                             shard_sizes=[32, 8],
                             placement="rank:0/cuda:0",
                         ),
-                        SimpleNamespace(
+                        ShardMetadata(
                             shard_offsets=[32, 0],
                             shard_sizes=[32, 8],
                             placement="rank:1/cuda:1",
@@ -990,6 +1036,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
                 ),
             )
         }
+        sharded_module._lookups = []
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._rank = 0
         dumper._tracker = SimpleNamespace(tracked_modules={"model.ebc": sharded_module})

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -854,6 +854,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         self.assertEqual(table_weight.shard_info.local_cols, 2)
 
     @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
+    @mark_ci_scope("gpu")
     def test_collect_dynamic_modules_uses_owner_fqn_keys(self):
         ebc_module = torch.nn.Module()
         ec_module = torch.nn.Module()

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -24,6 +24,7 @@ from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
 from torch import nn
 from torchrec import KeyedJaggedTensor
 from torchrec.distributed import DistributedModelParallel, ShardingEnv
+from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner import (
@@ -36,8 +37,15 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessTestBase,
 )
 from torchrec.distributed.types import ShardingType
-from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.embedding_configs import (
+    EmbeddingBagConfig,
+    EmbeddingConfig,
+    PoolingType,
+)
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+)
 
 from tzrec.protos import feature_pb2
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig
@@ -46,6 +54,7 @@ from tzrec.utils import config_util
 from tzrec.utils.delta_embedding_dump import (
     _DELTA_DUMP_SCHEMA,
     DeltaEmbeddingDumper,
+    ModelDeltaTracker,
     _table_shard_info_from_config,
     _TableShardInfo,
     _TableWeight,
@@ -61,6 +70,13 @@ _SHARDED_FEATURE_NAME = "feature_1"
 _SHARDED_NUM_EMBEDDINGS = 16
 _SHARDED_EMBEDDING_DIM = 4
 _SHARDED_INPUT_IDS = [0, 2, 8, 9, 15]
+_SHARED_TABLE_NAME = "shared_table"
+_SHARED_EBC_FEATURE_NAME = "deep_feature"
+_SHARED_EC_FEATURE_NAME = "sequence_feature"
+_SHARED_EBC_INPUT_IDS = [1, 2]
+_SHARED_EC_INPUT_IDS = [5, 6]
+_SHARED_EBC_EMBEDDING_DIM = 4
+_SHARED_EC_EMBEDDING_DIM = 8
 
 
 class _DeltaDumpEBCModel(nn.Module):
@@ -81,6 +97,39 @@ class _DeltaDumpEBCModel(nn.Module):
 
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
         return self.ebc(features).values()
+
+
+class _SharedTableECAndEBCModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name=_SHARED_TABLE_NAME,
+                    num_embeddings=_SHARDED_NUM_EMBEDDINGS,
+                    embedding_dim=_SHARED_EBC_EMBEDDING_DIM,
+                    feature_names=[_SHARED_EBC_FEATURE_NAME],
+                    pooling=PoolingType.SUM,
+                )
+            ],
+            device=torch.device("meta"),
+        )
+        self.ec = EmbeddingCollection(
+            tables=[
+                EmbeddingConfig(
+                    name=_SHARED_TABLE_NAME,
+                    num_embeddings=_SHARDED_NUM_EMBEDDINGS,
+                    embedding_dim=_SHARED_EC_EMBEDDING_DIM,
+                    feature_names=[_SHARED_EC_FEATURE_NAME],
+                )
+            ],
+            device=torch.device("meta"),
+        )
+
+    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
+        pooled = self.ebc(features).values().sum()
+        sequence = self.ec(features)[_SHARED_EC_FEATURE_NAME].values().sum()
+        return pooled + sequence
 
 
 class _FakeDynamicTables:
@@ -146,6 +195,20 @@ def _sharded_features(rank: int) -> KeyedJaggedTensor:
     )
 
 
+def _shared_table_features(rank: int) -> KeyedJaggedTensor:
+    device = torch.device(f"cuda:{rank}")
+    values = _SHARED_EBC_INPUT_IDS + _SHARED_EC_INPUT_IDS
+    return KeyedJaggedTensor.from_offsets_sync(
+        keys=[_SHARED_EBC_FEATURE_NAME, _SHARED_EC_FEATURE_NAME],
+        values=torch.tensor(values, device=device, dtype=torch.int64),
+        offsets=torch.tensor(
+            [0, len(_SHARED_EBC_INPUT_IDS), len(values)],
+            device=device,
+            dtype=torch.int64,
+        ),
+    )
+
+
 def _assert_sharded_dump_file(rank: int, output_path: str, dumper) -> None:
     testcase = unittest.TestCase()
     testcase.assertTrue(os.path.exists(output_path))
@@ -158,7 +221,9 @@ def _assert_sharded_dump_file(rank: int, output_path: str, dumper) -> None:
     )
     testcase.assertEqual(set(table["source"].to_pylist()), {"model_delta_tracker"})
 
-    table_weight = dumper._collect_table_weights()[_SHARDED_TABLE_NAME]
+    table_weight = dumper._collect_table_weights()[
+        f"ebc.embedding_bags.{_SHARDED_TABLE_NAME}"
+    ]
     expected_key_ids = [
         key_id
         for key_id in _SHARDED_INPUT_IDS
@@ -205,6 +270,95 @@ def _run_sharded_delta_embedding_dump(rank: int, world_size: int, output_dir: st
         unittest.TestCase().assertIsNotNone(output_path)
         _assert_sharded_dump_file(rank, output_path, dumper)
         torch.distributed.barrier()
+
+
+def _run_shared_table_fqn_delta_embedding_dump(
+    rank: int, world_size: int, output_dir: str
+):
+    with MultiProcessContext(rank=rank, world_size=world_size, backend="nccl") as ctx:
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+        model = _SharedTableECAndEBCModel()
+        sharders = [
+            EmbeddingBagCollectionSharder(),
+            EmbeddingCollectionSharder(),
+        ]
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size, "cuda"),
+        )
+        plan = planner.collective_plan(model, sharders, ctx.pg)
+        sharded_model = DistributedModelParallel(
+            module=model,
+            device=device,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=sharders,
+        )
+        dumper = DeltaEmbeddingDumper(
+            sharded_model,
+            DeltaEmbeddingDumpConfig(
+                dump_interval_steps=1,
+                output_dir=output_dir,
+                file_prefix="delta",
+            ),
+            output_dir,
+            device,
+            [],
+        )
+
+        sharded_model(_shared_table_features(rank)).backward()
+        output_path = dumper.dump(1)
+        testcase = unittest.TestCase()
+        testcase.assertIsNotNone(output_path)
+        table = pq.read_table(output_path)
+
+        ebc_fqn = f"ebc.embedding_bags.{_SHARED_TABLE_NAME}"
+        ec_fqn = f"ec.embeddings.{_SHARED_TABLE_NAME}"
+        testcase.assertEqual(set(table["table_fqn"].to_pylist()), {ebc_fqn, ec_fqn})
+        testcase.assertEqual(
+            set(dumper._tracker.fqn_to_feature_names()),
+            {ebc_fqn, ec_fqn},
+        )
+        table_weights = dumper._collect_table_weights()
+        testcase.assertEqual(set(table_weights), {ebc_fqn, ec_fqn})
+        testcase.assertEqual(set(dumper._table_shard_infos), {ebc_fqn, ec_fqn})
+        testcase.assertEqual(
+            dumper._table_shard_infos[ebc_fqn].global_cols,
+            _SHARED_EBC_EMBEDDING_DIM,
+        )
+        testcase.assertEqual(
+            dumper._table_shard_infos[ec_fqn].global_cols,
+            _SHARED_EC_EMBEDDING_DIM,
+        )
+
+        expected_ids = {
+            ebc_fqn: _SHARED_EBC_INPUT_IDS,
+            ec_fqn: _SHARED_EC_INPUT_IDS,
+        }
+        expected_features = {
+            ebc_fqn: _SHARED_EBC_FEATURE_NAME,
+            ec_fqn: _SHARED_EC_FEATURE_NAME,
+        }
+        for table_fqn in (ebc_fqn, ec_fqn):
+            owner_rows = table.filter(pa.compute.equal(table["table_fqn"], table_fqn))
+            key_ids = owner_rows["key_id"].to_pylist()
+            testcase.assertEqual(key_ids, expected_ids[table_fqn])
+            testcase.assertEqual(
+                set(owner_rows["feature_name"].to_pylist()),
+                {expected_features[table_fqn]},
+            )
+            expected_embeddings = (
+                table_weights[table_fqn]
+                .tensor[torch.tensor(key_ids, device=device)]
+                .detach()
+                .cpu()
+                .to(torch.float32)
+                .tolist()
+            )
+            testcase.assertEqual(
+                owner_rows["embedding"].to_pylist(),
+                expected_embeddings,
+            )
 
 
 class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
@@ -463,13 +617,12 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
 
     def test_tracker_uses_auto_compact(self):
         tracker = mock.MagicMock()
-        tracker.table_to_fqn = {}
         tracker.fqn_to_feature_names.return_value = {}
         tracker.get_tracked_modules.return_value = {}
         with (
             tempfile.TemporaryDirectory() as tmp_dir,
             mock.patch(
-                "tzrec.utils.delta_embedding_dump.ModelDeltaTrackerTrec",
+                "tzrec.utils.delta_embedding_dump.ModelDeltaTracker",
                 return_value=tracker,
             ) as tracker_cls,
         ):
@@ -482,6 +635,129 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
             )
 
         self.assertTrue(tracker_cls.call_args.kwargs["auto_compact"])
+
+    def test_model_delta_tracker_records_same_table_name_by_owner_fqn(self):
+        tracker = object.__new__(ModelDeltaTracker)
+        ebc_module = torch.nn.Module()
+        ec_module = torch.nn.Module()
+        ebc_fqn = "model.ebc.embedding_bags.shared"
+        ec_fqn = "model.ec.embeddings.shared"
+        tracker._feature_to_fqn_by_module = {
+            id(ebc_module): {"deep_feature": ebc_fqn},
+            id(ec_module): {"sequence_feature": ec_fqn},
+        }
+        tracker.curr_batch_idx = 3
+        tracker.store = mock.MagicMock()
+
+        ebc_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["deep_feature"],
+            values=torch.tensor([1, 2]),
+            offsets=torch.tensor([0, 2]),
+        )
+        ec_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["sequence_feature"],
+            values=torch.tensor([5, 6]),
+            offsets=torch.tensor([0, 2]),
+        )
+        tracker.record_lookup(ebc_features, torch.empty(0), ebc_module)
+        tracker.record_lookup(ec_features, torch.empty(0), ec_module)
+
+        self.assertEqual(tracker.store.append.call_count, 2)
+        ebc_call, ec_call = tracker.store.append.call_args_list
+        self.assertEqual(ebc_call.kwargs["fqn"], ebc_fqn)
+        torch.testing.assert_close(
+            ebc_call.kwargs["ids"], torch.tensor(_SHARED_EBC_INPUT_IDS)
+        )
+        self.assertEqual(ec_call.kwargs["fqn"], ec_fqn)
+        torch.testing.assert_close(
+            ec_call.kwargs["ids"], torch.tensor(_SHARED_EC_INPUT_IDS)
+        )
+
+    def test_collect_table_weights_uses_owner_fqn_keys(self):
+        ebc_module = torch.nn.Module()
+        ec_module = torch.nn.Module()
+        ebc_module._lookups = [
+            SimpleNamespace(
+                named_parameters_by_table=lambda: [
+                    ("shared", torch.tensor([[1.0, 2.0]]))
+                ]
+            )
+        ]
+        ec_module._lookups = [
+            SimpleNamespace(
+                named_parameters_by_table=lambda: [
+                    ("shared", torch.tensor([[3.0, 4.0]]))
+                ]
+            )
+        ]
+        dumper = object.__new__(DeltaEmbeddingDumper)
+        dumper._table_shard_infos = {}
+        dumper._tracker = SimpleNamespace(
+            get_tracked_modules=lambda: {
+                "model.ebc": ebc_module,
+                "model.ec": ec_module,
+            }
+        )
+
+        with mock.patch(
+            "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
+            side_effect=lambda module_fqn, _module, table_name: (
+                f"{module_fqn}.{table_name}"
+            ),
+        ):
+            table_weights = dumper._collect_table_weights()
+
+        self.assertEqual(
+            set(table_weights),
+            {"model.ebc.shared", "model.ec.shared"},
+        )
+        torch.testing.assert_close(
+            table_weights["model.ebc.shared"].tensor,
+            torch.tensor([[1.0, 2.0]]),
+        )
+        torch.testing.assert_close(
+            table_weights["model.ec.shared"].tensor,
+            torch.tensor([[3.0, 4.0]]),
+        )
+
+    @unittest.skipUnless(has_dynamicemb, "dynamicemb is not installed; skipping.")
+    def test_collect_dynamic_modules_uses_owner_fqn_keys(self):
+        ebc_module = torch.nn.Module()
+        ec_module = torch.nn.Module()
+        ebc_dynamic_module = SimpleNamespace(table_names=["shared"])
+        ec_dynamic_module = SimpleNamespace(table_names=["shared"])
+        dumper = object.__new__(DeltaEmbeddingDumper)
+        dumper._tracker = SimpleNamespace(
+            get_tracked_modules=lambda: {
+                "model.ebc": ebc_module,
+                "model.ec": ec_module,
+            }
+        )
+
+        with (
+            mock.patch(
+                "dynamicemb.dump_load.get_dynamic_emb_module",
+                side_effect=lambda module: (
+                    [ebc_dynamic_module]
+                    if module is ebc_module
+                    else [ec_dynamic_module]
+                ),
+            ),
+            mock.patch(
+                "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
+                side_effect=lambda module_fqn, _module, table_name: (
+                    f"{module_fqn}.{table_name}"
+                ),
+            ),
+        ):
+            dynamic_modules = dumper._collect_dynamic_modules()
+
+        self.assertEqual(
+            set(dynamic_modules),
+            {"model.ebc.shared", "model.ec.shared"},
+        )
+        self.assertIs(dynamic_modules["model.ebc.shared"], ebc_dynamic_module)
+        self.assertIs(dynamic_modules["model.ec.shared"], ec_dynamic_module)
 
     def test_multi_gpu_output_path_uses_step_underscore_dir(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -606,12 +882,23 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
             ]
         )
         dumper = object.__new__(DeltaEmbeddingDumper)
-        dumper._model = torch.nn.Sequential(
-            original_config_module, grouped_config_module
+        owner_module = torch.nn.Sequential(
+            original_config_module,
+            grouped_config_module,
         )
-        shard_infos = dumper._collect_table_shard_infos()
-        self.assertTrue(shard_infos["user_emb"].has_shard_metadata)
-        self.assertEqual(shard_infos["user_emb"].row_offset, 32)
+        dumper._tracker = SimpleNamespace(
+            get_tracked_modules=lambda: {"model.ebc": owner_module}
+        )
+        with mock.patch(
+            "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
+            side_effect=lambda module_fqn, _module, table_name: (
+                f"{module_fqn}.{table_name}"
+            ),
+        ):
+            shard_infos = dumper._collect_table_shard_infos()
+        table_fqn = "model.ebc.user_emb"
+        self.assertTrue(shard_infos[table_fqn].has_shard_metadata)
+        self.assertEqual(shard_infos[table_fqn].row_offset, 32)
 
     def test_collect_table_shard_infos_falls_back_to_sharding_plan(self):
         sharded_module = torch.nn.Module()
@@ -644,25 +931,41 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         }
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._rank = 0
-        dumper._model = sharded_module
-        shard_infos = dumper._collect_table_shard_infos()
-        self.assertTrue(shard_infos["adgroup_id_emb"].has_shard_metadata)
-        self.assertEqual(shard_infos["adgroup_id_emb"].row_offset, 0)
+        dumper._tracker = SimpleNamespace(
+            get_tracked_modules=lambda: {"model.ebc": sharded_module}
+        )
+        table_fqn = "model.ebc.adgroup_id_emb"
+        with mock.patch(
+            "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
+            side_effect=lambda module_fqn, _module, table_name: (
+                f"{module_fqn}.{table_name}"
+            ),
+        ):
+            shard_infos = dumper._collect_table_shard_infos()
+        self.assertTrue(shard_infos[table_fqn].has_shard_metadata)
+        self.assertEqual(shard_infos[table_fqn].row_offset, 0)
 
         dumper._rank = 1
-        shard_infos = dumper._collect_table_shard_infos()
-        self.assertTrue(shard_infos["adgroup_id_emb"].has_shard_metadata)
-        self.assertEqual(shard_infos["adgroup_id_emb"].row_offset, 32)
+        with mock.patch(
+            "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
+            side_effect=lambda module_fqn, _module, table_name: (
+                f"{module_fqn}.{table_name}"
+            ),
+        ):
+            shard_infos = dumper._collect_table_shard_infos()
+        self.assertTrue(shard_infos[table_fqn].has_shard_metadata)
+        self.assertEqual(shard_infos[table_fqn].row_offset, 32)
 
     def test_row_wise_lookup_outputs_global_key_ids(self):
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._world_size = 2
         weight = torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1], [3.0, 3.1]])
+        table_fqn = "model.ebc.embedding_bags.user_emb"
         embeddings, key_ids = dumper._lookup_embeddings(
-            "user_emb",
+            table_fqn,
             torch.tensor([0, 2]),
             table_weights={
-                "user_emb": _TableWeight(
+                table_fqn: _TableWeight(
                     tensor=weight,
                     shard_info=_TableShardInfo(
                         row_offset=32,
@@ -683,11 +986,12 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._world_size = 2
         weight = torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1], [3.0, 3.1]])
+        table_fqn = "model.ebc.embedding_bags.user_emb"
         embeddings, key_ids = dumper._lookup_embeddings(
-            "user_emb",
+            table_fqn,
             torch.tensor([0, 2, 99, -1]),
             table_weights={
-                "user_emb": _TableWeight(
+                table_fqn: _TableWeight(
                     tensor=weight,
                     shard_info=_TableShardInfo(
                         row_offset=32,
@@ -708,11 +1012,12 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._world_size = 2
         weight = torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1], [3.0, 3.1]])
+        table_fqn = "model.ebc.embedding_bags.user_emb"
         embeddings, key_ids = dumper._lookup_embeddings(
-            "user_emb",
+            table_fqn,
             torch.tensor([], dtype=torch.long),
             table_weights={
-                "user_emb": _TableWeight(
+                table_fqn: _TableWeight(
                     tensor=weight,
                     shard_info=_TableShardInfo(
                         row_offset=32,
@@ -732,12 +1037,13 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
     def test_row_wise_lookup_requires_shard_metadata(self):
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._world_size = 2
+        table_fqn = "model.ebc.embedding_bags.user_emb"
         with self.assertRaisesRegex(ValueError, "shard metadata"):
             dumper._lookup_embeddings(
-                "user_emb",
+                table_fqn,
                 torch.tensor([0]),
                 table_weights={
-                    "user_emb": _TableWeight(
+                    table_fqn: _TableWeight(
                         tensor=torch.zeros(4, 2),
                         shard_info=_TableShardInfo(
                             local_rows=4,
@@ -767,7 +1073,9 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         )
 
         embeddings, key_ids = dumper._lookup_dynamic_embeddings(
-            dynamic_module, "dyn_table", torch.tensor([101, 102, 103])
+            dynamic_module,
+            "model.ec.embeddings.dyn_table",
+            torch.tensor([101, 102, 103]),
         )
 
         dynamic_module.flush.assert_called_once_with()
@@ -797,7 +1105,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         for table_name in ("dyn_a", "dyn_b"):
             dumper._lookup_dynamic_embeddings(
                 dynamic_module,
-                table_name,
+                f"model.ec.embeddings.{table_name}",
                 torch.tensor([101, 102, 103]),
                 flushed_module_ids,
             )
@@ -841,6 +1149,16 @@ class DeltaEmbeddingDumpShardedIntegrationTest(MultiProcessTestBase):
                         )
                     )
                 )
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "test requires a GPU")
+    @mark_ci_scope("gpu")
+    def test_shared_table_name_tracks_ec_and_ebc_fqns_independently(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._run_multi_process_test(
+                callable=_run_shared_table_fqn_delta_embedding_dump,
+                world_size=1,
+                output_dir=tmp_dir,
+            )
 
 
 class DeltaEmbeddingDumpDynamicembIntegrationTest(unittest.TestCase):

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -316,7 +316,7 @@ def _run_shared_table_fqn_delta_embedding_dump(
         ec_fqn = f"ec.embeddings.{_SHARED_TABLE_NAME}"
         testcase.assertEqual(set(table["table_fqn"].to_pylist()), {ebc_fqn, ec_fqn})
         testcase.assertEqual(
-            set(dumper._tracker.fqn_to_feature_names()),
+            set(dumper._tracker.fqn_to_feature_names),
             {ebc_fqn, ec_fqn},
         )
         table_weights = dumper._collect_table_weights()
@@ -617,8 +617,8 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
 
     def test_tracker_uses_auto_compact(self):
         tracker = mock.MagicMock()
-        tracker.fqn_to_feature_names.return_value = {}
-        tracker.get_tracked_modules.return_value = {}
+        tracker.fqn_to_feature_names = {}
+        tracker.tracked_modules = {}
         with (
             tempfile.TemporaryDirectory() as tmp_dir,
             mock.patch(
@@ -643,8 +643,12 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         ebc_fqn = "model.ebc.embedding_bags.shared"
         ec_fqn = "model.ec.embeddings.shared"
         tracker._feature_to_fqn_by_module = {
-            id(ebc_module): {"deep_feature": ebc_fqn},
-            id(ec_module): {"sequence_feature": ec_fqn},
+            ebc_module: {"deep_feature": ebc_fqn},
+            ec_module: {"sequence_feature": ec_fqn},
+        }
+        tracker.fqn_to_feature_names = {
+            ebc_fqn: ["deep_feature"],
+            ec_fqn: ["sequence_feature"],
         }
         tracker.curr_batch_idx = 3
         tracker.store = mock.MagicMock()
@@ -672,6 +676,67 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         torch.testing.assert_close(
             ec_call.kwargs["ids"], torch.tensor(_SHARED_EC_INPUT_IDS)
         )
+        self.assertEqual(
+            tracker.fqn_to_feature_names,
+            {
+                ebc_fqn: ["deep_feature"],
+                ec_fqn: ["sequence_feature"],
+            },
+        )
+
+    def test_model_delta_tracker_advances_consumer_cursor_and_deletes_read_ids(self):
+        tracker = object.__new__(ModelDeltaTracker)
+        tracker._delete_on_read = True
+        tracker.per_consumer_batch_idx = {"delta": -1}
+        tracker.curr_batch_idx = 0
+        tracker.store = mock.MagicMock()
+        tracker.store.get_unique.return_value = {
+            "model.ebc.embedding_bags.shared": SimpleNamespace(
+                ids=torch.tensor([1, 2]),
+                states=None,
+            )
+        }
+
+        rows = tracker.get_unique("delta")
+
+        torch.testing.assert_close(
+            rows["model.ebc.embedding_bags.shared"].ids,
+            torch.tensor([1, 2]),
+        )
+        tracker.store.compact.assert_called_once_with(-1, 1)
+        tracker.store.get_unique.assert_called_once_with(from_idx=-1)
+        tracker.store.delete.assert_called_once_with(up_to_idx=1)
+        self.assertEqual(tracker.per_consumer_batch_idx["delta"], 1)
+
+        tracker.step()
+        tracker.store.reset_mock()
+        tracker.get_unique("delta")
+        tracker.store.compact.assert_called_once_with(1, 2)
+        tracker.store.get_unique.assert_called_once_with(from_idx=1)
+        tracker.store.delete.assert_called_once_with(up_to_idx=2)
+        self.assertEqual(tracker.per_consumer_batch_idx["delta"], 2)
+
+    def test_model_delta_tracker_auto_compacts_once_per_batch(self):
+        tracker = object.__new__(ModelDeltaTracker)
+        tracker.per_consumer_batch_idx = {"delta": -1}
+        tracker.curr_batch_idx = 2
+        tracker.curr_compact_index = 0
+        tracker.store = mock.MagicMock()
+
+        tracker.trigger_compaction()
+        tracker.trigger_compaction()
+
+        tracker.store.compact.assert_called_once_with(-1, 2)
+        self.assertEqual(tracker.curr_compact_index, 2)
+
+    def test_model_delta_tracker_clears_single_consumer(self):
+        tracker = object.__new__(ModelDeltaTracker)
+        tracker.per_consumer_batch_idx = {"delta": -1}
+        tracker.store = mock.MagicMock()
+
+        tracker.clear("delta")
+
+        tracker.store.delete.assert_called_once_with()
 
     def test_collect_table_weights_uses_owner_fqn_keys(self):
         ebc_module = torch.nn.Module()
@@ -693,7 +758,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._table_shard_infos = {}
         dumper._tracker = SimpleNamespace(
-            get_tracked_modules=lambda: {
+            tracked_modules={
                 "model.ebc": ebc_module,
                 "model.ec": ec_module,
             }
@@ -728,7 +793,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         ec_dynamic_module = SimpleNamespace(table_names=["shared"])
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._tracker = SimpleNamespace(
-            get_tracked_modules=lambda: {
+            tracked_modules={
                 "model.ebc": ebc_module,
                 "model.ec": ec_module,
             }
@@ -828,9 +893,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         )
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._tracking_pause_depth = 0
-        dumper._tracker = SimpleNamespace(
-            get_tracked_modules=lambda: {"user_emb": sharded_module}
-        )
+        dumper._tracker = SimpleNamespace(tracked_modules={"user_emb": sharded_module})
         dumper._install_tracking_pause_guard()
 
         sharded_module.post_lookup_tracker_fn("train")
@@ -886,9 +949,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
             original_config_module,
             grouped_config_module,
         )
-        dumper._tracker = SimpleNamespace(
-            get_tracked_modules=lambda: {"model.ebc": owner_module}
-        )
+        dumper._tracker = SimpleNamespace(tracked_modules={"model.ebc": owner_module})
         with mock.patch(
             "tzrec.utils.delta_embedding_dump._embedding_table_fqn",
             side_effect=lambda module_fqn, _module, table_name: (
@@ -931,9 +992,7 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         }
         dumper = object.__new__(DeltaEmbeddingDumper)
         dumper._rank = 0
-        dumper._tracker = SimpleNamespace(
-            get_tracked_modules=lambda: {"model.ebc": sharded_module}
-        )
+        dumper._tracker = SimpleNamespace(tracked_modules={"model.ebc": sharded_module})
         table_fqn = "model.ebc.adgroup_id_emb"
         with mock.patch(
             "tzrec.utils.delta_embedding_dump._embedding_table_fqn",

--- a/tzrec/utils/delta_embedding_dump_test.py
+++ b/tzrec/utils/delta_embedding_dump_test.py
@@ -704,11 +704,14 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
         tracker.per_consumer_batch_idx = {"delta": -1}
         tracker.curr_batch_idx = 0
         tracker.store = mock.MagicMock()
-        tracker.store.get_unique.return_value = {
-            "model.ebc.embedding_bags.shared": SimpleNamespace(
-                ids=torch.tensor([1, 2]),
-                states=None,
-            )
+        tracker.store.per_fqn_lookups = {
+            "model.ebc.embedding_bags.shared": [
+                SimpleNamespace(
+                    batch_idx=0,
+                    ids=torch.tensor([1, 2]),
+                    states=None,
+                )
+            ]
         }
 
         rows = tracker.get_unique("delta")
@@ -718,16 +721,42 @@ class DeltaEmbeddingDumpValidationTest(unittest.TestCase):
             torch.tensor([1, 2]),
         )
         tracker.store.compact.assert_called_once_with(-1, 1)
-        tracker.store.get_unique.assert_called_once_with(from_idx=-1)
         tracker.store.delete.assert_called_once_with(up_to_idx=1)
         self.assertEqual(tracker.per_consumer_batch_idx["delta"], 1)
 
         tracker.step()
         tracker.store.reset_mock()
-        tracker.get_unique("delta")
+        rows = tracker.get_unique("delta")
+        self.assertEqual(rows, {})
         tracker.store.compact.assert_called_once_with(1, 2)
-        tracker.store.get_unique.assert_called_once_with(from_idx=1)
         tracker.store.delete.assert_called_once_with(up_to_idx=2)
+        self.assertEqual(tracker.per_consumer_batch_idx["delta"], 2)
+
+    def test_model_delta_tracker_skips_empty_table_in_later_interval(self):
+        tracker = ModelDeltaTracker(
+            torch.nn.Module(),
+            consumers=["delta"],
+            delete_on_read=True,
+        )
+        table_fqn = "model.ebc.embedding_bags.shared"
+        tracker.store.append(
+            batch_idx=0,
+            fqn=table_fqn,
+            ids=torch.tensor([2, 1, 2]),
+            states=None,
+        )
+
+        first_rows = tracker.get_unique("delta")
+        torch.testing.assert_close(
+            first_rows[table_fqn].ids,
+            torch.tensor([1, 2]),
+        )
+        self.assertEqual(tracker.store.per_fqn_lookups[table_fqn], [])
+
+        tracker.step()
+        second_rows = tracker.get_unique("delta")
+
+        self.assertEqual(second_rows, {})
         self.assertEqual(tracker.per_consumer_batch_idx["delta"], 2)
 
     def test_model_delta_tracker_auto_compacts_once_per_batch(self):

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"


### PR DESCRIPTION
## Summary

- track touched embedding IDs by canonical, owner-qualified table FQN
- keep same-named tables under different sharded EC/EBC owners independent
- use FQN keys throughout shard metadata, static weights, dynamic modules, lookup validation, and parquet output
- omit retained FQN buckets that have no unread IDs, allowing later quiet dump intervals to complete normally
- use TorchRec 1.7's concrete owner, grouped-lookup, embedding-config, sharding-metadata, `ShardedTensor`, and `DTensor` interfaces
- fail fast on unsupported lookup and weight implementations
- bump the TorchEasyRec version to 1.3.6

## Root cause

The previous tracking path built global mappings keyed by raw table name. When separate sharded modules owned tables with the same name, the later mapping could overwrite the earlier one, causing feature mappings, touched IDs, and embedding lookups to resolve to the wrong owner.

Additionally, `DeltaStoreTrec.delete(up_to_idx=...)` retains FQN buckets with empty lookup lists. A later interval with no new IDs for a previously seen table could therefore reach `torch.cat([])` inside TorchRec's `get_unique()` implementation instead of reaching the dumper's empty-output path.

## Implementation

The delta dump now has an ID-only tracker built directly on TorchRec's abstract `ModelDeltaTracker`. Each lookup callback uses its owning sharded module to resolve a module-local feature-to-FQN mapping, so IDs remain attached to the exact EC/EBC owner that produced them.

`DeltaEmbeddingDumper` carries that FQN directly through metadata and storage collection and into `table_fqn` output. Dynamicemb extracts only the final table-name component where its table index API requires it; no `fqn_to_table` mapping is introduced.

The tracker builds unique rows only from unread lookups in each FQN bucket and omits buckets with no unread IDs. Consumer cursors, delete-on-read, compaction, and empty-shard behavior remain unchanged.

The implementation intentionally uses the supported TorchRec 1.7 interfaces instead of accepting arbitrary lookalike objects through defensive reflection. The sole remaining `getattr` selects the active protobuf oneof field. The parquet schema, configuration, and dump scheduling are unchanged.

## Test Plan

Run in the `tzrec130` environment:

- `PYTHONPATH=. python -m tzrec.utils.delta_embedding_dump_test` — 43 tests passed, including two consecutive intervals where the second has no unread IDs, duplicate EC/EBC owners, row-wise sharding, static and DTensor weights, pause guards, dynamicemb, and multi-process DMP regressions
- `pre-commit run -a` — passed
- `git diff --check` — passed
- `python scripts/pyre_check.py` — blocked by existing environment/repository constraints: the committed `.pyre_configuration` is invalid JSON, and the Pyre backend requires newer GLIBC/GLIBCXX symbols than the host provides
