### PR TITLE
[refactor] remove INPUT_TILE checkpoint mapping file

### DIFF
--- a/tzrec/acc/utils.py
+++ b/tzrec/acc/utils.py
@@ -312,40 +312,6 @@ def mixed_precision_for_export(pipeline_config: EasyRecConfig) -> str:
     return export_mp
 
 
-def write_mapping_file_for_input_tile(
-    state_dict: Dict[str, torch.Tensor], remap_file_path: str
-) -> None:
-    r"""Mapping ebc params to ebc_user and ebc_item Updates the model's state.
-
-    dictionary with adapted parameters for the input tile.
-
-    Args:
-        state_dict (Dict[str, torch.Tensor]): model state_dict
-        remap_file_path (str) : store new_params_name\told_params_name\n
-    """
-    input_tile_mapping = {
-        ".ebc_user.embedding_bags.": ".ebc.embedding_bags.",
-        ".mc_ebc_user._embedding_module.": ".mc_ebc._embedding_module.",
-        ".mc_ebc_user._managed_collision_collection.": ".mc_ebc._managed_collision_collection.",  # NOQA
-        ".ec_list_user.": ".ec_list.",
-        ".mc_ec_list_user.": ".mc_ec_list.",
-        ".ec_dict_user.": ".ec_dict.",
-        ".mc_ec_dict_user.": ".mc_ec_dict.",
-    }
-
-    remap_str = ""
-    for key, _ in state_dict.items():
-        for input_tile_key in input_tile_mapping:
-            if input_tile_key in key:
-                src_key = key.replace(
-                    input_tile_key, input_tile_mapping[input_tile_key]
-                )
-                remap_str += key + "\t" + src_key + "\n"
-
-    with open(remap_file_path, "w") as f:
-        f.write(remap_str)
-
-
 def export_acc_config(
     additional_export_config: Optional[Dict[str, Union[bool, str]]] = None,
 ) -> Dict[str, Union[bool, str]]:

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -341,11 +341,6 @@ class RankIntegrationTest(unittest.TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(input_tile_dir_emb, "export/model_acc.json"))
         )
-        self.assertFalse(
-            os.path.exists(
-                os.path.join(input_tile_dir_emb, "export/emb_ckpt_mapping.txt")
-            )
-        )
         with open(os.path.join(input_tile_dir_emb, "export/model_acc.json")) as f:
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg["QUANT_EMB"], "1")

--- a/tzrec/tests/rank_integration_test.py
+++ b/tzrec/tests/rank_integration_test.py
@@ -341,6 +341,11 @@ class RankIntegrationTest(unittest.TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(input_tile_dir_emb, "export/model_acc.json"))
         )
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(input_tile_dir_emb, "export/emb_ckpt_mapping.txt")
+            )
+        )
         with open(os.path.join(input_tile_dir_emb, "export/model_acc.json")) as f:
             acc_cfg = json.load(f)
             self.assertEqual(acc_cfg["QUANT_EMB"], "1")

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -53,8 +53,6 @@ _INPUT_TILE_USER_REPLACEMENTS: Tuple[Tuple[str, str], ...] = (
         ".mc_ebc_user._managed_collision_collection.",
         ".mc_ebc._managed_collision_collection.",
     ),
-    (".ec_list_user.", ".ec_list."),
-    (".mc_ec_list_user.", ".mc_ec_list."),
     (".ec_dict_user.", ".ec_dict."),
     (".mc_ec_dict_user.", ".mc_ec_dict."),
 )

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -46,7 +46,6 @@ from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
 
 # INPUT_TILE=3 load-time fallback from user-side keys to non-user checkpoint keys.
-# Mirrors `tzrec/acc/utils.py:write_mapping_file_for_input_tile`.
 _INPUT_TILE_USER_REPLACEMENTS: Tuple[Tuple[str, str], ...] = (
     (".ebc_user.embedding_bags.", ".ebc.embedding_bags."),
     (".mc_ebc_user._embedding_module.", ".mc_ebc._embedding_module."),
@@ -122,48 +121,62 @@ class PartialLoadPlanner(DefaultLoadPlanner):
             ):
                 continue
 
-            meta_fqn = fqn
-
             fqn_remap_set = set()
+            meta_fqn = fqn
             if fqn in self._ckpt_param_map:
                 meta_fqn = self._ckpt_param_map[fqn]
                 fqn_remap_set.add(fqn)
                 logger.info(f"Remap restore state [{fqn}] from [{meta_fqn}]")
 
+            candidates: List[Tuple[str, bool, Optional[str]]] = [
+                (meta_fqn, False, None)
+            ]
             for ec_new, ec_old in ec_compat_map.items():
                 if ec_new in meta_fqn:
-                    new_meta_fqn = meta_fqn
-                    meta_fqn = new_meta_fqn.replace(ec_new, ec_old)
-                    fqn_remap_set.add(fqn)
-                    logger.warning(
-                        f"Remap EmbeddingCollection state [{new_meta_fqn}] from old "
-                        "[{meta_fqn}], will be deprecated when tzrec version >= 1.0.0"
+                    candidates.append(
+                        (meta_fqn.replace(ec_new, ec_old), False, meta_fqn)
                     )
 
-            # INPUT_TILE=3 export adds user-side twin modules absent from
-            # training checkpoints. Remap to existing non-user keys, matching
-            # export_model_normal's emb_ckpt_mapping.txt fallback.
-            if (
-                is_input_tile_emb()
-                and meta_fqn not in self.metadata.state_dict_metadata
-            ):
+            if is_input_tile_emb():
                 for new_pat, old_pat in _INPUT_TILE_USER_REPLACEMENTS:
                     if new_pat not in meta_fqn:
                         continue
-                    candidate = meta_fqn.replace(new_pat, old_pat)
-                    if candidate in self.metadata.state_dict_metadata:
-                        logger.info(
-                            f"Remap INPUT_TILE=3 state [{fqn}] from [{candidate}]"
-                        )
-                        meta_fqn = candidate
-                        fqn_remap_set.add(fqn)
-                        break
+                    input_tile_fqn = meta_fqn.replace(new_pat, old_pat)
+                    candidates.append((input_tile_fqn, True, None))
+                    for ec_new, ec_old in ec_compat_map.items():
+                        if ec_new in input_tile_fqn:
+                            candidates.append(
+                                (
+                                    input_tile_fqn.replace(ec_new, ec_old),
+                                    True,
+                                    input_tile_fqn,
+                                )
+                            )
 
-            if meta_fqn in self.metadata.state_dict_metadata:
-                md = self.metadata.state_dict_metadata[meta_fqn]
-            else:
+            matched_candidate = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate[0] in self.metadata.state_dict_metadata
+                ),
+                None,
+            )
+            if matched_candidate is None:
                 logger.warning(f"Skip restore state [{fqn}]")
                 continue
+
+            meta_fqn, input_tile_remap, ec_compat_source = matched_candidate
+            if input_tile_remap:
+                logger.info(f"Remap INPUT_TILE=3 state [{fqn}] from [{meta_fqn}]")
+            if ec_compat_source is not None:
+                logger.warning(
+                    f"Remap EmbeddingCollection state [{ec_compat_source}] from old "
+                    f"[{meta_fqn}], will be deprecated when tzrec version >= 1.0.0"
+                )
+            if meta_fqn != fqn:
+                fqn_remap_set.add(fqn)
+
+            md = self.metadata.state_dict_metadata[meta_fqn]
 
             read_items = []
             if isinstance(obj, DTensor):

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -119,62 +119,42 @@ class PartialLoadPlanner(DefaultLoadPlanner):
             ):
                 continue
 
-            fqn_remap_set = set()
             meta_fqn = fqn
+
+            fqn_remap_set = set()
             if fqn in self._ckpt_param_map:
                 meta_fqn = self._ckpt_param_map[fqn]
                 fqn_remap_set.add(fqn)
                 logger.info(f"Remap restore state [{fqn}] from [{meta_fqn}]")
 
-            candidates: List[Tuple[str, bool, Optional[str]]] = [
-                (meta_fqn, False, None)
-            ]
-            for ec_new, ec_old in ec_compat_map.items():
-                if ec_new in meta_fqn:
-                    candidates.append(
-                        (meta_fqn.replace(ec_new, ec_old), False, meta_fqn)
-                    )
-
+            # INPUT_TILE=3 export adds user-side twin modules absent from
+            # training checkpoints. Remap them before EC compatibility handling.
             if is_input_tile_emb():
                 for new_pat, old_pat in _INPUT_TILE_USER_REPLACEMENTS:
                     if new_pat not in meta_fqn:
                         continue
-                    input_tile_fqn = meta_fqn.replace(new_pat, old_pat)
-                    candidates.append((input_tile_fqn, True, None))
-                    for ec_new, ec_old in ec_compat_map.items():
-                        if ec_new in input_tile_fqn:
-                            candidates.append(
-                                (
-                                    input_tile_fqn.replace(ec_new, ec_old),
-                                    True,
-                                    input_tile_fqn,
-                                )
-                            )
+                    meta_fqn = meta_fqn.replace(new_pat, old_pat)
+                    fqn_remap_set.add(fqn)
+                    logger.info(f"Remap INPUT_TILE=3 state [{fqn}] from [{meta_fqn}]")
+                    break
 
-            matched_candidate = next(
-                (
-                    candidate
-                    for candidate in candidates
-                    if candidate[0] in self.metadata.state_dict_metadata
-                ),
-                None,
-            )
-            if matched_candidate is None:
+            if meta_fqn not in self.metadata.state_dict_metadata:
+                for ec_new, ec_old in ec_compat_map.items():
+                    if ec_new in meta_fqn:
+                        new_meta_fqn = meta_fqn
+                        meta_fqn = new_meta_fqn.replace(ec_new, ec_old)
+                        fqn_remap_set.add(fqn)
+                        logger.warning(
+                            f"Remap EmbeddingCollection state [{new_meta_fqn}] from "
+                            "old [{meta_fqn}], will be deprecated when tzrec version "
+                            ">= 1.0.0"
+                        )
+
+            if meta_fqn in self.metadata.state_dict_metadata:
+                md = self.metadata.state_dict_metadata[meta_fqn]
+            else:
                 logger.warning(f"Skip restore state [{fqn}]")
                 continue
-
-            meta_fqn, input_tile_remap, ec_compat_source = matched_candidate
-            if input_tile_remap:
-                logger.info(f"Remap INPUT_TILE=3 state [{fqn}] from [{meta_fqn}]")
-            if ec_compat_source is not None:
-                logger.warning(
-                    f"Remap EmbeddingCollection state [{ec_compat_source}] from old "
-                    f"[{meta_fqn}], will be deprecated when tzrec version >= 1.0.0"
-                )
-            if meta_fqn != fqn:
-                fqn_remap_set.add(fqn)
-
-            md = self.metadata.state_dict_metadata[meta_fqn]
 
             read_items = []
             if isinstance(obj, DTensor):

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -129,7 +129,10 @@ class PartialLoadPlanner(DefaultLoadPlanner):
 
             # INPUT_TILE=3 export adds user-side twin modules absent from
             # training checkpoints. Remap them before EC compatibility handling.
-            if is_input_tile_emb():
+            if (
+                is_input_tile_emb()
+                and meta_fqn not in self.metadata.state_dict_metadata
+            ):
                 for new_pat, old_pat in _INPUT_TILE_USER_REPLACEMENTS:
                     if new_pat not in meta_fqn:
                         continue

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -22,6 +22,7 @@ import torch.distributed as dist
 import torchrec
 from parameterized import param, parameterized
 from torch import nn
+from torch.distributed.checkpoint import save
 from torchrec import EmbeddingBagCollection
 from torchrec.distributed.model_parallel import (
     DistributedModelParallel,
@@ -119,6 +120,39 @@ def _create_test_model(large_table_cnt=2, small_table_cnt=2):
     torch.sum(losses, dim=0).backward()
     optimizer.step()
     return model, optimizer
+
+
+def _create_input_tile_ebc_model(module_values):
+    model = nn.Module()
+    model.group = nn.Module()
+    for module_name, value in module_values.items():
+        ebc = nn.Module()
+        ebc.embedding_bags = nn.ModuleDict(
+            {"table": nn.Embedding(num_embeddings=2, embedding_dim=4)}
+        )
+        nn.init.constant_(ebc.embedding_bags["table"].weight, value)
+        model.group.add_module(module_name, ebc)
+    return model
+
+
+def _create_legacy_ec_list_model(value):
+    model = nn.Module()
+    model.group = nn.Module()
+    model.group.ec_list = nn.ModuleList(
+        [nn.Embedding(num_embeddings=2, embedding_dim=4)]
+    )
+    nn.init.constant_(model.group.ec_list[0].weight, value)
+    return model
+
+
+def _create_input_tile_ec_dict_model(value):
+    model = nn.Module()
+    model.group = nn.Module()
+    model.group.ec_dict_user = nn.ModuleDict(
+        {"4": nn.Embedding(num_embeddings=2, embedding_dim=4)}
+    )
+    nn.init.constant_(model.group.ec_dict_user["4"].weight, value)
+    return model
 
 
 def _save_restore_worker(test_dir, rank, world_size, port):
@@ -401,6 +435,45 @@ class CheckpointUtilTest(unittest.TestCase):
             p.join()
             if p.exitcode != 0:
                 raise RuntimeError(f"worker-{i} failed.")
+
+    def test_input_tile_restores_ebc_user_without_mapping_file(self):
+        source = _create_input_tile_ebc_model({"ebc": 1.0})
+        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
+        target = _create_input_tile_ebc_model({"ebc_user": 0.0})
+
+        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
+            checkpoint_util.restore_model(self.test_dir, target)
+
+        torch.testing.assert_close(
+            target.group.ebc_user.embedding_bags["table"].weight,
+            source.group.ebc.embedding_bags["table"].weight,
+        )
+
+    def test_input_tile_restores_legacy_ec_list_without_mapping_file(self):
+        source = _create_legacy_ec_list_model(1.0)
+        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
+        target = _create_input_tile_ec_dict_model(0.0)
+
+        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
+            checkpoint_util.restore_model(self.test_dir, target)
+
+        torch.testing.assert_close(
+            target.group.ec_dict_user["4"].weight,
+            source.group.ec_list[0].weight,
+        )
+
+    def test_input_tile_prefers_exact_user_checkpoint_key(self):
+        source = _create_input_tile_ebc_model({"ebc": 1.0, "ebc_user": 2.0})
+        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
+        target = _create_input_tile_ebc_model({"ebc_user": 0.0})
+
+        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
+            checkpoint_util.restore_model(self.test_dir, target)
+
+        torch.testing.assert_close(
+            target.group.ebc_user.embedding_bags["table"].weight,
+            source.group.ebc_user.embedding_bags["table"].weight,
+        )
 
 
 class DataloaderCheckpointTest(unittest.TestCase):

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -122,36 +122,16 @@ def _create_test_model(large_table_cnt=2, small_table_cnt=2):
     return model, optimizer
 
 
-def _create_input_tile_ebc_model(module_values):
+def _create_nested_embedding_model(module_path, value):
     model = nn.Module()
-    model.group = nn.Module()
-    for module_name, value in module_values.items():
-        ebc = nn.Module()
-        ebc.embedding_bags = nn.ModuleDict(
-            {"table": nn.Embedding(num_embeddings=2, embedding_dim=4)}
-        )
-        nn.init.constant_(ebc.embedding_bags["table"].weight, value)
-        model.group.add_module(module_name, ebc)
-    return model
-
-
-def _create_legacy_ec_list_model(value):
-    model = nn.Module()
-    model.group = nn.Module()
-    model.group.ec_list = nn.ModuleList(
-        [nn.Embedding(num_embeddings=2, embedding_dim=4)]
-    )
-    nn.init.constant_(model.group.ec_list[0].weight, value)
-    return model
-
-
-def _create_input_tile_ec_dict_model(value):
-    model = nn.Module()
-    model.group = nn.Module()
-    model.group.ec_dict_user = nn.ModuleDict(
-        {"4": nn.Embedding(num_embeddings=2, embedding_dim=4)}
-    )
-    nn.init.constant_(model.group.ec_dict_user["4"].weight, value)
+    parent = model
+    for module_name in module_path[:-1]:
+        child = nn.Module()
+        parent.add_module(module_name, child)
+        parent = child
+    embedding = nn.Embedding(num_embeddings=2, embedding_dim=4)
+    nn.init.constant_(embedding.weight, value)
+    parent.add_module(module_path[-1], embedding)
     return model
 
 
@@ -436,44 +416,36 @@ class CheckpointUtilTest(unittest.TestCase):
             if p.exitcode != 0:
                 raise RuntimeError(f"worker-{i} failed.")
 
-    def test_input_tile_restores_ebc_user_without_mapping_file(self):
-        source = _create_input_tile_ebc_model({"ebc": 1.0})
-        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
-        target = _create_input_tile_ebc_model({"ebc_user": 0.0})
+    def test_input_tile_restores_without_mapping_file(self):
+        cases = [
+            (
+                "ebc",
+                ("group", "ebc", "embedding_bags", "table"),
+                ("group", "ebc_user", "embedding_bags", "table"),
+            ),
+            (
+                "legacy_ec_list",
+                ("group", "ec_list", "0"),
+                ("group", "ec_dict_user", "4"),
+            ),
+        ]
+        for name, source_path, target_path in cases:
+            with self.subTest(name=name):
+                checkpoint_dir = os.path.join(self.test_dir, name)
+                source = _create_nested_embedding_model(source_path, 1.0)
+                save(
+                    source.state_dict(),
+                    checkpoint_id=os.path.join(checkpoint_dir, "model"),
+                )
+                target = _create_nested_embedding_model(target_path, 0.0)
 
-        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
-            checkpoint_util.restore_model(self.test_dir, target)
+                with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
+                    checkpoint_util.restore_model(checkpoint_dir, target)
 
-        torch.testing.assert_close(
-            target.group.ebc_user.embedding_bags["table"].weight,
-            source.group.ebc.embedding_bags["table"].weight,
-        )
-
-    def test_input_tile_restores_legacy_ec_list_without_mapping_file(self):
-        source = _create_legacy_ec_list_model(1.0)
-        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
-        target = _create_input_tile_ec_dict_model(0.0)
-
-        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
-            checkpoint_util.restore_model(self.test_dir, target)
-
-        torch.testing.assert_close(
-            target.group.ec_dict_user["4"].weight,
-            source.group.ec_list[0].weight,
-        )
-
-    def test_input_tile_prefers_exact_user_checkpoint_key(self):
-        source = _create_input_tile_ebc_model({"ebc": 1.0, "ebc_user": 2.0})
-        save(source.state_dict(), checkpoint_id=os.path.join(self.test_dir, "model"))
-        target = _create_input_tile_ebc_model({"ebc_user": 0.0})
-
-        with mock.patch.dict(os.environ, {"INPUT_TILE": "3"}):
-            checkpoint_util.restore_model(self.test_dir, target)
-
-        torch.testing.assert_close(
-            target.group.ebc_user.embedding_bags["table"].weight,
-            source.group.ebc_user.embedding_bags["table"].weight,
-        )
+                torch.testing.assert_close(
+                    target.state_dict()[".".join(target_path) + ".weight"],
+                    source.state_dict()[".".join(source_path) + ".weight"],
+                )
 
 
 class DataloaderCheckpointTest(unittest.TestCase):

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -233,28 +233,14 @@ def export_model_normal(
     input_path = data_input_path or pipeline_config.train_input_path
     dataloader = create_dataloader(data_config, features, input_path, mode=Mode.PREDICT)
 
-    ckpt_param_map_path = None
-    if checkpoint_path:
-        if acc_utils.is_input_tile_emb():
-            # generate embedding name mapping file
-            ckpt_param_map_path = os.path.join(save_dir, "emb_ckpt_mapping.txt")
-            if is_rank_zero:
-                if not os.path.exists(save_dir):
-                    os.makedirs(save_dir)
-                acc_utils.write_mapping_file_for_input_tile(
-                    model.state_dict(), ckpt_param_map_path
-                )
-                dist.barrier()
-    else:
+    if not checkpoint_path:
         raise ValueError("checkpoint path should be specified.")
 
     if is_rank_zero:
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
         init_parameters(model, torch.device("cpu"))
-        checkpoint_util.restore_model(
-            checkpoint_path, model, ckpt_param_map_path=ckpt_param_map_path
-        )
+        checkpoint_util.restore_model(checkpoint_path, model)
         # for mc modules, fix output_segments_tensor is a meta tensor.
         fix_mch_state(model)
 


### PR DESCRIPTION
## Summary

- remove the generated `emb_ckpt_mapping.txt` artifact from normal INPUT_TILE=3 exports
- remap export-only `*_user` keys to their training checkpoint names in `PartialLoadPlanner`
- preserve legacy `ec_list` checkpoint compatibility

## Why

Normal exports generated a mapping file that duplicated loader-side INPUT_TILE remapping. The previous fallback order also could not resolve `ec_dict_user` parameters from legacy checkpoints containing only `ec_list` keys.

The loader now remaps export-only user keys first, loads the current non-user key when available, and falls back to the legacy `ec_list` name only when needed. The generic `ckpt_param_map_path` restore interface remains available for custom mappings.

## Impact

INPUT_TILE=3 exports no longer contain `emb_ckpt_mapping.txt`. Current training checkpoints and legacy checkpoints containing only `ec_list` keys remain loadable.

## Test Plan

- `conda run -n tzrec130 env PYTHONPATH=. python -m tzrec.utils.checkpoint_util_test` (55 tests passed)
- `conda run -n tzrec130 env PYTHONPATH=. python -m tzrec.utils.export_util_test` (16 tests passed)
- `conda run -n tzrec130 pre-commit run -a`

Pyre could not run because the repository configuration contains invalid JSON and the installed `pyre.bin` requires newer GLIBC/GLIBCXX versions than the host provides.
