### PR TITLE
[ci] build the PPU image from this repo

### DIFF
--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -43,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_tool":/__w/_tool \
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
-            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.2-ppu-u1 \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2-ppu \
             bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -43,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_tool":/__w/_tool \
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
-            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.2-ppu \
             bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()

--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -43,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_tool":/__w/_tool \
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
-            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.2-ppu \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-test:1.2-ppu-u1 \
             bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()

--- a/docker/Dockerfile.ppu
+++ b/docker/Dockerfile.ppu
@@ -1,0 +1,46 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN sed -i "s@http://archive.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    sed -i "s@http://security.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    sed -i "s@http://ports.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential ca-certificates \
+        ccache cmake gcc git vim watchman wget curl sudo iproute2 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://tzrec.oss-accelerate.aliyuncs.com/third_party/libidn11_1.33-2.2ubuntu2_amd64.deb && \
+    apt-get install ./libidn11_1.33-2.2ubuntu2_amd64.deb && rm libidn11_1.33-2.2ubuntu2_amd64.deb
+
+ARG PIP_MIRROR=mirrors.aliyun.com
+RUN mkdir -p /root/.config/pip && \
+    printf '[global]\nindex-url = http://%s/pypi/simple\ntrusted-host = %s\ntimeout = 120\n' "${PIP_MIRROR}" "${PIP_MIRROR}" > /root/.config/pip/pip.conf
+
+ARG PPU_PIP_INDEX
+RUN pip install torch==2.11.0 triton==3.6.0 -i ${PPU_PIP_INDEX} && \
+    pip install fbgemm-gpu==1.6.0 faiss==1.14.1 -i ${PPU_PIP_INDEX} && \
+    pip install torchmetrics==1.0.3 tensordict && \
+    pip install torchrec==1.6.0 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/torchrec/repo.html && \
+    pip cache purge
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+ADD requirements /root/requirements
+ADD requirements.txt /root/requirements.txt
+RUN cd /root && \
+    pip install -r requirements.txt && \
+    rm -rf requirements requirements.txt && \
+    pip cache purge
+
+RUN mkdir -p /home/pai/bin && \
+    wget -O /home/pai/bin/prepare_dlc_environment https://tzrec.oss-accelerate.aliyuncs.com/third_party/pai/prepare_dlc_environment.sh && \
+    chmod +x /home/pai/bin/prepare_dlc_environment && \
+    apt-get update && apt-get install -y --no-install-recommends openssh-server && rm -rf /var/lib/apt/lists/* && service ssh start
+ENV PATH $PATH:/home/pai/bin
+
+ENV SHELL=/bin/bash
+RUN echo "dash dash/sh boolean false" | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash

--- a/docs/source/develop.md
+++ b/docs/source/develop.md
@@ -75,3 +75,9 @@ bash scripts/build_wheel.sh release
 ```bash
 bash scripts/build_docker.sh
 ```
+
+**构建PPU镜像**
+
+```bash
+bash scripts/build_docker_ppu.sh
+```

--- a/scripts/build_docker_ppu.sh
+++ b/scripts/build_docker_ppu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Build the PPU image on top of the vendor PPU base image. torch/triton/faiss are the
+# PPU builds from the FlyTiger Eco pypi index; everything else comes from requirements/.
+
+REGISTRY=mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec
+REPO_NAME=tzrec-test
+DOCKER_TAG=1.2
+DOCKER_TAG_SUFFIX=-u1
+BASE_IMAGE=pkg.flytiger-eco.com/docker_release/ppu:v2.1.1-cuda13.0-ubuntu24-py312
+PPU_PIP_INDEX=https://pkg.flytiger-eco.com/artifactory/api/pypi/pypi_index/simple
+
+rm -rf docker/requirements*
+cp -r requirements*.txt docker/
+cp -r requirements/ docker/requirements
+cd docker
+
+docker build --network host -f Dockerfile.ppu -t ${REGISTRY}/${REPO_NAME}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX} \
+    --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg PPU_PIP_INDEX=${PPU_PIP_INDEX} \
+    ${PIP_MIRROR:+--build-arg PIP_MIRROR=${PIP_MIRROR}} .
+docker push ${REGISTRY}/${REPO_NAME}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX}

--- a/scripts/promote_docker_ppu.sh
+++ b/scripts/promote_docker_ppu.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Promote tzrec-test:<tag>-ppu<suffix> to tzrec-devel:<tag>-ppu after PPU CI passes.
+# Separate from promote_docker.sh: the PPU image is built and validated on its own
+# cadence and may lag the cpu/cu* images, and it never takes the <tag>/latest aliases.
+
+REGISTRY=mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec
+SRC_REPO=tzrec-test
+DST_REPO=tzrec-devel
+DOCKER_TAG=1.2
+DOCKER_TAG_SUFFIX=-u1
+
+docker pull ${REGISTRY}/${SRC_REPO}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX}
+docker tag ${REGISTRY}/${SRC_REPO}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX} ${REGISTRY}/${DST_REPO}:${DOCKER_TAG}-ppu
+docker push ${REGISTRY}/${DST_REPO}:${DOCKER_TAG}-ppu

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.23"
+__version__ = "1.2.24"


### PR DESCRIPTION
Build the PPU image from this repo instead of an out-of-tree addons checkout, and pick up the PPU artifacts' new home.

The PPU image was built outside the repo, so it drifted from `requirements/` whenever the release pins moved and could not be reproduced from a checkout. `docker/Dockerfile.ppu` now installs the PPU torch/triton/faiss/fbgemm builds from the vendor pypi index on top of the vendor PPU base image, then installs `requirements.txt` like the other images do. The `torch==2.11.0` / `fbgemm-gpu==1.6.0` / `torchrec==1.6.0` pins in `requirements/runtime.txt` are satisfied by the PPU builds (their local version `+v0.1.0.ppu2.1.1` matches the pin), so no non-PPU wheel is pulled in.

Changes:

- `docker/Dockerfile.ppu`: base image `ppu:v2.1.1-cuda13.0-ubuntu24-py312`, PPU wheels from the vendor index, `mirrors.aliyun.com` for everything else. Drops the `PIP_INDEX_URL` + `sitecustomize.py` / `aiextpypi.pth` STS shim the old out-of-tree Dockerfile carried; it is no longer needed.
- `scripts/build_docker_ppu.sh` / `scripts/promote_docker_ppu.sh`: build and promotion for the single PPU tag. Kept separate from `build_docker.sh` / `promote_docker.sh` because the PPU image is built and validated on its own cadence and may lag the cpu/cu* images; it also never takes the `<tag>` / `latest` aliases.
- `.github/workflows/unittest_ppu_ci.yml`: run the PPU lane on the freshly built image (switched back to `tzrec-devel:1.2-ppu` after promotion).
- `docs/source/develop.md`: document the PPU image build.
- Version bumped to 1.2.24.

## Test Plan

- Built the image from this branch and smoke-tested it off-device: `torch 2.11.0+v0.1.0.ppu2.1.1`, `triton 3.6.0+v0.2.0.ppu2.1.1`, `faiss 1.14.1+v0.1.0.ppu2.1.1`, `fbgemm_gpu 1.6.0+v0.1.0.ppu2.1.1`, `torchrec 1.6.0`; `torch`, `triton`, `faiss`, `fbgemm_gpu`, `torchrec`, `torchmetrics`, `graphlearn`, `pyfg`, `tensorboard`, `sklearn` all import.
- Confirmed in the build log that `pip install -r requirements.txt` reports torch/fbgemm-gpu/torchrec as already satisfied, i.e. the shared requirements files do not re-resolve a non-PPU torch.
- Validated cache-cold (`--no-cache`): an earlier build had cached a layer from when the vendor index still proxied the upstream `fbgemm_gpu` wheel, which loads against real CUDA but not the PPU CUDA shim (`undefined symbol: __cudaGetKernel, version libcudart.so.13`). The vendor index now serves only PPU artifacts for that name, and the cold build resolves `fbgemm_gpu-1.6.0+v0.1.0.ppu2.1.1`.
- PPU unit-test CI lane (`scripts/ci/ci_test_ppu.sh`, full `tzrec/tests/run.py`) on the built image.
