### PR TITLE
[bugfix] fix fx-trace race in online dense export worker

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -2007,13 +2007,23 @@ def finalize_dense_export(
     device: torch.device,
     save_dir: str,
     dense_graph_config: Dict[str, Any],
-) -> None:
+    dense_model_traced: Optional[torch.fx.GraphModule] = None,
+) -> torch.fx.GraphModule:
     """Sanity-check and script a dense graph carrying its final weights.
 
     Runs the rewritten graph once on serving-style inputs rebuilt from the
     warm-up batch (so graph surgery or KeyedTensor regroup errors surface at
     export time instead of at serving time), then writes dense_meta.json,
     the graph dumps and the scripted model under ``save_dir``.
+
+    FX tracing patches ``torch.nn.Module.__call__`` process-wide for its
+    duration, so it is not safe to run concurrently with eager forwards.
+    Callers that export from a background thread (the online dense export)
+    trace once up front and pass the result via ``dense_model_traced``,
+    reusing it across versions; the traced module shares ``gm``'s parameters,
+    so reloading ``gm``'s weights is reflected without re-tracing. When no
+    traced module is supplied -- the standalone, single-threaded CLI path --
+    it is traced here.
 
     Args:
         model: model the dense graph was traced from.
@@ -2023,6 +2033,11 @@ def finalize_dense_export(
         device: device of ``gm``.
         save_dir: directory the export artifacts are written to.
         dense_graph_config: dense_meta config from build_dense_graph_module.
+        dense_model_traced: pre-traced ``gm`` to script; traced here if None.
+
+    Returns:
+        The traced module that was scripted, so a caller can reuse it across
+        exports without re-tracing.
     """
     graph_dir = os.path.join(save_dir, "graph")
     os.makedirs(save_dir, exist_ok=True)
@@ -2037,11 +2052,13 @@ def finalize_dense_export(
     with open(os.path.join(graph_dir, "gm_dense.graph"), "w") as f:
         f.write(str(gm.graph))
 
-    dense_model_traced = symbolic_trace(gm)
+    if dense_model_traced is None:
+        dense_model_traced = symbolic_trace(gm)
     with open(os.path.join(save_dir, "gm_dense.code"), "w") as f:
         f.write(dense_model_traced.code)
     dense_model_scripted = torch.jit.script(dense_model_traced)
     dense_model_scripted.save(os.path.join(save_dir, "scripted_model.pt"))
+    return dense_model_traced
 
 
 def export_dense_model_cpu(

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1170,44 +1170,52 @@ class ExportUtilTest(unittest.TestCase):
 
             # The online export traces once (captured above) and reuses the
             # traced module across versions instead of re-tracing on the worker.
-            # Reusing it at the same weights must script identical predictions.
-            reuse_dir = os.path.join(test_dir, "dense_export_reuse")
-            finalize_dense_export(
-                live_model,
-                full_graph,
-                gm,
-                warmup_data,
-                device,
-                reuse_dir,
-                dense_graph_config,
-                dense_model_traced=dense_model_traced,
-            )
-            out_reuse = torch.jit.load(os.path.join(reuse_dir, "scripted_model.pt"))(
-                serving_data
-            )
-            for key in out_inproc:
-                torch.testing.assert_close(out_reuse[key], out_inproc[key])
+            # Reusing it must not call symbolic_trace at all: a regression that
+            # re-traces on the reuse path would re-open the worker-thread race
+            # this PR fixes while still passing a mere output-equivalence check,
+            # so patch symbolic_trace to raise under the reuse calls.
+            with mock.patch(
+                "tzrec.utils.export_util.symbolic_trace",
+                side_effect=AssertionError("reuse path must not call symbolic_trace"),
+            ):
+                reuse_dir = os.path.join(test_dir, "dense_export_reuse")
+                finalize_dense_export(
+                    live_model,
+                    full_graph,
+                    gm,
+                    warmup_data,
+                    device,
+                    reuse_dir,
+                    dense_graph_config,
+                    dense_model_traced=dense_model_traced,
+                )
+                out_reuse = torch.jit.load(
+                    os.path.join(reuse_dir, "scripted_model.pt")
+                )(serving_data)
+                for key in out_inproc:
+                    torch.testing.assert_close(out_reuse[key], out_inproc[key])
 
-            # A weight reload into gm (whose parameters the traced module
-            # shares) must be reflected by the reused traced module without
-            # re-tracing, matching a fresh internal-trace finalize on the same
-            # reloaded weights.
-            reloaded = {
-                key: value + 1.0 if value.is_floating_point() else value
-                for key, value in gm.state_dict().items()
-            }
-            gm.load_state_dict(reloaded)
-            reload_reuse_dir = os.path.join(test_dir, "dense_export_reload_reuse")
-            finalize_dense_export(
-                live_model,
-                full_graph,
-                gm,
-                warmup_data,
-                device,
-                reload_reuse_dir,
-                dense_graph_config,
-                dense_model_traced=dense_model_traced,
-            )
+                # A weight reload into gm (whose parameters the traced module
+                # shares) must be reflected by the reused traced module without
+                # re-tracing, matching a fresh internal-trace finalize on the
+                # same reloaded weights.
+                reloaded = {
+                    key: value + 1.0 if value.is_floating_point() else value
+                    for key, value in gm.state_dict().items()
+                }
+                gm.load_state_dict(reloaded)
+                reload_reuse_dir = os.path.join(test_dir, "dense_export_reload_reuse")
+                finalize_dense_export(
+                    live_model,
+                    full_graph,
+                    gm,
+                    warmup_data,
+                    device,
+                    reload_reuse_dir,
+                    dense_graph_config,
+                    dense_model_traced=dense_model_traced,
+                )
+            # The fresh internal-trace path (no cached module) still traces.
             reload_fresh_dir = os.path.join(test_dir, "dense_export_reload_fresh")
             finalize_dense_export(
                 live_model,

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1136,7 +1136,7 @@ class ExportUtilTest(unittest.TestCase):
                         for key in sorted(gm.state_dict().keys())
                     }
                     gm.load_state_dict(snapshot)
-                    finalize_dense_export(
+                    dense_model_traced = finalize_dense_export(
                         live_model,
                         full_graph,
                         gm,
@@ -1167,6 +1167,72 @@ class ExportUtilTest(unittest.TestCase):
             self.assertEqual(set(out_ckpt.keys()), set(out_inproc.keys()))
             for key in out_ckpt:
                 torch.testing.assert_close(out_ckpt[key], out_inproc[key])
+
+            # The online export traces once (captured above) and reuses the
+            # traced module across versions instead of re-tracing on the worker.
+            # Reusing it at the same weights must script identical predictions.
+            reuse_dir = os.path.join(test_dir, "dense_export_reuse")
+            finalize_dense_export(
+                live_model,
+                full_graph,
+                gm,
+                warmup_data,
+                device,
+                reuse_dir,
+                dense_graph_config,
+                dense_model_traced=dense_model_traced,
+            )
+            out_reuse = torch.jit.load(os.path.join(reuse_dir, "scripted_model.pt"))(
+                serving_data
+            )
+            for key in out_inproc:
+                torch.testing.assert_close(out_reuse[key], out_inproc[key])
+
+            # A weight reload into gm (whose parameters the traced module
+            # shares) must be reflected by the reused traced module without
+            # re-tracing, matching a fresh internal-trace finalize on the same
+            # reloaded weights.
+            reloaded = {
+                key: value + 1.0 if value.is_floating_point() else value
+                for key, value in gm.state_dict().items()
+            }
+            gm.load_state_dict(reloaded)
+            reload_reuse_dir = os.path.join(test_dir, "dense_export_reload_reuse")
+            finalize_dense_export(
+                live_model,
+                full_graph,
+                gm,
+                warmup_data,
+                device,
+                reload_reuse_dir,
+                dense_graph_config,
+                dense_model_traced=dense_model_traced,
+            )
+            reload_fresh_dir = os.path.join(test_dir, "dense_export_reload_fresh")
+            finalize_dense_export(
+                live_model,
+                full_graph,
+                gm,
+                warmup_data,
+                device,
+                reload_fresh_dir,
+                dense_graph_config,
+            )
+            out_reload_reuse = torch.jit.load(
+                os.path.join(reload_reuse_dir, "scripted_model.pt")
+            )(serving_data)
+            out_reload_fresh = torch.jit.load(
+                os.path.join(reload_fresh_dir, "scripted_model.pt")
+            )(serving_data)
+            for key in out_reload_fresh:
+                torch.testing.assert_close(out_reload_reuse[key], out_reload_fresh[key])
+            self.assertTrue(
+                any(
+                    not torch.allclose(out_reload_reuse[key], out_reuse[key])
+                    for key in out_reload_reuse
+                ),
+                "weight reload was not reflected by the reused traced module",
+            )
         finally:
             shutil.rmtree(test_dir, ignore_errors=True)
 

--- a/tzrec/utils/online_dense_export_util.py
+++ b/tzrec/utils/online_dense_export_util.py
@@ -281,6 +281,9 @@ class OnlineDenseExportManager:
         self._full_graph: Optional[torch.fx.Graph] = None
         self._warmup_data: Optional[Dict[str, Any]] = None
         self._dense_graph_config: Optional[Dict[str, Any]] = None
+        # FX-traced gm, traced once at construction and reused by every export
+        # so the worker never fx-traces concurrent with training forwards.
+        self._dense_model_traced: Optional[torch.fx.GraphModule] = None
 
         override = os.environ.get("ONLINE_DENSE_EXPORT_DIR")
         export_root = resolve_dense_export_root(model_dir)
@@ -421,10 +424,13 @@ class OnlineDenseExportManager:
                 twin_model, warmup_data, device
             )
             # Fail fast on trace/script errors instead of at the first export.
+            # Tracing happens here on the main thread and the traced module is
+            # reused by every export; fx-tracing on the worker would patch
+            # nn.Module.__call__ process-wide and race training forwards.
             with tempfile.TemporaryDirectory(
                 prefix="online_dense_export_dryrun_"
             ) as dry_run_dir:
-                finalize_dense_export(
+                dense_model_traced = finalize_dense_export(
                     twin_model,
                     full_graph,
                     gm,
@@ -478,6 +484,7 @@ class OnlineDenseExportManager:
         self._full_graph = full_graph
         self._warmup_data = warmup_data
         self._dense_graph_config = dense_graph_config
+        self._dense_model_traced = dense_model_traced
         return pairs
 
     def _verify_state_pairs(self, model: nn.Module) -> None:
@@ -742,6 +749,9 @@ class OnlineDenseExportManager:
             assert self._full_graph is not None
             assert self._warmup_data is not None
             assert self._dense_graph_config is not None
+            assert self._dense_model_traced is not None
+            # load_state_dict copies in place and the traced module shares these
+            # parameters, so it carries the reloaded weights without re-tracing.
             self._gm.load_state_dict(task["snapshot"])
             finalize_dense_export(
                 self._twin_model,
@@ -751,6 +761,7 @@ class OnlineDenseExportManager:
                 device,
                 tmp_dir,
                 self._dense_graph_config,
+                dense_model_traced=self._dense_model_traced,
             )
             ready_path = os.path.join(tmp_dir, "READY")
             with open(ready_path, "w") as f:

--- a/tzrec/utils/online_dense_export_util_test.py
+++ b/tzrec/utils/online_dense_export_util_test.py
@@ -753,6 +753,7 @@ class OnlineDenseExportUtilTest(unittest.TestCase):
             self._full_graph = mock.Mock()
             self._warmup_data = {}
             self._dense_graph_config = {}
+            self._dense_model_traced = mock.Mock()
             return [("w", "model.w")]
 
         with (

--- a/tzrec/utils/online_dense_export_util_test.py
+++ b/tzrec/utils/online_dense_export_util_test.py
@@ -820,6 +820,72 @@ class OnlineDenseExportUtilTest(unittest.TestCase):
             dist.destroy_process_group()
         torch.testing.assert_close(box["gm"].w, torch.full((2,), 9.0))
 
+    def test_worker_reuses_construction_time_traced_module(self) -> None:
+        """The worker scripts the construction-time traced module, not a re-trace.
+
+        The manager traces once during the construction-time dry run and must
+        forward that exact traced module to every worker export. A regression
+        that re-traces on the worker would re-open the fx-trace race this fix
+        targets, yet still pass an output-equivalence check (re-tracing is
+        weight-correct in a single-threaded test), so assert object identity.
+        """
+        sentinel = mock.Mock(name="traced_sentinel")
+        seen: List[Dict[str, Any]] = []
+
+        def fake_finalize(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            # construction dry run returns the cached traced module; the worker
+            # call (with dense_model_traced=) must forward it verbatim.
+            return sentinel
+
+        fake_gm = mock.Mock()
+        fake_gm.state_dict.return_value = {}
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                mock.patch.dict(os.environ, _base_env(tmp_dir), clear=True),
+                mock.patch(
+                    _BUILD_PATCHES.format("config_util.load_pipeline_config"),
+                    return_value=_dummy_pipeline_config(),
+                ),
+                mock.patch("tzrec.main._create_features", return_value=[]),
+                mock.patch("tzrec.main._create_model", return_value=mock.Mock()),
+                mock.patch("tzrec.models.model.ScriptWrapper", side_effect=lambda m: m),
+                mock.patch(
+                    _BUILD_PATCHES.format("create_dense_export_warmup_data"),
+                    return_value={},
+                ),
+                mock.patch(
+                    _BUILD_PATCHES.format("build_dense_graph_module"),
+                    return_value=(fake_gm, mock.Mock(), {}),
+                ),
+                mock.patch(
+                    _BUILD_PATCHES.format("finalize_dense_export"),
+                    side_effect=fake_finalize,
+                ),
+            ):
+                mgr = OnlineDenseExportManager(
+                    model_dir=tmp_dir,
+                    pipeline_config_path=os.path.join(tmp_dir, "pipeline.config"),
+                    model=_mock_model({}),
+                )
+                try:
+                    # the real build stored the construction-time finalize
+                    # return as the cached traced module
+                    self.assertIs(mgr._dense_model_traced, sentinel)
+                    mgr.maybe_export(5, 42.0, _mock_model({}))
+                    current_path = os.path.join(
+                        tmp_dir, "serving_root", "dense_hot_export", "current.json"
+                    )
+                    self.assertTrue(_wait_for(lambda: os.path.exists(current_path)))
+                finally:
+                    mgr.close()
+            # one construction call (no cached module) then one worker call
+            # forwarding the construction-time sentinel verbatim
+            self.assertEqual(len(seen), 2)
+            self.assertNotIn("dense_model_traced", seen[0])
+            self.assertIn("dense_model_traced", seen[1])
+            self.assertIs(seen[1]["dense_model_traced"], sentinel)
+
     # --- publish helpers ---
 
     def test_atomic_write_json_creates_dirs_and_replaces(self) -> None:


### PR DESCRIPTION
## Problem

A training job with the in-process online dense export enabled crashes after it runs long enough for a dense export to fire. Rank 0 dies with:

```
NameError: module is not installed as a submodule
```

raised from `torchrec/fx/tracer.py` `path_of_module`, deep inside a *training* forward (`pipeline.progress` -> model forward). The FeatureStore delta upload then fails with `RuntimeError: cannot schedule new futures after interpreter shutdown` — a secondary symptom of the process tearing down, not a cause.

## Root cause

`finalize_dense_export` called `symbolic_trace(gm)` on every export, and the online dense export runs that on a background worker thread concurrently with the training loop. FX tracing patches `torch.nn.Module.__call__` **process-wide** for the duration of the trace (torch's `Tracer.trace` installs `module_call_wrapper` via `_Patcher`, and torchrec's `Tracer` also flips a module-global `_is_fx_tracing_flag`); it is not thread-safe. When a training forward on the main thread landed in the worker's tracing window, it was intercepted by the worker's tracer, which tried to resolve the live training model's submodule against the export graph root (a separate "twin" module tree) and raised `NameError: module is not installed as a submodule`.

This is a timing race, which is why it only appears after a while: it requires a dense export to fire AND a training forward to fall inside the short `symbolic_trace` window. The dense graph structure is fixed once at construction — only the weights change per export — so the per-export trace was unnecessary work as well as the hazard.

## Solution

Trace the dense graph **once, at construction, on the main thread** (during the existing fail-fast dry run, before the worker starts) and cache the resulting `GraphModule`. The traced module shares parameters with the resident graph `gm`, so each export on the worker only needs to `gm.load_state_dict(snapshot)` (visible to the cached module through the shared parameters) and run `torch.jit.script` — no FX tracing ever runs concurrently with training. `torch.jit.script` compiles statically and does not install the process-wide eager-call hook, so it is safe on the worker (the original crash stack contains only FX frames, no JIT frames).

- `finalize_dense_export` now takes an optional `dense_model_traced`; it traces internally only when none is supplied (the single-threaded standalone `export_dense_model_cpu` CLI path, unchanged) and returns the traced module so a caller can reuse it.
- `OnlineDenseExportManager` caches the traced module from the construction-time dry run and passes it on every export.

## Test Plan

- Verified the design assumptions empirically: the fx-traced module shares `Parameter` objects with `gm` (so an in-place `load_state_dict` on `gm` is reflected without re-tracing), `state_dict` keys match, `.code` is weight-independent, and re-scripting the same cached traced module after a weight reload picks up the new weights.
- `python -m tzrec.utils.online_dense_export_util_test` — 26 tests pass.
- `python -m tzrec.utils.export_util_test ExportUtilTest.test_in_process_dense_export_matches_checkpoint_export` — extended to assert that reusing the traced module scripts predictions identical to the internal-trace path, and that a weight reload into `gm` is reflected by the reused module (matching a fresh internal-trace finalize). Passes.
- `pre-commit run -a` (ruff lint/format, license, codespell) clean.
- Pyre type-check relies on CI (cannot run in the local environment).

## Alternatives considered

- Running the export's `symbolic_trace` / `torch.jit.script` in a separate subprocess for full isolation: correct but much heavier (serialize the graph module and snapshot across the process boundary); rejected since only the trace — not the script — is hazardous and it can simply be hoisted out of the worker.
- Blocking the training thread to trace synchronously per export: removes the race but adds latency to training on every export, defeating the purpose of the background worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
