### PR TITLE
[doc] Move dense export contract to code

### DIFF
--- a/docs/source/usage/export.md
+++ b/docs/source/usage/export.md
@@ -87,34 +87,6 @@ torchrun --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT \
 
 `ONLINE_DENSE_EXPORT_STEPS` 与 `ONLINE_DENSE_EXPORT_INTERVAL` 至少要设置一个；训练结束时还会强制导出一次最终状态。导出频率与 checkpoint 频率完全独立，checkpoint 仍按原有配置保存、用于训练恢复。
 
-### 导出产物与切换契约
-
-```
-<ONLINE_DENSE_EXPORT_DIR>/dense_hot_export/
-├── current.json                  # 服务指向的最新版本指针（原子写）
-└── versions/
-    └── <yyyyMMddHHmmss>/         # 一个不可变的版本目录
-        ├── scripted_model.pt     # TorchScript dense 模型
-        ├── dense_meta.json       # placeholder 名 -> serving embedding 名映射
-        ├── graph/                # 图 dump（排查用）
-        └── READY                 # 目录完整的标记文件，先写 READY 再原子换版
-```
-
-`current.json` 内容：
-
-```json
-{
-  "checkpoint_step": 1200,
-  "created_at": "2026-07-24T05:20:00.000000+00:00",
-  "data_timestamp": 1782365432.0,
-  "version": "20260724052000"
-}
-```
-
-- `version`: 版本目录名，单调递增的时间戳。
-- `checkpoint_step` / `data_timestamp`: 导出时训练步数与该 rank 消费到的事件时间，供 serving 侧与 sparse 状态对齐版本一致性。
-- 推理 Processor 应只读取 `current.json` 指向的版本，且只消费最新版本。
-
 ### 运行与排障说明
 
 - 仅 rank 0 执行建图与发布；启动时会对整条建图 + script 链路做一次试运行，任何 trace/script 失败会在训练开始前就暴露（fail-fast）。

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -15,9 +15,26 @@
 r"""Utilities for exporting and atomically publishing online dense models.
 
 Serving publish contract:
-- ``versions/<version>/`` is immutable and contains ``scripted_model.pt``,
-  ``dense_meta.json``, ``graph/``, and ``READY``. Build it under a temporary
-  directory, write ``READY``, then rename it atomically into place.
+
+<ONLINE_DENSE_EXPORT_DIR>/dense_hot_export/
+├── current.json                  # Atomic pointer to the latest version
+└── versions/
+    └── <yyyyMMddHHmmss>/         # Immutable version directory
+        ├── scripted_model.pt     # TorchScript dense model
+        ├── dense_meta.json       # Placeholder -> serving embedding mapping
+        ├── graph/                # Graph dump for debugging
+        └── READY                 # Completion marker written before the switch
+
+current.json:
+{
+  "checkpoint_step": 1200,
+  "created_at": "2026-07-24T05:20:00.000000+00:00",
+  "data_timestamp": 1782365432.0,
+  "version": "20260724052000"
+}
+
+- Build each version under a temporary directory, write ``READY``, then rename
+  it atomically into place.
 - Only after the rename, atomically replace ``current.json`` with ``version``,
   ``checkpoint_step``, ``data_timestamp``, and ``created_at``. The processor
   reads only the version it names; step/timestamp align dense and sparse state.

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -12,13 +12,16 @@
 # Copyright (c) 2026, Alibaba Group;
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-# Serving publish contract:
-# - versions/<version>/ is immutable and contains scripted_model.pt,
-#   dense_meta.json, graph/, and READY. Build it under a temporary directory,
-#   write READY, then rename it atomically into place.
-# - Only after the rename, atomically replace current.json with version,
-#   checkpoint_step, data_timestamp, and created_at. The processor reads only
-#   the version it names; step/timestamp align dense and sparse state.
+r"""Utilities for exporting and atomically publishing online dense models.
+
+Serving publish contract:
+- ``versions/<version>/`` is immutable and contains ``scripted_model.pt``,
+  ``dense_meta.json``, ``graph/``, and ``READY``. Build it under a temporary
+  directory, write ``READY``, then rename it atomically into place.
+- Only after the rename, atomically replace ``current.json`` with ``version``,
+  ``checkpoint_step``, ``data_timestamp``, and ``created_at``. The processor
+  reads only the version it names; step/timestamp align dense and sparse state.
+"""
 
 import datetime
 import json

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -693,6 +693,13 @@ class OnlineDenseExportManager:
 
     def _run_task(self, task: Dict[str, Any]) -> None:
         """Load the snapshot into the resident graph, script it and publish."""
+        # Serving publish contract:
+        # - versions/<version>/ is immutable and contains scripted_model.pt,
+        #   dense_meta.json, graph/, and READY. Build it under a temporary
+        #   directory, write READY, then rename it atomically into place.
+        # - Only after the rename, atomically replace current.json with version,
+        #   checkpoint_step, data_timestamp, and created_at. The processor reads
+        #   only the version it names; step/timestamp align dense and sparse state.
         version = task["version"]
         versions_root = os.path.join(self._export_root, VERSIONS_DIR)
         version_dir = os.path.join(versions_root, version)

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -42,6 +42,13 @@ from tzrec.utils.export_util import (
 )
 from tzrec.utils.logging_util import logger
 
+# Serving publish contract:
+# - versions/<version>/ is immutable and contains scripted_model.pt,
+#   dense_meta.json, graph/, and READY. Build it under a temporary directory,
+#   write READY, then rename it atomically into place.
+# - Only after the rename, atomically replace current.json with version,
+#   checkpoint_step, data_timestamp, and created_at. The processor reads only
+#   the version it names; step/timestamp align dense and sparse state.
 VERSIONS_DIR = "versions"
 CURRENT_JSON = "current.json"
 _VERSION_TIME_FORMAT = "%Y%m%d%H%M%S"
@@ -693,13 +700,6 @@ class OnlineDenseExportManager:
 
     def _run_task(self, task: Dict[str, Any]) -> None:
         """Load the snapshot into the resident graph, script it and publish."""
-        # Serving publish contract:
-        # - versions/<version>/ is immutable and contains scripted_model.pt,
-        #   dense_meta.json, graph/, and READY. Build it under a temporary
-        #   directory, write READY, then rename it atomically into place.
-        # - Only after the rename, atomically replace current.json with version,
-        #   checkpoint_step, data_timestamp, and created_at. The processor reads
-        #   only the version it names; step/timestamp align dense and sparse state.
         version = task["version"]
         versions_root = os.path.join(self._export_root, VERSIONS_DIR)
         version_dir = os.path.join(versions_root, version)

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -36,8 +36,9 @@ current.json:
 - Build each version under a temporary directory, write ``READY``, then rename
   it atomically into place.
 - Only after the rename, atomically replace ``current.json`` with ``version``,
-  ``checkpoint_step``, ``data_timestamp``, and ``created_at``. The processor
-  reads only the version it names; step/timestamp align dense and sparse state.
+  ``checkpoint_step``, ``data_timestamp``, and ``created_at``.
+- The processor reads only the version named by ``current.json``; step/timestamp
+  align dense and sparse state.
 """
 
 import datetime

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -12,6 +12,14 @@
 # Copyright (c) 2026, Alibaba Group;
 # Licensed under the Apache License, Version 2.0 (the "License");
 
+# Serving publish contract:
+# - versions/<version>/ is immutable and contains scripted_model.pt,
+#   dense_meta.json, graph/, and READY. Build it under a temporary directory,
+#   write READY, then rename it atomically into place.
+# - Only after the rename, atomically replace current.json with version,
+#   checkpoint_step, data_timestamp, and created_at. The processor reads only
+#   the version it names; step/timestamp align dense and sparse state.
+
 import datetime
 import json
 import os
@@ -42,13 +50,6 @@ from tzrec.utils.export_util import (
 )
 from tzrec.utils.logging_util import logger
 
-# Serving publish contract:
-# - versions/<version>/ is immutable and contains scripted_model.pt,
-#   dense_meta.json, graph/, and READY. Build it under a temporary directory,
-#   write READY, then rename it atomically into place.
-# - Only after the rename, atomically replace current.json with version,
-#   checkpoint_step, data_timestamp, and created_at. The processor reads only
-#   the version it names; step/timestamp align dense and sparse state.
 VERSIONS_DIR = "versions"
 CURRENT_JSON = "current.json"
 _VERSION_TIME_FORMAT = "%Y%m%d%H%M%S"


### PR DESCRIPTION
## Summary

- remove the internal online dense export artifact and switching contract from the user-facing export guide
- keep the environment-variable and operational guidance in the user documentation
- document the immutable version layout, READY/rename sequence, atomic `current.json` update, and dense/sparse alignment at the top of `online_dense_export_util.py`

## Why

The artifact layout and atomic switching sequence are implementation contracts rather than user-facing configuration, so they should stay with the publishing implementation.

## Test Plan

- `conda run -n tzrec130 pre-commit run -a`
- `PYTHONPATH=. conda run -n tzrec130 python scripts/pyre_check.py` (the script reports the existing invalid `.pyre_configuration`, then reports no critical type errors)
- `git diff --check`