### PR TITLE
[feat] add dense EMA support

### DIFF
--- a/docs/source/models/optimizer.md
+++ b/docs/source/models/optimizer.md
@@ -58,11 +58,7 @@ train_config {
 
   - ema:
 
-    对全部稠密参数（包括`part_optimizers`管理的参数）计算指数移动平均。配置该字段后启用，`decay`取值范围为`[0, 1]`，默认为`0.999`。EMA在每次实际参数更新后执行；梯度累计的中间步以及GradScaler跳过的异常更新不会计入。
-
-    训练checkpoint仍以原始参数作为主模型，保证optimizer状态能够精确续训，并额外保存稠密EMA状态。训练内评估和独立评估默认使用EMA参数，可通过`eval_config.use_dense_ema`覆盖；checkpoint推理、普通模型导出和在线稠密模型导出默认使用EMA参数，可通过`export_config.use_dense_ema`覆盖。旧checkpoint没有EMA状态时会输出告警并回退到原始参数；从旧checkpoint续训时，EMA会在下一次实际参数更新时重新初始化。
-
-    EMA仅平均稠密parameters，BatchNorm等buffers继续使用实时值，不对稀疏Embedding做平均。启用后会在训练设备上额外占用约一份稠密参数大小的显存。
+    对全部稠密参数（包括`part_optimizers`管理的参数）计算指数移动平均。配置该字段后启用，`decay`取值范围为`[0, 1]`，默认为`0.999`。EMA在每次实际参数更新后执行。
 
   - part_optimizers:
 

--- a/docs/source/models/optimizer.md
+++ b/docs/source/models/optimizer.md
@@ -21,6 +21,9 @@ train_config {
         }
         constant_learning_rate {
         }
+        ema {
+            decay: 0.999
+        }
         part_optimizers {
             adamw_optimizer {
                 lr: 0.01
@@ -52,6 +55,14 @@ train_config {
   - optimizer: 优化器类型，具体见dense optimize的[配置文档](../reference.md)
 
   - learning_rate: dense_optimizer的学习率计划器,具体见dense_optimizer中的learning_rate的[配置文档](../reference.md)
+
+  - ema:
+
+    对全部稠密参数（包括`part_optimizers`管理的参数）计算指数移动平均。配置该字段后启用，`decay`取值范围为`[0, 1]`，默认为`0.999`。EMA在每次实际参数更新后执行；梯度累计的中间步以及GradScaler跳过的异常更新不会计入。
+
+    训练checkpoint仍以原始参数作为主模型，保证optimizer状态能够精确续训，并额外保存稠密EMA状态。训练内评估、独立评估、checkpoint推理、普通模型导出和在线稠密模型导出默认使用EMA参数。旧checkpoint没有EMA状态时会输出告警并回退到原始参数；从旧checkpoint续训时，EMA会在下一次实际参数更新时重新初始化。
+
+    EMA仅平均稠密parameters，BatchNorm等buffers继续使用实时值，不对稀疏Embedding做平均。启用后会在训练设备上额外占用约一份稠密参数大小的显存。
 
   - part_optimizers:
 

--- a/docs/source/models/optimizer.md
+++ b/docs/source/models/optimizer.md
@@ -60,7 +60,7 @@ train_config {
 
     对全部稠密参数（包括`part_optimizers`管理的参数）计算指数移动平均。配置该字段后启用，`decay`取值范围为`[0, 1]`，默认为`0.999`。EMA在每次实际参数更新后执行；梯度累计的中间步以及GradScaler跳过的异常更新不会计入。
 
-    训练checkpoint仍以原始参数作为主模型，保证optimizer状态能够精确续训，并额外保存稠密EMA状态。训练内评估、独立评估、checkpoint推理、普通模型导出和在线稠密模型导出默认使用EMA参数。旧checkpoint没有EMA状态时会输出告警并回退到原始参数；从旧checkpoint续训时，EMA会在下一次实际参数更新时重新初始化。
+    训练checkpoint仍以原始参数作为主模型，保证optimizer状态能够精确续训，并额外保存稠密EMA状态。训练内评估和独立评估默认使用EMA参数，可通过`eval_config.use_dense_ema`覆盖；checkpoint推理、普通模型导出和在线稠密模型导出默认使用EMA参数，可通过`export_config.use_dense_ema`覆盖。旧checkpoint没有EMA状态时会输出告警并回退到原始参数；从旧checkpoint续训时，EMA会在下一次实际参数更新时重新初始化。
 
     EMA仅平均稠密parameters，BatchNorm等buffers继续使用实时值，不对稀疏Embedding做平均。启用后会在训练设备上额外占用约一份稠密参数大小的显存。
 

--- a/docs/source/usage/eval.md
+++ b/docs/source/usage/eval.md
@@ -31,3 +31,4 @@ eval_config {
 
 - num_steps: 评估的步数，默认为评估eval_input_path中指定的所有数据
 - log_step_count_steps: 评估打印log和summary的步数间隔（如果打印时间间隔小于1s，会跳过打印）
+- use_dense_ema: 是否使用稠密EMA参数进行评估。未配置时默认跟随`train_config.dense_optimizer.ema`是否启用；可显式配置为`true`或`false`覆盖默认行为

--- a/docs/source/usage/export.md
+++ b/docs/source/usage/export.md
@@ -14,6 +14,7 @@ export_config {
   - best 导出最好的模型
 - best_exporter_metric: 当exporter_type为best的时候，确定最优导出模型的metric，注意该metric要在对应任务的metrics设置了才行。对于多任务模型则需要设置 {metric_name}\_{tower_name}。
 - metric_larger_is_better: 确定最优导出模型的metric是越大越好，还是越小越好，默认是越大越好
+- use_dense_ema: 是否使用稠密EMA参数导出模型。未配置时默认跟随`train_config.dense_optimizer.ema`是否启用；可显式配置为`true`或`false`覆盖默认行为，在线Dense导出同样使用该配置
 
 ## 导出命令
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -75,6 +75,7 @@ from tzrec.optim.lr_scheduler import BaseLR
 from tzrec.optim.optimizer import TZRecOptimizer
 from tzrec.protos.data_pb2 import DataConfig, DatasetType
 from tzrec.protos.eval_pb2 import EvalConfig
+from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.protos.feature_pb2 import FeatureConfig
 from tzrec.protos.model_pb2 import Kernel as KernelProto
 from tzrec.protos.model_pb2 import ModelConfig
@@ -340,6 +341,7 @@ def _train_and_evaluate(
     delta_embedding_dumper: Optional[DeltaEmbeddingDumper] = None,
     pipeline_config_path: Optional[str] = None,
     dense_ema: Optional[DenseEMA] = None,
+    export_config: Optional[ExportConfig] = None,
 ) -> None:
     """Train and evaluate the model."""
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
@@ -434,6 +436,15 @@ def _train_and_evaluate(
     i_step = 0
     i_epoch = 0
     losses = {}
+    eval_dense_ema = (
+        dense_ema if config_util.use_dense_ema(eval_config, train_config) else None
+    )
+    export_dense_ema = (
+        dense_ema
+        if export_config is None
+        or config_util.use_dense_ema(export_config, train_config)
+        else None
+    )
 
     def run_eval(step: int, epoch: int) -> None:
         """Run eval after a checkpoint save, if an eval dataloader is configured."""
@@ -444,8 +455,8 @@ def _train_and_evaluate(
                 else nullcontext()
             )
             ema_context = (
-                dense_ema.average_parameters()
-                if dense_ema is not None
+                eval_dense_ema.average_parameters()
+                if eval_dense_ema is not None
                 else nullcontext()
             )
             with tracking_context, ema_context:
@@ -565,7 +576,7 @@ def _train_and_evaluate(
                 # Unconditional: the exporter decides its own (checkpoint-
                 # independent) cadence and enters its collective in lockstep.
                 online_dense_exporter.maybe_export(
-                    i_step, data_timestamp, model, dense_ema=dense_ema
+                    i_step, data_timestamp, model, dense_ema=export_dense_ema
                 )
                 if train_config.is_profiling:
                     prof.step()
@@ -581,7 +592,7 @@ def _train_and_evaluate(
             ):
                 run_eval(i_step, i_epoch)
             online_dense_exporter.maybe_export(
-                i_step, data_timestamp, model, dense_ema=dense_ema
+                i_step, data_timestamp, model, dense_ema=export_dense_ema
             )
 
             if use_step and i_step >= train_config.num_steps - 1:
@@ -633,7 +644,7 @@ def _train_and_evaluate(
             data_timestamp,
             model,
             final=True,
-            dense_ema=dense_ema,
+            dense_ema=export_dense_ema,
         )
     finally:
         online_dense_exporter.close()
@@ -912,6 +923,7 @@ def train_and_evaluate(
         delta_embedding_dumper=delta_embedding_dumper,
         pipeline_config_path=os.path.join(pipeline_config.model_dir, "pipeline.config"),
         dense_ema=dense_ema,
+        export_config=pipeline_config.export_config,
     )
     if is_local_rank_zero:
         logger.info("Train and Evaluate Finished.")
@@ -995,7 +1007,10 @@ def evaluate(
         ckpt_manager.restore(
             checkpoint_path,
             model,
-            use_dense_ema=train_config.dense_optimizer.HasField("ema"),
+            use_dense_ema=config_util.use_dense_ema(
+                pipeline_config.eval_config,
+                train_config,
+            ),
         )
     else:
         raise ValueError("Eval checkpoint path should be specified.")
@@ -1548,7 +1563,10 @@ def predict_checkpoint(
         ckpt_manager.restore(
             checkpoint_path,
             model,
-            use_dense_ema=train_config.dense_optimizer.HasField("ema"),
+            use_dense_ema=config_util.use_dense_ema(
+                pipeline_config.export_config,
+                train_config,
+            ),
         )
     else:
         raise ValueError("Predict checkpoint path should be specified.")

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -440,10 +440,7 @@ def _train_and_evaluate(
         dense_ema if config_util.use_dense_ema(eval_config, train_config) else None
     )
     export_dense_ema = (
-        dense_ema
-        if export_config is None
-        or config_util.use_dense_ema(export_config, train_config)
-        else None
+        dense_ema if config_util.use_dense_ema(export_config, train_config) else None
     )
 
     def run_eval(step: int, epoch: int) -> None:

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -70,6 +70,7 @@ from tzrec.models.tdm import TDM, TDMEmbedding
 from tzrec.modules.embedding import EmbeddingGroup
 from tzrec.ops import Kernel
 from tzrec.optim import optimizer_builder
+from tzrec.optim.ema import DenseEMA, EMAOptimizer
 from tzrec.optim.lr_scheduler import BaseLR
 from tzrec.optim.optimizer import TZRecOptimizer
 from tzrec.protos.data_pb2 import DataConfig, DatasetType
@@ -338,6 +339,7 @@ def _train_and_evaluate(
     dataloader_state: Optional[Dict[str, Any]] = None,
     delta_embedding_dumper: Optional[DeltaEmbeddingDumper] = None,
     pipeline_config_path: Optional[str] = None,
+    dense_ema: Optional[DenseEMA] = None,
 ) -> None:
     """Train and evaluate the model."""
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
@@ -441,7 +443,12 @@ def _train_and_evaluate(
                 if delta_embedding_dumper is not None
                 else nullcontext()
             )
-            with tracking_context:
+            ema_context = (
+                dense_ema.average_parameters()
+                if dense_ema is not None
+                else nullcontext()
+            )
+            with tracking_context, ema_context:
                 _evaluate(
                     model,
                     eval_dataloader,
@@ -480,7 +487,11 @@ def _train_and_evaluate(
             if i_step == 0 and ckpt_path is not None:
                 if ignore_restore_optimizer:
                     ckpt_manager.restore(
-                        ckpt_path, model, None, train_config.fine_tune_ckpt_param_map
+                        ckpt_path,
+                        model,
+                        None,
+                        train_config.fine_tune_ckpt_param_map,
+                        dense_ema=dense_ema,
                     )
                 else:
                     # optimizer state is lazy, so peek one batch to init it
@@ -493,6 +504,7 @@ def _train_and_evaluate(
                         model,
                         optimizer,
                         train_config.fine_tune_ckpt_param_map,
+                        dense_ema=dense_ema,
                     )
                 if delta_embedding_dumper is not None:
                     delta_embedding_dumper.clear()
@@ -546,12 +558,15 @@ def _train_and_evaluate(
                     model,
                     optimizer,
                     dataloader_state,
+                    dense_ema,
                     data_timestamp=data_timestamp,
                 ):
                     run_eval(i_step, i_epoch)
                 # Unconditional: the exporter decides its own (checkpoint-
                 # independent) cadence and enters its collective in lockstep.
-                online_dense_exporter.maybe_export(i_step, data_timestamp, model)
+                online_dense_exporter.maybe_export(
+                    i_step, data_timestamp, model, dense_ema=dense_ema
+                )
                 if train_config.is_profiling:
                     prof.step()
 
@@ -560,11 +575,14 @@ def _train_and_evaluate(
                 model,
                 optimizer,
                 dataloader_state,
+                dense_ema,
                 epoch=i_epoch,
                 data_timestamp=data_timestamp,
             ):
                 run_eval(i_step, i_epoch)
-            online_dense_exporter.maybe_export(i_step, data_timestamp, model)
+            online_dense_exporter.maybe_export(
+                i_step, data_timestamp, model, dense_ema=dense_ema
+            )
 
             if use_step and i_step >= train_config.num_steps - 1:
                 break
@@ -605,11 +623,18 @@ def _train_and_evaluate(
             model,
             optimizer,
             dataloader_state,
+            dense_ema,
             data_timestamp=data_timestamp,
             final=True,
         ):
             run_eval(i_step, i_epoch)
-        online_dense_exporter.maybe_export(i_step, data_timestamp, model, final=True)
+        online_dense_exporter.maybe_export(
+            i_step,
+            data_timestamp,
+            model,
+            final=True,
+            dense_ema=dense_ema,
+        )
     finally:
         online_dense_exporter.close()
         ckpt_manager.close()
@@ -788,12 +813,19 @@ def train_and_evaluate(
     part_optim_cls, part_optim_kwargs, part_optim_regex_patterns = (
         optimizer_builder.create_part_optimizer(train_config.dense_optimizer)
     )
+    dense_params = dict(in_backward_optimizer_filter(model.named_parameters()))
     remaining_params, part_optim_params = (
         optimizer_builder.group_param_by_regex_pattern(
-            dict(in_backward_optimizer_filter(model.named_parameters())),
+            dense_params,
             part_optim_regex_patterns,
         )
     )
+    dense_ema = None
+    if train_config.dense_optimizer.HasField("ema"):
+        dense_ema = DenseEMA(
+            dense_params,
+            train_config.dense_optimizer.ema.decay,
+        )
     dense_optimizer = KeyedOptimizerWrapper(
         remaining_params,
         lambda params: dense_optim_cls(params, **dense_optim_kwargs),
@@ -831,6 +863,8 @@ def train_and_evaluate(
                 norm_type=gc_config.norm_type,
                 enable_global_grad_clip=gc_config.enable_global_grad_clip,
             )
+    if dense_ema is not None:
+        combined_optimizer = EMAOptimizer(combined_optimizer, dense_ema)
     optimizer = TZRecOptimizer(
         combined_optimizer,
         grad_scaler=grad_scaler,
@@ -877,6 +911,7 @@ def train_and_evaluate(
         dataloader_state=dataloader_state,
         delta_embedding_dumper=delta_embedding_dumper,
         pipeline_config_path=os.path.join(pipeline_config.model_dir, "pipeline.config"),
+        dense_ema=dense_ema,
     )
     if is_local_rank_zero:
         logger.info("Train and Evaluate Finished.")
@@ -957,7 +992,11 @@ def evaluate(
     )
 
     if checkpoint_path:
-        ckpt_manager.restore(checkpoint_path, model)
+        ckpt_manager.restore(
+            checkpoint_path,
+            model,
+            use_dense_ema=train_config.dense_optimizer.HasField("ema"),
+        )
     else:
         raise ValueError("Eval checkpoint path should be specified.")
 
@@ -1506,7 +1545,11 @@ def predict_checkpoint(
     model.eval()
 
     if checkpoint_path:
-        ckpt_manager.restore(checkpoint_path, model)
+        ckpt_manager.restore(
+            checkpoint_path,
+            model,
+            use_dense_ema=train_config.dense_optimizer.HasField("ema"),
+        )
     else:
         raise ValueError("Predict checkpoint path should be specified.")
 

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -22,6 +22,9 @@ import torch
 
 from tzrec.main import _train_and_evaluate
 from tzrec.optim.ema import DenseEMA
+from tzrec.protos.eval_pb2 import EvalConfig
+from tzrec.protos.export_pb2 import ExportConfig
+from tzrec.protos.optimizer_pb2 import DenseOptimizer, EMAConfig
 
 
 class MainTest(unittest.TestCase):
@@ -58,8 +61,9 @@ class MainTest(unittest.TestCase):
             tensorboard_summaries=[],
             is_profiling=False,
             log_step_count_steps=1,
+            dense_optimizer=DenseOptimizer(),
         )
-        eval_config = SimpleNamespace()
+        eval_config = EvalConfig()
 
         with tempfile.TemporaryDirectory() as model_dir:
             with (
@@ -120,6 +124,7 @@ class MainTest(unittest.TestCase):
             tensorboard_summaries=[],
             is_profiling=False,
             log_step_count_steps=10,
+            dense_optimizer=DenseOptimizer(ema=EMAConfig()),
         )
 
         def assert_ema(*args, **kwargs):
@@ -139,13 +144,16 @@ class MainTest(unittest.TestCase):
                 lr_scheduler=[],
                 model_dir="unused",
                 train_config=train_config,
-                eval_config=SimpleNamespace(),
+                eval_config=EvalConfig(),
                 ckpt_manager=ckpt_manager,
                 dense_ema=dense_ema,
+                export_config=ExportConfig(use_dense_ema=False),
             )
 
         torch.testing.assert_close(parameter, torch.tensor([4.0]))
         self.assertTrue(model.module.model.on_train_end.called)
+        for call in exporter.maybe_export.call_args_list:
+            self.assertIsNone(call.kwargs["dense_ema"])
 
 
 class TrainStepCounterMultiPassTest(unittest.TestCase):

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -18,7 +18,10 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
+
 from tzrec.main import _train_and_evaluate
+from tzrec.optim.ema import DenseEMA
 
 
 class MainTest(unittest.TestCase):
@@ -80,6 +83,69 @@ class MainTest(unittest.TestCase):
                     )
         self.assertTrue(exporter.close.called)
         self.assertTrue(ckpt_manager.close.called)
+
+    def test_train_eval_uses_ema_and_restores_training_parameters(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([2.0]))
+        dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)
+        dense_ema.update()
+        parameter.data.fill_(4.0)
+
+        model = mock.Mock()
+        model.module.model.compute_train_metric.return_value = {}
+        optimizer = mock.Mock()
+        optimizer.params = {}
+        optimizer.param_groups = []
+        train_dataloader = mock.Mock()
+        train_dataloader.get_iterator.return_value = iter([object()])
+        eval_dataloader = mock.Mock()
+        batch = SimpleNamespace(checkpoint_info=None, data_timestamp=-1.0)
+        pipeline = mock.Mock()
+        pipeline.progress.return_value = (
+            {"loss": torch.tensor(1.0)},
+            {},
+            batch,
+        )
+        ckpt_manager = mock.Mock()
+        ckpt_manager.maybe_save.side_effect = [True, False, False]
+        exporter = mock.Mock()
+        train_config = SimpleNamespace(
+            num_steps=1,
+            num_epochs=0,
+            save_checkpoints_steps=1,
+            save_checkpoints_epochs=0,
+            save_checkpoints_timestamp_interval=0,
+            save_checkpoints_timestamps=[],
+            save_checkpoints_timestamp_quorum=0,
+            use_tensorboard=False,
+            tensorboard_summaries=[],
+            is_profiling=False,
+            log_step_count_steps=10,
+        )
+
+        def assert_ema(*args, **kwargs):
+            torch.testing.assert_close(parameter, torch.tensor([2.0]))
+
+        with (
+            mock.patch.dict(os.environ, {"RANK": "1", "LOCAL_RANK": "1"}),
+            mock.patch("tzrec.main.create_train_pipeline", return_value=pipeline),
+            mock.patch("tzrec.main._evaluate", side_effect=assert_ema),
+            mock.patch("tzrec.main.OnlineDenseExportManager", return_value=exporter),
+        ):
+            _train_and_evaluate(
+                model=model,
+                optimizer=optimizer,
+                train_dataloader=train_dataloader,
+                eval_dataloader=eval_dataloader,
+                lr_scheduler=[],
+                model_dir="unused",
+                train_config=train_config,
+                eval_config=SimpleNamespace(),
+                ckpt_manager=ckpt_manager,
+                dense_ema=dense_ema,
+            )
+
+        torch.testing.assert_close(parameter, torch.tensor([4.0]))
+        self.assertTrue(model.module.model.on_train_end.called)
 
 
 class TrainStepCounterMultiPassTest(unittest.TestCase):

--- a/tzrec/optim/ema.py
+++ b/tzrec/optim/ema.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+from contextlib import contextmanager
+from typing import Any, Iterable, Iterator, Mapping
+
+import torch
+from torch import nn
+from torch.optim.swa_utils import AveragedModel, get_ema_multi_avg_fn
+from torchrec.optim import KeyedOptimizer, OptimizerWrapper
+
+DENSE_EMA_N_AVERAGED = "__n_averaged__"
+
+
+class DenseEMA:
+    """Track exponential moving averages of named dense parameters.
+
+    Args:
+        named_parameters: Dense parameters keyed by their model FQN.
+        decay: Exponential moving average decay in ``[0, 1]``.
+    """
+
+    def __init__(
+        self,
+        named_parameters: Mapping[str, nn.Parameter],
+        decay: float,
+    ) -> None:
+        self._names = list(named_parameters.keys())
+        self._source = nn.ParameterList(named_parameters.values())
+        device = self._source[0].device if len(self._source) > 0 else None
+        self._averaged_model = AveragedModel(
+            self._source,
+            device=device,
+            multi_avg_fn=get_ema_multi_avg_fn(decay),
+            use_buffers=False,
+        )
+        self._averaged_model.requires_grad_(False)
+
+    @property
+    def n_averaged(self) -> torch.Tensor:
+        """Number of successful optimizer updates included in the average."""
+        return self._averaged_model.n_averaged
+
+    def update(self) -> None:
+        """Update EMA parameters from the current dense parameters."""
+        self._averaged_model.update_parameters(self._source)
+
+    def named_averaged_parameters(self) -> "OrderedDict[str, torch.Tensor]":
+        """Return EMA parameters keyed by their original model FQN."""
+        return OrderedDict(
+            zip(
+                self._names,
+                self._averaged_model.module.parameters(),
+                strict=True,
+            )
+        )
+
+    def state_dict(self) -> "OrderedDict[str, torch.Tensor]":
+        """Return the distributed-checkpoint state for this EMA."""
+        state = self.named_averaged_parameters()
+        state[DENSE_EMA_N_AVERAGED] = self.n_averaged
+        return state
+
+    @torch.no_grad()
+    def reset(self) -> None:
+        """Reset EMA so the next update copies the current parameters."""
+        self.n_averaged.zero_()
+        self.initialize_missing(self._names)
+
+    @torch.no_grad()
+    def initialize_missing(self, names: Iterable[str]) -> None:
+        """Initialize selected EMA parameters from their current values.
+
+        Args:
+            names: Original parameter FQNs whose EMA state was not restored.
+        """
+        name_to_index = {name: i for i, name in enumerate(self._names)}
+        averaged = list(self._averaged_model.module.parameters())
+        for name in names:
+            index = name_to_index.get(name)
+            if index is not None:
+                averaged[index].copy_(self._source[index])
+
+    @contextmanager
+    def average_parameters(self) -> Iterator[None]:
+        """Temporarily expose EMA values through the live model parameters."""
+        averaged = list(self._averaged_model.module.parameters())
+        swapped = 0
+        with torch.no_grad():
+            for source, average in zip(self._source, averaged, strict=True):
+                temporary = source.detach().clone(memory_format=torch.preserve_format)
+                source.copy_(average)
+                average.copy_(temporary)
+                swapped += 1
+        try:
+            yield
+        finally:
+            with torch.no_grad():
+                for index in range(swapped - 1, -1, -1):
+                    source = self._source[index]
+                    average = averaged[index]
+                    temporary = source.detach().clone(
+                        memory_format=torch.preserve_format
+                    )
+                    source.copy_(average)
+                    average.copy_(temporary)
+
+
+class EMAOptimizer(OptimizerWrapper):
+    """Update Dense EMA after successful optimizer steps.
+
+    Args:
+        optimizer: Optimizer to wrap.
+        dense_ema: Dense EMA state updated after each successful step.
+    """
+
+    def __init__(self, optimizer: KeyedOptimizer, dense_ema: DenseEMA) -> None:
+        super().__init__(optimizer)
+        self._dense_ema = dense_ema
+
+    def step(self, closure: Any = None) -> None:
+        """Run an optimizer step and then update Dense EMA."""
+        self._optimizer.step(closure=closure)
+        self._dense_ema.update()

--- a/tzrec/optim/ema.py
+++ b/tzrec/optim/ema.py
@@ -11,7 +11,7 @@
 
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import Any, Iterable, Iterator, Mapping
+from typing import Any, Iterator, Mapping
 
 import torch
 from torch import nn
@@ -74,21 +74,12 @@ class DenseEMA:
     def reset(self) -> None:
         """Reset EMA so the next update copies the current parameters."""
         self.n_averaged.zero_()
-        self.initialize_missing(self._names)
-
-    @torch.no_grad()
-    def initialize_missing(self, names: Iterable[str]) -> None:
-        """Initialize selected EMA parameters from their current values.
-
-        Args:
-            names: Original parameter FQNs whose EMA state was not restored.
-        """
-        name_to_index = {name: i for i, name in enumerate(self._names)}
-        averaged = list(self._averaged_model.module.parameters())
-        for name in names:
-            index = name_to_index.get(name)
-            if index is not None:
-                averaged[index].copy_(self._source[index])
+        for source, average in zip(
+            self._source,
+            self._averaged_model.module.parameters(),
+            strict=True,
+        ):
+            average.copy_(source)
 
     @contextmanager
     def average_parameters(self) -> Iterator[None]:

--- a/tzrec/optim/ema.py
+++ b/tzrec/optim/ema.py
@@ -36,10 +36,8 @@ class DenseEMA:
     ) -> None:
         self._names = list(named_parameters.keys())
         self._source = nn.ParameterList(named_parameters.values())
-        device = self._source[0].device if len(self._source) > 0 else None
         self._averaged_model = AveragedModel(
             self._source,
-            device=device,
             multi_avg_fn=get_ema_multi_avg_fn(decay),
             use_buffers=False,
         )

--- a/tzrec/optim/ema.py
+++ b/tzrec/optim/ema.py
@@ -54,19 +54,15 @@ class DenseEMA:
         """Update EMA parameters from the current dense parameters."""
         self._averaged_model.update_parameters(self._source)
 
-    def named_averaged_parameters(self) -> "OrderedDict[str, torch.Tensor]":
-        """Return EMA parameters keyed by their original model FQN."""
-        return OrderedDict(
+    def state_dict(self) -> "OrderedDict[str, torch.Tensor]":
+        """Return the distributed-checkpoint state for this EMA."""
+        state = OrderedDict(
             zip(
                 self._names,
                 self._averaged_model.module.parameters(),
                 strict=True,
             )
         )
-
-    def state_dict(self) -> "OrderedDict[str, torch.Tensor]":
-        """Return the distributed-checkpoint state for this EMA."""
-        state = self.named_averaged_parameters()
         state[DENSE_EMA_N_AVERAGED] = self.n_averaged
         return state
 

--- a/tzrec/optim/ema_test.py
+++ b/tzrec/optim/ema_test.py
@@ -27,6 +27,14 @@ class DenseEMATest(unittest.TestCase):
         self.assertTrue(dense_optimizer.HasField("ema"))
         self.assertAlmostEqual(dense_optimizer.ema.decay, 0.999)
 
+    def test_counter_stays_on_cpu(self) -> None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        parameter = torch.nn.Parameter(torch.ones(1, device=device))
+        dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)
+
+        self.assertEqual(dense_ema.n_averaged.device.type, "cpu")
+        self.assertEqual(dense_ema.state_dict()["parameter"].device, parameter.device)
+
     def test_update_and_average_parameters(self) -> None:
         parameter = torch.nn.Parameter(torch.tensor([1.0]))
         dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)

--- a/tzrec/optim/ema_test.py
+++ b/tzrec/optim/ema_test.py
@@ -38,14 +38,14 @@ class DenseEMATest(unittest.TestCase):
 
         self.assertEqual(dense_ema.n_averaged.item(), 2)
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["parameter"],
+            dense_ema.state_dict()["parameter"],
             torch.tensor([3.0]),
         )
         with dense_ema.average_parameters():
             torch.testing.assert_close(parameter, torch.tensor([3.0]))
         torch.testing.assert_close(parameter, torch.tensor([4.0]))
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["parameter"],
+            dense_ema.state_dict()["parameter"],
             torch.tensor([3.0]),
         )
 
@@ -72,11 +72,9 @@ class DenseEMATest(unittest.TestCase):
         dense_ema.reset()
 
         self.assertEqual(dense_ema.n_averaged.item(), 0)
+        torch.testing.assert_close(dense_ema.state_dict()["first"], torch.tensor([3.0]))
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["first"], torch.tensor([3.0])
-        )
-        torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["second"], torch.tensor([4.0])
+            dense_ema.state_dict()["second"], torch.tensor([4.0])
         )
 
     def test_invalid_decay(self) -> None:
@@ -100,7 +98,7 @@ class DenseEMATest(unittest.TestCase):
 
         torch.testing.assert_close(parameter, torch.tensor([4.0]))
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["parameter"],
+            dense_ema.state_dict()["parameter"],
             torch.tensor([3.0]),
         )
 

--- a/tzrec/optim/ema_test.py
+++ b/tzrec/optim/ema_test.py
@@ -62,25 +62,21 @@ class DenseEMATest(unittest.TestCase):
                 raise RuntimeError("evaluation failed")
         torch.testing.assert_close(parameter, torch.tensor([4.0]))
 
-    def test_reset_and_initialize_missing(self) -> None:
+    def test_reset(self) -> None:
         first = torch.nn.Parameter(torch.tensor([1.0]))
         second = torch.nn.Parameter(torch.tensor([2.0]))
         dense_ema = DenseEMA({"first": first, "second": second}, decay=0.5)
         dense_ema.update()
         first.data.fill_(3.0)
         second.data.fill_(4.0)
-        dense_ema.initialize_missing(["second"])
-
-        torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["first"], torch.tensor([1.0])
-        )
-        torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["second"], torch.tensor([4.0])
-        )
         dense_ema.reset()
+
         self.assertEqual(dense_ema.n_averaged.item(), 0)
         torch.testing.assert_close(
             dense_ema.named_averaged_parameters()["first"], torch.tensor([3.0])
+        )
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["second"], torch.tensor([4.0])
         )
 
     def test_invalid_decay(self) -> None:

--- a/tzrec/optim/ema_test.py
+++ b/tzrec/optim/ema_test.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from torchrec.optim import KeyedOptimizerWrapper
+
+from tzrec.optim.ema import DenseEMA, EMAOptimizer
+from tzrec.protos import optimizer_pb2
+
+
+class DenseEMATest(unittest.TestCase):
+    def test_config_default(self) -> None:
+        dense_optimizer = optimizer_pb2.DenseOptimizer()
+        self.assertFalse(dense_optimizer.HasField("ema"))
+
+        dense_optimizer.ema.SetInParent()
+        self.assertTrue(dense_optimizer.HasField("ema"))
+        self.assertAlmostEqual(dense_optimizer.ema.decay, 0.999)
+
+    def test_update_and_average_parameters(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([1.0]))
+        dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)
+
+        parameter.data.fill_(2.0)
+        dense_ema.update()
+        parameter.data.fill_(4.0)
+        dense_ema.update()
+
+        self.assertEqual(dense_ema.n_averaged.item(), 2)
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["parameter"],
+            torch.tensor([3.0]),
+        )
+        with dense_ema.average_parameters():
+            torch.testing.assert_close(parameter, torch.tensor([3.0]))
+        torch.testing.assert_close(parameter, torch.tensor([4.0]))
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["parameter"],
+            torch.tensor([3.0]),
+        )
+
+    def test_average_parameters_restores_after_error(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([1.0]))
+        dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)
+        parameter.data.fill_(2.0)
+        dense_ema.update()
+        parameter.data.fill_(4.0)
+
+        with self.assertRaisesRegex(RuntimeError, "evaluation failed"):
+            with dense_ema.average_parameters():
+                torch.testing.assert_close(parameter, torch.tensor([2.0]))
+                raise RuntimeError("evaluation failed")
+        torch.testing.assert_close(parameter, torch.tensor([4.0]))
+
+    def test_reset_and_initialize_missing(self) -> None:
+        first = torch.nn.Parameter(torch.tensor([1.0]))
+        second = torch.nn.Parameter(torch.tensor([2.0]))
+        dense_ema = DenseEMA({"first": first, "second": second}, decay=0.5)
+        dense_ema.update()
+        first.data.fill_(3.0)
+        second.data.fill_(4.0)
+        dense_ema.initialize_missing(["second"])
+
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["first"], torch.tensor([1.0])
+        )
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["second"], torch.tensor([4.0])
+        )
+        dense_ema.reset()
+        self.assertEqual(dense_ema.n_averaged.item(), 0)
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["first"], torch.tensor([3.0])
+        )
+
+    def test_invalid_decay(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([1.0]))
+        with self.assertRaisesRegex(ValueError, "decay"):
+            DenseEMA({"parameter": parameter}, decay=1.1)
+
+    def test_optimizer_updates_ema_after_step(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([1.0]))
+        dense_ema = DenseEMA({"parameter": parameter}, decay=0.5)
+        optimizer = KeyedOptimizerWrapper(
+            {"parameter": parameter},
+            lambda params: torch.optim.SGD(params, lr=1.0),
+        )
+        optimizer = EMAOptimizer(optimizer, dense_ema)
+
+        parameter.grad = torch.tensor([-1.0])
+        optimizer.step()
+        parameter.grad = torch.tensor([-2.0])
+        optimizer.step()
+
+        torch.testing.assert_close(parameter, torch.tensor([4.0]))
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["parameter"],
+            torch.tensor([3.0]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/optim/optimizer_test.py
+++ b/tzrec/optim/optimizer_test.py
@@ -12,10 +12,8 @@
 import unittest
 
 import torch
-from torch.amp import GradScaler
 from torchrec.optim import KeyedOptimizerWrapper
 
-from tzrec.optim.ema import DenseEMA, EMAOptimizer
 from tzrec.optim.optimizer import TZRecOptimizer
 
 
@@ -54,48 +52,6 @@ class TZRecOptimizerTest(unittest.TestCase):
         torch.testing.assert_close(param_1, torch.tensor([0.9980, 1.9960]))
         optimizer.zero_grad()
         torch.testing.assert_close(param_1.grad, None)
-
-    def test_ema_updates_only_on_gradient_accumulation_boundary(self):
-        param_1 = torch.tensor([1.0], requires_grad=True)
-        dense_ema = DenseEMA({"param_1": param_1}, decay=0.5)
-        keyed_optimizer = KeyedOptimizerWrapper(
-            {"param_1": param_1}, lambda params: torch.optim.SGD(params, lr=1.0)
-        )
-        optimizer = TZRecOptimizer(
-            EMAOptimizer(keyed_optimizer, dense_ema),
-            gradient_accumulation_steps=2,
-        )
-
-        param_1.grad = torch.tensor([-1.0])
-        optimizer.step()
-        self.assertEqual(dense_ema.n_averaged.item(), 0)
-        torch.testing.assert_close(param_1, torch.tensor([1.0]))
-
-        optimizer.step()
-        self.assertEqual(dense_ema.n_averaged.item(), 1)
-        torch.testing.assert_close(param_1, torch.tensor([2.0]))
-        torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["param_1"],
-            torch.tensor([2.0]),
-        )
-
-    def test_ema_does_not_update_when_grad_scaler_skips_step(self):
-        param_1 = torch.tensor([1.0], requires_grad=True)
-        dense_ema = DenseEMA({"param_1": param_1}, decay=0.5)
-        keyed_optimizer = KeyedOptimizerWrapper(
-            {"param_1": param_1}, lambda params: torch.optim.SGD(params, lr=1.0)
-        )
-        grad_scaler = GradScaler("cpu")
-        optimizer = TZRecOptimizer(
-            EMAOptimizer(keyed_optimizer, dense_ema),
-            grad_scaler=grad_scaler,
-        )
-
-        grad_scaler.scale(param_1.sum() * torch.tensor(float("inf"))).backward()
-        optimizer.step()
-
-        self.assertEqual(dense_ema.n_averaged.item(), 0)
-        torch.testing.assert_close(param_1, torch.tensor([1.0]))
 
 
 if __name__ == "__main__":

--- a/tzrec/optim/optimizer_test.py
+++ b/tzrec/optim/optimizer_test.py
@@ -12,8 +12,10 @@
 import unittest
 
 import torch
+from torch.amp import GradScaler
 from torchrec.optim import KeyedOptimizerWrapper
 
+from tzrec.optim.ema import DenseEMA, EMAOptimizer
 from tzrec.optim.optimizer import TZRecOptimizer
 
 
@@ -52,6 +54,48 @@ class TZRecOptimizerTest(unittest.TestCase):
         torch.testing.assert_close(param_1, torch.tensor([0.9980, 1.9960]))
         optimizer.zero_grad()
         torch.testing.assert_close(param_1.grad, None)
+
+    def test_ema_updates_only_on_gradient_accumulation_boundary(self):
+        param_1 = torch.tensor([1.0], requires_grad=True)
+        dense_ema = DenseEMA({"param_1": param_1}, decay=0.5)
+        keyed_optimizer = KeyedOptimizerWrapper(
+            {"param_1": param_1}, lambda params: torch.optim.SGD(params, lr=1.0)
+        )
+        optimizer = TZRecOptimizer(
+            EMAOptimizer(keyed_optimizer, dense_ema),
+            gradient_accumulation_steps=2,
+        )
+
+        param_1.grad = torch.tensor([-1.0])
+        optimizer.step()
+        self.assertEqual(dense_ema.n_averaged.item(), 0)
+        torch.testing.assert_close(param_1, torch.tensor([1.0]))
+
+        optimizer.step()
+        self.assertEqual(dense_ema.n_averaged.item(), 1)
+        torch.testing.assert_close(param_1, torch.tensor([2.0]))
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["param_1"],
+            torch.tensor([2.0]),
+        )
+
+    def test_ema_does_not_update_when_grad_scaler_skips_step(self):
+        param_1 = torch.tensor([1.0], requires_grad=True)
+        dense_ema = DenseEMA({"param_1": param_1}, decay=0.5)
+        keyed_optimizer = KeyedOptimizerWrapper(
+            {"param_1": param_1}, lambda params: torch.optim.SGD(params, lr=1.0)
+        )
+        grad_scaler = GradScaler("cpu")
+        optimizer = TZRecOptimizer(
+            EMAOptimizer(keyed_optimizer, dense_ema),
+            grad_scaler=grad_scaler,
+        )
+
+        grad_scaler.scale(param_1.sum() * torch.tensor(float("inf"))).backward()
+        optimizer.step()
+
+        self.assertEqual(dense_ema.n_averaged.item(), 0)
+        torch.testing.assert_close(param_1, torch.tensor([1.0]))
 
 
 if __name__ == "__main__":

--- a/tzrec/protos/eval.proto
+++ b/tzrec/protos/eval.proto
@@ -6,4 +6,6 @@ message EvalConfig {
     optional uint32 num_steps = 1;
     // the frequency progress be logged during eval
     optional uint32 log_step_count_steps = 2 [default = 10];
+    // Whether evaluation uses dense EMA parameters.
+    optional bool use_dense_ema = 3;
 }

--- a/tzrec/protos/export.proto
+++ b/tzrec/protos/export.proto
@@ -21,4 +21,6 @@ message ExportConfig {
     optional bool cudnn_allow_tf32 = 5 [default = true];
     // whether to use torch.backends.cuda.matmul.allow_tf32
     optional bool cuda_matmul_allow_tf32 = 6 [default = false];
+    // Whether export uses dense EMA parameters.
+    optional bool use_dense_ema = 7;
 }

--- a/tzrec/protos/optimizer.proto
+++ b/tzrec/protos/optimizer.proto
@@ -23,6 +23,11 @@ message SparseOptimizer {
     }
 }
 
+message EMAConfig {
+    // Exponential moving average decay in [0, 1].
+    optional float decay = 1 [default = 0.999];
+}
+
 message DenseOptimizer {
     oneof optimizer {
         SGDOptimizer sgd_optimizer = 1;
@@ -40,6 +45,7 @@ message DenseOptimizer {
         CosineAnnealingWarmRestartsLR cosine_annealing_warm_restarts_learning_rate = 105;
     }
     repeated PartOptimizer part_optimizers = 201;
+    optional EMAConfig ema = 202;
 }
 
 message PartOptimizer {

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -90,7 +90,6 @@ def remap_input_tile_user_key(
 
 # queue token meaning "run a prune pass"; ``None`` means "stop the worker".
 _PRUNE_REQUEST = object()
-DENSE_EMA_CKPT_DIR = "dense_ema"
 
 
 class PartialLoadPlanner(DefaultLoadPlanner):
@@ -972,7 +971,7 @@ def restore_model(
     meta_path = os.path.join(checkpoint_dir, "meta")
     model_ckpt_path = os.path.join(checkpoint_dir, "model")
     optim_ckpt_path = os.path.join(checkpoint_dir, "optimizer")
-    dense_ema_ckpt_path = os.path.join(checkpoint_dir, DENSE_EMA_CKPT_DIR)
+    dense_ema_ckpt_path = os.path.join(checkpoint_dir, "dense_ema")
 
     cur_world_size = dist.get_world_size() if dist.is_initialized() else 1
     needs_mch_redistribution = _needs_mch_redistribution(
@@ -1132,7 +1131,7 @@ def save_model(
     if dense_ema is not None:
         save(
             dense_ema.state_dict(),
-            checkpoint_id=os.path.join(checkpoint_dir, DENSE_EMA_CKPT_DIR),
+            checkpoint_id=os.path.join(checkpoint_dir, "dense_ema"),
         )
     if has_dynamicemb:
         from dynamicemb.dump_load import DynamicEmbDump

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -41,6 +41,7 @@ from torchrec.modules.mc_modules import MCHManagedCollisionModule
 
 from tzrec.acc.utils import is_input_tile_emb
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
+from tzrec.optim.ema import DENSE_EMA_N_AVERAGED, DenseEMA
 from tzrec.protos import export_pb2
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
@@ -89,6 +90,7 @@ def remap_input_tile_user_key(
 
 # queue token meaning "run a prune pass"; ``None`` means "stop the worker".
 _PRUNE_REQUEST = object()
+DENSE_EMA_CKPT_DIR = "dense_ema"
 
 
 class PartialLoadPlanner(DefaultLoadPlanner):
@@ -104,6 +106,7 @@ class PartialLoadPlanner(DefaultLoadPlanner):
             do not include the current rank's boundaries would crash
             ``validate_state()``. Set this when the saved world size is
             not a multiple divisor of the current world size.
+        warn_on_missing_keys (bool): Log states absent from the checkpoint.
 
     Model states missing from the checkpoint are skipped with a warning and
     recorded in ``skipped_keys``.
@@ -115,10 +118,12 @@ class PartialLoadPlanner(DefaultLoadPlanner):
         flatten_sharded_tensors: bool = True,
         ckpt_param_map_path: Optional[str] = None,
         skip_output_segments_tensor: bool = False,
+        warn_on_missing_keys: bool = True,
     ) -> None:
         super().__init__(flatten_state_dict, flatten_sharded_tensors)
         self._ckpt_param_map = dict()
         self._skip_output_segments_tensor = skip_output_segments_tensor
+        self._warn_on_missing_keys = warn_on_missing_keys
         self.skipped_keys: List[str] = []
         if ckpt_param_map_path:
             with open(ckpt_param_map_path) as f:
@@ -189,7 +194,8 @@ class PartialLoadPlanner(DefaultLoadPlanner):
             if meta_fqn in self.metadata.state_dict_metadata:
                 md = self.metadata.state_dict_metadata[meta_fqn]
             else:
-                logger.warning(f"Skip restore state [{fqn}]")
+                if self._warn_on_missing_keys:
+                    logger.warning(f"Skip restore state [{fqn}]")
                 self.skipped_keys.append(fqn)
                 continue
 
@@ -383,10 +389,11 @@ class CheckpointManager:
         model: nn.Module,
         optimizer: Optional[optim.Optimizer] = None,
         dataloader_state: Optional[Dict[str, Any]] = None,
+        dense_ema: Optional[DenseEMA] = None,
     ) -> str:
         """Save a checkpoint at the given step, then request an async prune."""
         ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
-        save_model(ckpt_dir, model, optimizer)
+        save_model(ckpt_dir, model, optimizer, dense_ema)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
         self._last_ckpt_dir = ckpt_dir
@@ -473,6 +480,7 @@ class CheckpointManager:
         model: nn.Module,
         optimizer: Optional[optim.Optimizer] = None,
         dataloader_state: Optional[Dict[str, Any]] = None,
+        dense_ema: Optional[DenseEMA] = None,
         *,
         epoch: Optional[int] = None,
         data_timestamp: float = -1.0,
@@ -492,6 +500,7 @@ class CheckpointManager:
             optimizer: optimizer to save, if any.
             dataloader_state: dataloader resume state; the event-time watermark is
                 stamped into it on save.
+            dense_ema: Dense EMA state to save, if enabled.
             epoch: current epoch; enables the epoch trigger when not None.
             data_timestamp: this rank's consumed event-time (seconds), -1.0 if none;
                 reconciled across workers (quorum) for the event-time trigger.
@@ -545,7 +554,7 @@ class CheckpointManager:
         if data_ts is not None:
             # advance the watermark on every save so resume is exact
             self._last_data_ts = data_ts
-        self.save(step, model, optimizer, dataloader_state)
+        self.save(step, model, optimizer, dataloader_state, dense_ema)
         return True
 
     def prune(self) -> None:
@@ -599,9 +608,18 @@ class CheckpointManager:
         model: nn.Module,
         optimizer: Optional[optim.Optimizer] = None,
         ckpt_param_map_path: Optional[str] = None,
+        dense_ema: Optional[DenseEMA] = None,
+        use_dense_ema: bool = False,
     ) -> None:
         """Restore model/optimizer state from a checkpoint dir."""
-        restore_model(ckpt_path, model, optimizer, ckpt_param_map_path)
+        restore_model(
+            ckpt_path,
+            model,
+            optimizer,
+            ckpt_param_map_path,
+            dense_ema=dense_ema,
+            use_dense_ema=use_dense_ema,
+        )
 
     def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, Any]]:
         """Restore dataloader state saved alongside a checkpoint.
@@ -929,6 +947,8 @@ def restore_model(
     optimizer: Optional[optim.Optimizer] = None,
     ckpt_param_map_path: Optional[str] = None,
     error_on_missing_keys: bool = False,
+    dense_ema: Optional[DenseEMA] = None,
+    use_dense_ema: bool = False,
 ) -> None:
     """Restore model state.
 
@@ -940,6 +960,8 @@ def restore_model(
         error_on_missing_keys (bool): If True, raise RuntimeError when the
             model has states absent from the checkpoint instead of skipping
             them with a warning (which would leave them uninitialized).
+        dense_ema: Dense EMA state to restore for continued training.
+        use_dense_ema: Overlay Dense EMA parameters onto the restored model.
     """
     is_local_rank_zero = int(os.environ.get("LOCAL_RANK", 0)) == 0
     if is_local_rank_zero:
@@ -950,6 +972,7 @@ def restore_model(
     meta_path = os.path.join(checkpoint_dir, "meta")
     model_ckpt_path = os.path.join(checkpoint_dir, "model")
     optim_ckpt_path = os.path.join(checkpoint_dir, "optimizer")
+    dense_ema_ckpt_path = os.path.join(checkpoint_dir, DENSE_EMA_CKPT_DIR)
 
     cur_world_size = dist.get_world_size() if dist.is_initialized() else 1
     needs_mch_redistribution = _needs_mch_redistribution(
@@ -1007,6 +1030,53 @@ def restore_model(
             if is_local_rank_zero:
                 logger.warning(f"optim_ckpt_path[{optim_ckpt_path}] not exists.")
 
+    if dense_ema is not None:
+        if os.path.exists(dense_ema_ckpt_path):
+            state_dict = dense_ema.state_dict()
+            planner = PartialLoadPlanner(
+                ckpt_param_map_path=ckpt_param_map_path,
+                warn_on_missing_keys=False,
+            )
+            load(
+                state_dict,
+                checkpoint_id=dense_ema_ckpt_path,
+                planner=planner,
+            )
+            dense_ema.initialize_missing(
+                name for name in planner.skipped_keys if name != DENSE_EMA_N_AVERAGED
+            )
+        else:
+            if is_local_rank_zero:
+                logger.warning(
+                    f"Dense EMA checkpoint [{dense_ema_ckpt_path}] not found; "
+                    "EMA will restart from the next optimizer step."
+                )
+            dense_ema.reset()
+
+    if use_dense_ema:
+        if os.path.exists(dense_ema_ckpt_path):
+            state_dict = dict(model.named_parameters())
+            planner = PartialLoadPlanner(
+                ckpt_param_map_path=ckpt_param_map_path,
+                warn_on_missing_keys=False,
+            )
+            load(
+                state_dict,
+                checkpoint_id=dense_ema_ckpt_path,
+                planner=planner,
+            )
+            restored_count = len(state_dict) - len(planner.skipped_keys)
+            if restored_count == 0 and is_local_rank_zero:
+                logger.warning(
+                    f"No Dense EMA parameters from [{dense_ema_ckpt_path}] "
+                    "matched the restored model."
+                )
+        elif is_local_rank_zero:
+            logger.warning(
+                f"Dense EMA checkpoint [{dense_ema_ckpt_path}] not found; "
+                "using original model parameters."
+            )
+
     if has_dynamicemb:
         from dynamicemb.dump_load import DynamicEmbLoad
 
@@ -1047,7 +1117,10 @@ def restore_model(
 
 
 def save_model(
-    checkpoint_dir: str, model: nn.Module, optimizer: Optional[optim.Optimizer] = None
+    checkpoint_dir: str,
+    model: nn.Module,
+    optimizer: Optional[optim.Optimizer] = None,
+    dense_ema: Optional[DenseEMA] = None,
 ) -> None:
     """Save model state.
 
@@ -1055,6 +1128,7 @@ def save_model(
         checkpoint_dir (str): easyrec model checkpoint dir.
         model (nn.Module): a EasyRec model.
         optimizer (optim.Optimizer, optional): a optimizer.
+        dense_ema: Dense EMA state to save.
     """
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:
         logger.info(f"Saving checkpoint to {checkpoint_dir}...")
@@ -1063,6 +1137,11 @@ def save_model(
         save(
             optimizer.state_dict(),
             checkpoint_id=os.path.join(checkpoint_dir, "optimizer"),
+        )
+    if dense_ema is not None:
+        save(
+            dense_ema.state_dict(),
+            checkpoint_id=os.path.join(checkpoint_dir, DENSE_EMA_CKPT_DIR),
         )
     if has_dynamicemb:
         from dynamicemb.dump_load import DynamicEmbDump

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -1062,12 +1062,6 @@ def restore_model(
                 checkpoint_id=dense_ema_ckpt_path,
                 planner=planner,
             )
-            restored_count = len(state_dict) - len(planner.skipped_keys)
-            if restored_count == 0 and is_local_rank_zero:
-                logger.warning(
-                    f"No Dense EMA parameters from [{dense_ema_ckpt_path}] "
-                    "matched the restored model."
-                )
         elif is_local_rank_zero:
             logger.warning(
                 f"Dense EMA checkpoint [{dense_ema_ckpt_path}] not found; "

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -41,7 +41,7 @@ from torchrec.modules.mc_modules import MCHManagedCollisionModule
 
 from tzrec.acc.utils import is_input_tile_emb
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
-from tzrec.optim.ema import DENSE_EMA_N_AVERAGED, DenseEMA
+from tzrec.optim.ema import DenseEMA
 from tzrec.protos import export_pb2
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
@@ -1031,6 +1031,7 @@ def restore_model(
                 logger.warning(f"optim_ckpt_path[{optim_ckpt_path}] not exists.")
 
     if dense_ema is not None:
+        dense_ema.reset()
         if os.path.exists(dense_ema_ckpt_path):
             state_dict = dense_ema.state_dict()
             planner = PartialLoadPlanner(
@@ -1042,16 +1043,12 @@ def restore_model(
                 checkpoint_id=dense_ema_ckpt_path,
                 planner=planner,
             )
-            dense_ema.initialize_missing(
-                name for name in planner.skipped_keys if name != DENSE_EMA_N_AVERAGED
-            )
         else:
             if is_local_rank_zero:
                 logger.warning(
                     f"Dense EMA checkpoint [{dense_ema_ckpt_path}] not found; "
                     "EMA will restart from the next optimizer step."
                 )
-            dense_ema.reset()
 
     if use_dense_ema:
         if os.path.exists(dense_ema_ckpt_path):

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -585,7 +585,7 @@ class CheckpointUtilTest(unittest.TestCase):
                 torch.full_like(resumed_model.dense.weight, 4.0),
             )
             torch.testing.assert_close(
-                resumed_ema.named_averaged_parameters()["dense.weight"],
+                resumed_ema.state_dict()["dense.weight"],
                 torch.full_like(resumed_model.dense.weight, 3.0),
             )
             self.assertEqual(resumed_ema.n_averaged.item(), 2)
@@ -614,11 +614,11 @@ class CheckpointUtilTest(unittest.TestCase):
             )
         self.assertEqual(dense_ema.n_averaged.item(), 0)
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["weight"],
+            dense_ema.state_dict()["weight"],
             torch.full_like(model.weight, 3.0),
         )
         torch.testing.assert_close(
-            dense_ema.named_averaged_parameters()["bias"],
+            dense_ema.state_dict()["bias"],
             torch.full_like(model.bias, 4.0),
         )
 
@@ -655,11 +655,11 @@ class CheckpointUtilTest(unittest.TestCase):
 
         self.assertEqual(resumed_ema.n_averaged.item(), 1)
         torch.testing.assert_close(
-            resumed_ema.named_averaged_parameters()["weight"],
+            resumed_ema.state_dict()["weight"],
             torch.full_like(resumed_model.weight, 2.0),
         )
         torch.testing.assert_close(
-            resumed_ema.named_averaged_parameters()["bias"],
+            resumed_ema.state_dict()["bias"],
             torch.full_like(resumed_model.bias, 5.0),
         )
 

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -36,6 +36,7 @@ from torchrec.optim.optimizers import in_backward_optimizer_filter
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
+from tzrec.optim.ema import DenseEMA
 from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.utils import checkpoint_util, misc_util
 from tzrec.utils.test_util import make_test_dir
@@ -497,6 +498,118 @@ class CheckpointUtilTest(unittest.TestCase):
                 )
         finally:
             dist.destroy_process_group()
+
+    def test_dense_ema_save_restore_and_inference_overlay(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = nn.Embedding(3, 2)
+                self.dense = nn.Linear(2, 1)
+                self.bn = nn.BatchNorm1d(1)
+
+        model = Model()
+        dense_ema = DenseEMA(
+            {
+                "dense.weight": model.dense.weight,
+                "dense.bias": model.dense.bias,
+            },
+            decay=0.5,
+        )
+        with torch.no_grad():
+            model.dense.weight.fill_(2.0)
+            model.dense.bias.fill_(2.0)
+            model.embedding.weight.fill_(5.0)
+            model.bn.running_mean.fill_(7.0)
+        dense_ema.update()
+        with torch.no_grad():
+            model.dense.weight.fill_(4.0)
+            model.dense.bias.fill_(4.0)
+        dense_ema.update()
+
+        with mock.patch.object(checkpoint_util, "has_dynamicemb", False):
+            checkpoint_util.save_model(
+                self.test_dir,
+                model,
+                dense_ema=dense_ema,
+            )
+
+            raw_model = Model()
+            checkpoint_util.restore_model(self.test_dir, raw_model)
+            torch.testing.assert_close(
+                raw_model.dense.weight,
+                torch.full_like(raw_model.dense.weight, 4.0),
+            )
+            torch.testing.assert_close(
+                raw_model.embedding.weight,
+                torch.full_like(raw_model.embedding.weight, 5.0),
+            )
+            torch.testing.assert_close(
+                raw_model.bn.running_mean,
+                torch.full_like(raw_model.bn.running_mean, 7.0),
+            )
+
+            inference_model = Model()
+            checkpoint_util.restore_model(
+                self.test_dir,
+                inference_model,
+                use_dense_ema=True,
+            )
+            torch.testing.assert_close(
+                inference_model.dense.weight,
+                torch.full_like(inference_model.dense.weight, 3.0),
+            )
+            torch.testing.assert_close(
+                inference_model.embedding.weight,
+                torch.full_like(inference_model.embedding.weight, 5.0),
+            )
+            torch.testing.assert_close(
+                inference_model.bn.running_mean,
+                torch.full_like(inference_model.bn.running_mean, 7.0),
+            )
+
+            resumed_model = Model()
+            resumed_ema = DenseEMA(
+                {
+                    "dense.weight": resumed_model.dense.weight,
+                    "dense.bias": resumed_model.dense.bias,
+                },
+                decay=0.5,
+            )
+            checkpoint_util.restore_model(
+                self.test_dir,
+                resumed_model,
+                dense_ema=resumed_ema,
+            )
+            torch.testing.assert_close(
+                resumed_model.dense.weight,
+                torch.full_like(resumed_model.dense.weight, 4.0),
+            )
+            torch.testing.assert_close(
+                resumed_ema.named_averaged_parameters()["dense.weight"],
+                torch.full_like(resumed_model.dense.weight, 3.0),
+            )
+            self.assertEqual(resumed_ema.n_averaged.item(), 2)
+
+    def test_dense_ema_missing_checkpoint_resets_state(self):
+        model = nn.Linear(2, 1)
+        dense_ema = DenseEMA(
+            {
+                "weight": model.weight,
+                "bias": model.bias,
+            },
+            decay=0.5,
+        )
+        dense_ema.update()
+        self.assertEqual(dense_ema.n_averaged.item(), 1)
+
+        with mock.patch.object(checkpoint_util, "has_dynamicemb", False):
+            checkpoint_util.save_model(self.test_dir, model)
+            checkpoint_util.restore_model(
+                self.test_dir,
+                model,
+                dense_ema=dense_ema,
+            )
+        self.assertEqual(dense_ema.n_averaged.item(), 0)
 
     def test_remap_input_tile_user_key_maps_user_twins(self) -> None:
         self.assertEqual(

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -601,6 +601,9 @@ class CheckpointUtilTest(unittest.TestCase):
         )
         dense_ema.update()
         self.assertEqual(dense_ema.n_averaged.item(), 1)
+        with torch.no_grad():
+            model.weight.fill_(3.0)
+            model.bias.fill_(4.0)
 
         with mock.patch.object(checkpoint_util, "has_dynamicemb", False):
             checkpoint_util.save_model(self.test_dir, model)
@@ -610,6 +613,55 @@ class CheckpointUtilTest(unittest.TestCase):
                 dense_ema=dense_ema,
             )
         self.assertEqual(dense_ema.n_averaged.item(), 0)
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["weight"],
+            torch.full_like(model.weight, 3.0),
+        )
+        torch.testing.assert_close(
+            dense_ema.named_averaged_parameters()["bias"],
+            torch.full_like(model.bias, 4.0),
+        )
+
+    def test_dense_ema_partial_checkpoint_keeps_restored_model_parameters(self):
+        model = nn.Linear(2, 1)
+        with torch.no_grad():
+            model.weight.fill_(2.0)
+            model.bias.fill_(3.0)
+        dense_ema = DenseEMA({"weight": model.weight}, decay=0.5)
+        dense_ema.update()
+        with torch.no_grad():
+            model.weight.fill_(4.0)
+            model.bias.fill_(5.0)
+
+        with mock.patch.object(checkpoint_util, "has_dynamicemb", False):
+            checkpoint_util.save_model(
+                self.test_dir,
+                model,
+                dense_ema=dense_ema,
+            )
+            resumed_model = nn.Linear(2, 1)
+            resumed_ema = DenseEMA(
+                {
+                    "weight": resumed_model.weight,
+                    "bias": resumed_model.bias,
+                },
+                decay=0.5,
+            )
+            checkpoint_util.restore_model(
+                self.test_dir,
+                resumed_model,
+                dense_ema=resumed_ema,
+            )
+
+        self.assertEqual(resumed_ema.n_averaged.item(), 1)
+        torch.testing.assert_close(
+            resumed_ema.named_averaged_parameters()["weight"],
+            torch.full_like(resumed_model.weight, 2.0),
+        )
+        torch.testing.assert_close(
+            resumed_ema.named_averaged_parameters()["bias"],
+            torch.full_like(resumed_model.bias, 5.0),
+        )
 
     def test_remap_input_tile_user_key_maps_user_twins(self) -> None:
         self.assertEqual(

--- a/tzrec/utils/config_util.py
+++ b/tzrec/utils/config_util.py
@@ -11,13 +11,13 @@
 
 import os
 import re
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Type, Union
 
 import numpy as np
 from google.protobuf import json_format, text_format
 from google.protobuf.message import Message
 
-from tzrec.protos import data_pb2, pipeline_pb2
+from tzrec.protos import data_pb2, eval_pb2, export_pb2, pipeline_pb2, train_pb2
 from tzrec.protos.data_pb2 import FgMode
 from tzrec.utils.logging_util import logger
 
@@ -73,6 +73,21 @@ def config_to_kwargs(config: Message) -> Dict[str, Any]:
 def which_msg(config: Message, oneof_group: str) -> str:
     """Returns the name of the message that is set inside a oneof group."""
     return getattr(config, config.WhichOneof(oneof_group)).__class__.__name__
+
+
+def use_dense_ema(
+    config: Union[eval_pb2.EvalConfig, export_pb2.ExportConfig],
+    train_config: train_pb2.TrainConfig,
+) -> bool:
+    """Resolve whether evaluation or export should use Dense EMA parameters.
+
+    Args:
+        config: EvalConfig or ExportConfig containing the optional override.
+        train_config: Training configuration providing the default.
+    """
+    if config.HasField("use_dense_ema"):
+        return bool(config.use_dense_ema)
+    return train_config.dense_optimizer.HasField("ema")
 
 
 def _get_compatible_fg_mode(data_config: data_pb2.DataConfig) -> FgMode:

--- a/tzrec/utils/config_util.py
+++ b/tzrec/utils/config_util.py
@@ -11,7 +11,7 @@
 
 import os
 import re
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import numpy as np
 from google.protobuf import json_format, text_format
@@ -76,16 +76,17 @@ def which_msg(config: Message, oneof_group: str) -> str:
 
 
 def use_dense_ema(
-    config: Union[eval_pb2.EvalConfig, export_pb2.ExportConfig],
+    config: Optional[Union[eval_pb2.EvalConfig, export_pb2.ExportConfig]],
     train_config: train_pb2.TrainConfig,
 ) -> bool:
     """Resolve whether evaluation or export should use Dense EMA parameters.
 
     Args:
-        config: EvalConfig or ExportConfig containing the optional override.
+        config: EvalConfig or ExportConfig containing the optional override,
+            or None to use the training default.
         train_config: Training configuration providing the default.
     """
-    if config.HasField("use_dense_ema"):
+    if config is not None and config.HasField("use_dense_ema"):
         return bool(config.use_dense_ema)
     return train_config.dense_optimizer.HasField("ema")
 

--- a/tzrec/utils/config_util_test.py
+++ b/tzrec/utils/config_util_test.py
@@ -11,10 +11,46 @@
 
 import unittest
 
+from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import config_util
 
 
 class ConfigUtilTest(unittest.TestCase):
+    def test_use_dense_ema(self):
+        for config_field in ("eval_config", "export_config"):
+            with self.subTest(config_field=config_field):
+                pipeline_config = EasyRecConfig()
+                config = getattr(pipeline_config, config_field)
+
+                self.assertFalse(
+                    config_util.use_dense_ema(
+                        config,
+                        pipeline_config.train_config,
+                    )
+                )
+                pipeline_config.train_config.dense_optimizer.ema.SetInParent()
+                self.assertTrue(
+                    config_util.use_dense_ema(
+                        config,
+                        pipeline_config.train_config,
+                    )
+                )
+
+                config.use_dense_ema = False
+                self.assertFalse(
+                    config_util.use_dense_ema(
+                        config,
+                        pipeline_config.train_config,
+                    )
+                )
+                config.use_dense_ema = True
+                self.assertTrue(
+                    config_util.use_dense_ema(
+                        config,
+                        pipeline_config.train_config,
+                    )
+                )
+
     def test_edit_config(self):
         pipeline_config = config_util.load_pipeline_config(
             "examples/multi_tower_taobao.config"

--- a/tzrec/utils/config_util_test.py
+++ b/tzrec/utils/config_util_test.py
@@ -17,6 +17,21 @@ from tzrec.utils import config_util
 
 class ConfigUtilTest(unittest.TestCase):
     def test_use_dense_ema(self):
+        pipeline_config = EasyRecConfig()
+        self.assertFalse(
+            config_util.use_dense_ema(
+                None,
+                pipeline_config.train_config,
+            )
+        )
+        pipeline_config.train_config.dense_optimizer.ema.SetInParent()
+        self.assertTrue(
+            config_util.use_dense_ema(
+                None,
+                pipeline_config.train_config,
+            )
+        )
+
         for config_field in ("eval_config", "export_config"):
             with self.subTest(config_field=config_field):
                 pipeline_config = EasyRecConfig()

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -247,7 +247,10 @@ def export_model_normal(
         checkpoint_util.restore_model(
             checkpoint_path,
             model,
-            use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+            use_dense_ema=config_util.use_dense_ema(
+                pipeline_config.export_config,
+                pipeline_config.train_config,
+            ),
         )
         # for mc modules, fix output_segments_tensor is a meta tensor.
         fix_mch_state(model)
@@ -1152,7 +1155,10 @@ def export_rtp_model(
     checkpoint_util.restore_model(
         checkpoint_path,
         gm,
-        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+        use_dense_ema=config_util.use_dense_ema(
+            pipeline_config.export_config,
+            pipeline_config.train_config,
+        ),
     )
 
     if is_rank_zero:
@@ -1648,7 +1654,10 @@ def export_distributed_embedding(
     checkpoint_util.restore_model(
         checkpoint_path,
         gm,
-        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+        use_dense_ema=config_util.use_dense_ema(
+            pipeline_config.export_config,
+            pipeline_config.train_config,
+        ),
     )
 
     if is_rank_zero:
@@ -2086,7 +2095,10 @@ def export_dense_model_cpu(
         checkpoint_path,
         gm,
         error_on_missing_keys=True,
-        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+        use_dense_ema=config_util.use_dense_ema(
+            pipeline_config.export_config,
+            pipeline_config.train_config,
+        ),
     )
     finalize_dense_export(
         model, full_graph, gm, data, device, save_dir, dense_graph_config

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -244,7 +244,11 @@ def export_model_normal(
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
         init_parameters(model, torch.device("cpu"))
-        checkpoint_util.restore_model(checkpoint_path, model)
+        checkpoint_util.restore_model(
+            checkpoint_path,
+            model,
+            use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+        )
         # for mc modules, fix output_segments_tensor is a meta tensor.
         fix_mch_state(model)
 
@@ -1145,7 +1149,11 @@ def export_rtp_model(
     gm = _prune_unused_param_and_buffer(gm)
     init_parameters(gm, device)
     gm.to(device)
-    checkpoint_util.restore_model(checkpoint_path, gm)
+    checkpoint_util.restore_model(
+        checkpoint_path,
+        gm,
+        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+    )
 
     if is_rank_zero:
         with open(os.path.join(graph_dir, "gm_dense.graph"), "w") as f:
@@ -1637,7 +1645,11 @@ def export_distributed_embedding(
 
     init_parameters(gm, device)
     gm.to(device)
-    checkpoint_util.restore_model(checkpoint_path, gm)
+    checkpoint_util.restore_model(
+        checkpoint_path,
+        gm,
+        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+    )
 
     if is_rank_zero:
         with open(os.path.join(save_dir, "dense_meta.json"), "w") as f:
@@ -2070,7 +2082,12 @@ def export_dense_model_cpu(
         pipeline_config, model, device, data_input_path
     )
     gm, full_graph, dense_graph_config = build_dense_graph_module(model, data, device)
-    checkpoint_util.restore_model(checkpoint_path, gm, error_on_missing_keys=True)
+    checkpoint_util.restore_model(
+        checkpoint_path,
+        gm,
+        error_on_missing_keys=True,
+        use_dense_ema=pipeline_config.train_config.dense_optimizer.HasField("ema"),
+    )
     finalize_dense_export(
         model, full_graph, gm, data, device, save_dir, dense_graph_config
     )

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -584,9 +584,7 @@ class OnlineDenseExportManager:
         gathered: Dict[str, torch.Tensor] = {}
         if self._state_pairs:
             source_state = model.state_dict()
-            ema_state = (
-                dense_ema.named_averaged_parameters() if dense_ema is not None else {}
-            )
+            ema_state = dense_ema.state_dict() if dense_ema is not None else {}
             for gm_key, source_key in self._state_pairs:
                 value = ema_state.get(source_key, source_state[source_key])
                 if isinstance(value, DTensor):

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -561,10 +561,7 @@ class OnlineDenseExportManager:
         if data_ts is not None:
             # advance the watermark on every export
             self._last_data_ts = data_ts
-        if dense_ema is None:
-            self._gather_and_submit(step, data_timestamp, model)
-        else:
-            self._gather_and_submit(step, data_timestamp, model, dense_ema)
+        self._gather_and_submit(step, data_timestamp, model, dense_ema)
 
     def _gather_and_submit(
         self,

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -58,6 +58,7 @@ from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._tensor import DTensor
 
 from tzrec.acc import utils as acc_utils
+from tzrec.optim.ema import DenseEMA
 from tzrec.utils import config_util
 from tzrec.utils.checkpoint_util import (
     quorum_event_time,
@@ -521,6 +522,7 @@ class OnlineDenseExportManager:
         data_timestamp: float,
         model: nn.Module,
         final: bool = False,
+        dense_ema: Optional[DenseEMA] = None,
     ) -> None:
         """Export a dense version now if a configured trigger fires.
 
@@ -537,6 +539,7 @@ class OnlineDenseExportManager:
             model: the live DMP training model to gather weights from.
             final: force an export (still subject to the per-step dedupe),
                 e.g. at train end.
+            dense_ema: Dense EMA state to use for exported parameters.
         """
         if not self._enabled:
             return
@@ -558,10 +561,17 @@ class OnlineDenseExportManager:
         if data_ts is not None:
             # advance the watermark on every export
             self._last_data_ts = data_ts
-        self._gather_and_submit(step, data_timestamp, model)
+        if dense_ema is None:
+            self._gather_and_submit(step, data_timestamp, model)
+        else:
+            self._gather_and_submit(step, data_timestamp, model, dense_ema)
 
     def _gather_and_submit(
-        self, step: int, data_timestamp: float, model: nn.Module
+        self,
+        step: int,
+        data_timestamp: float,
+        model: nn.Module,
+        dense_ema: Optional[DenseEMA] = None,
     ) -> None:
         """Gather the dense graph's weights from the DMP model (all ranks).
 
@@ -577,8 +587,11 @@ class OnlineDenseExportManager:
         gathered: Dict[str, torch.Tensor] = {}
         if self._state_pairs:
             source_state = model.state_dict()
+            ema_state = (
+                dense_ema.named_averaged_parameters() if dense_ema is not None else {}
+            )
             for gm_key, source_key in self._state_pairs:
-                value = source_state[source_key]
+                value = ema_state.get(source_key, source_state[source_key])
                 if isinstance(value, DTensor):
                     # collective on the DTensor's mesh; all ranks participate
                     tensor = value.full_tensor()

--- a/tzrec/utils/online_dense_export_util_test.py
+++ b/tzrec/utils/online_dense_export_util_test.py
@@ -660,7 +660,7 @@ class OnlineDenseExportUtilTest(unittest.TestCase):
                             mgr.maybe_export(step, -1.0, model)
                         gather.assert_not_called()
                         mgr.maybe_export(5, -1.0, model)
-                        gather.assert_called_once_with(5, -1.0, model)
+                        gather.assert_called_once_with(5, -1.0, model, None)
                         # same step (even forced) is deduped
                         mgr.maybe_export(5, -1.0, model, final=True)
                         gather.assert_called_once()

--- a/tzrec/utils/online_dense_export_util_test.py
+++ b/tzrec/utils/online_dense_export_util_test.py
@@ -35,6 +35,7 @@ from torch.distributed._shard.sharded_tensor.metadata import (
 from torch.distributed._tensor import DTensor, Replicate
 from torch.distributed.device_mesh import init_device_mesh
 
+from tzrec.optim.ema import DenseEMA
 from tzrec.utils import misc_util
 from tzrec.utils.online_dense_export_util import (
     OnlineDenseExportManager,
@@ -800,6 +801,32 @@ class OnlineDenseExportUtilTest(unittest.TestCase):
                 os.path.exists(os.path.join(versions_root, payload["version"], "READY"))
             )
         torch.testing.assert_close(box["gm"].w, torch.full((2,), 7.0))
+
+    def test_gather_uses_ema_parameters_and_live_buffers(self) -> None:
+        manager = OnlineDenseExportManager.__new__(OnlineDenseExportManager)
+        manager._rank = 0
+        manager._state_pairs = [
+            ("w", "model.w"),
+            ("running", "model.running"),
+        ]
+        parameter = nn.Parameter(torch.full((2,), 2.0))
+        dense_ema = DenseEMA({"model.w": parameter}, decay=0.5)
+        dense_ema.update()
+        parameter.data.fill_(4.0)
+        dense_ema.update()
+        model = _mock_model(
+            {
+                "model.w": parameter,
+                "model.running": torch.full((2,), 7.0),
+            }
+        )
+
+        with mock.patch.object(manager, "_enqueue") as enqueue:
+            manager._gather_and_submit(5, 42.0, model, dense_ema)
+
+        snapshot = enqueue.call_args.args[2]
+        torch.testing.assert_close(snapshot["w"], torch.full((2,), 3.0))
+        torch.testing.assert_close(snapshot["running"], torch.full((2,), 7.0))
 
     def test_maybe_export_gathers_dtensor(self) -> None:
         """Sharded-as-DTensor state is all-gathered via full_tensor()."""

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"


### PR DESCRIPTION
## Summary

Add optional exponential moving average support for dense model parameters through `dense_optimizer.ema.decay`.

The training checkpoint keeps raw parameters in `model/` so optimizer state can resume exactly, while dense EMA parameters and the update count are stored separately in `dense_ema/`. Training evaluation, standalone evaluation, checkpoint prediction, standard exports, distributed/CPU dense exports, and online dense exports use EMA parameters when the option is enabled. Sparse embeddings and live buffers are not averaged.

Old checkpoints without `dense_ema/` emit a warning and fall back to raw parameters. Continued training initializes EMA from the current dense parameters on the next successful optimizer update. The package version is updated from 1.3.7 to 1.3.8.

## Test Plan

- `pre-commit run --files` for all files in this change
- `python -m unittest tzrec.optim.ema_test tzrec.optim.optimizer_test tzrec.main_test tzrec.utils.checkpoint_util_test tzrec.utils.online_dense_export_util_test`
- `python -m unittest tzrec.utils.export_util_test.ExportUtilTest.test_export_dense_model_cpu_end_to_end`
- Regenerated and smoke-tested the `optimizer.proto` Python bindings

Pyre was not run because the matching PyTorch environment does not contain the required Pyre 0.9.25 client; the available system client is 0.9.23.