### PR TITLE
[ci] release GPU cache between HSTU examples

### DIFF
--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -368,14 +368,21 @@ def _build_batch(
 @mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
     def teardown_example(self, example):
-        cleanup_cuda_memory()
+        try:
+            cleanup_cuda_memory()
+        finally:
+            self._cleanup_test_dir()
 
     def setUp(self):
         self.test_dir = None
 
     def tearDown(self):
+        self._cleanup_test_dir()
+
+    def _cleanup_test_dir(self):
         if self.test_dir is not None and os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
+        self.test_dir = None
 
     @unittest.skipIf(*gpu_unavailable)
     @given(

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import os
 import shutil
 import unittest
@@ -366,6 +367,12 @@ def _build_batch(
 
 @mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
+    def teardown_example(self, example):
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.memory_summary()
+
     def setUp(self):
         self.test_dir = None
 

--- a/tzrec/models/dlrm_hstu_test.py
+++ b/tzrec/models/dlrm_hstu_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import os
 import shutil
 import unittest
@@ -38,6 +37,7 @@ from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.utils.state_dict_util import init_parameters
 from tzrec.utils.test_util import (
     TestGraphType,
+    cleanup_cuda_memory,
     create_test_model,
     gpu_unavailable,
     make_test_dir,
@@ -368,10 +368,7 @@ def _build_batch(
 @mark_ci_scope("gpu")
 class DlrmHSTUTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()
+        cleanup_cuda_memory()
 
     def setUp(self):
         self.test_dir = None

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import os
 import shutil
 import unittest
@@ -40,6 +39,7 @@ from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.utils.state_dict_util import init_parameters
 from tzrec.utils.test_util import (
     TestGraphType,
+    cleanup_cuda_memory,
     create_test_model,
     gpu_unavailable,
     make_test_dir,
@@ -330,10 +330,7 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
 @mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()
+        cleanup_cuda_memory()
 
     def setUp(self):
         self.test_dir = None

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -329,14 +329,21 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
 @mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
     def teardown_example(self, example):
-        cleanup_cuda_memory()
+        try:
+            cleanup_cuda_memory()
+        finally:
+            self._cleanup_test_dir()
 
     def setUp(self):
         self.test_dir = None
 
     def tearDown(self):
+        self._cleanup_test_dir()
+
+    def _cleanup_test_dir(self):
         if self.test_dir is not None and os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
+        self.test_dir = None
 
     @unittest.skipIf(*gpu_unavailable)
     @given(
@@ -372,7 +379,7 @@ class UltraHSTUTest(unittest.TestCase):
     )
     @settings(
         verbosity=Verbosity.verbose,
-        max_examples=15,
+        max_examples=20,
         deadline=None,
     )
     def test_ultra_hstu(

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -18,7 +18,6 @@ from typing import List, Tuple
 import torch
 from hypothesis import Verbosity, assume, given
 from hypothesis import strategies as st
-from parameterized import parameterized
 from torchrec import JaggedTensor, KeyedJaggedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, Batch
@@ -339,22 +338,22 @@ class UltraHSTUTest(unittest.TestCase):
         if self.test_dir is not None and os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-    @parameterized.expand(
-        [
-            # Single channel exercises the bare-HSTUTransducer return
-            # path (no _HSTUTransducerStack wrapper).
-            ("single", [("a", 256)]),
-            # Two channels at the same STU dim exercise the wrapper +
-            # concat path.
-            ("multi_uniform", [("a", 256), ("b", 256)]),
-            # Two channels at distinct STU dims so that
-            # _stu_embedding_dim's `sum` is the only correct answer
-            # (it can't collapse to N*dim or max(dims)).
-            ("multi_hetero", [("a", 256), ("b", 512)]),
-        ]
-    )
     @unittest.skipIf(*gpu_unavailable)
     @given(
+        channel_specs=st.sampled_from(
+            [
+                # Single channel exercises the bare-HSTUTransducer return
+                # path (no _HSTUTransducerStack wrapper).
+                [("a", 256)],
+                # Two channels at the same STU dim exercise the wrapper +
+                # concat path.
+                [("a", 256), ("b", 256)],
+                # Two channels at distinct STU dims so that
+                # _stu_embedding_dim's `sum` is the only correct answer
+                # (it can't collapse to N*dim or max(dims)).
+                [("a", 256), ("b", 512)],
+            ]
+        ),
         graph_type=st.sampled_from(
             [
                 TestGraphType.NORMAL,
@@ -373,12 +372,11 @@ class UltraHSTUTest(unittest.TestCase):
     )
     @settings(
         verbosity=Verbosity.verbose,
-        max_examples=6,
+        max_examples=15,
         deadline=None,
     )
     def test_ultra_hstu(
         self,
-        case_name,
         channel_specs,
         graph_type,
         kernel,

--- a/tzrec/models/ultra_hstu_test.py
+++ b/tzrec/models/ultra_hstu_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import os
 import shutil
 import unittest
@@ -328,6 +329,12 @@ def _build_batch(device: torch.device, channel_names: List[str]) -> Batch:
 
 @mark_ci_scope("gpu")
 class UltraHSTUTest(unittest.TestCase):
+    def teardown_example(self, example):
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.memory_summary()
+
     def setUp(self):
         self.test_dir = None
 

--- a/tzrec/ops/hstu_attention_test.py
+++ b/tzrec/ops/hstu_attention_test.py
@@ -21,6 +21,7 @@ from tzrec.ops import (
     Kernel,
 )
 from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
     cutlass_hstu_unavailable,
     generate_sparse_seq_len,
     get_test_dtypes,
@@ -263,10 +264,7 @@ def test_delta_attn(
 @mark_ci_scope("h20", "gpu")
 class HSTUAttentionTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore

--- a/tzrec/ops/hstu_compute_test.py
+++ b/tzrec/ops/hstu_compute_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import random
 import unittest
 from typing import Optional
@@ -20,6 +19,7 @@ from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
 from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
     generate_sparse_seq_len,
     get_test_dtypes,
     get_test_enable_tma,
@@ -32,10 +32,7 @@ from tzrec.utils.test_util import hypothesis_settings as settings
 @mark_ci_scope("h20", "gpu")
 class HSTUComputeTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]

--- a/tzrec/ops/jagged_tensors_test.py
+++ b/tzrec/ops/jagged_tensors_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import unittest
 from typing import Optional
 
@@ -19,6 +18,7 @@ from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
 from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
     generate_sparse_seq_len,
     get_test_dtypes,
     gpu_unavailable,
@@ -30,10 +30,7 @@ from tzrec.utils.test_util import hypothesis_settings as settings
 @mark_ci_scope("h20", "gpu")
 class JaggedTensorsTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore

--- a/tzrec/ops/layer_norm_test.py
+++ b/tzrec/ops/layer_norm_test.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 
-import gc
 import unittest
 
 import torch
@@ -18,17 +17,19 @@ from hypothesis import Verbosity, given
 from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
-from tzrec.utils.test_util import get_test_dtypes, gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
+    get_test_dtypes,
+    gpu_unavailable,
+    mark_ci_scope,
+)
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
 @mark_ci_scope("h20", "gpu")
 class LayerNormTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]

--- a/tzrec/ops/mm_test.py
+++ b/tzrec/ops/mm_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import unittest
 from typing import Optional
 
@@ -18,17 +17,19 @@ from hypothesis import Verbosity, given
 from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
-from tzrec.utils.test_util import get_test_dtypes, gpu_unavailable, mark_ci_scope
+from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
+    get_test_dtypes,
+    gpu_unavailable,
+    mark_ci_scope,
+)
 from tzrec.utils.test_util import hypothesis_settings as settings
 
 
 @mark_ci_scope("h20", "gpu")
 class MMlTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]

--- a/tzrec/ops/position_test.py
+++ b/tzrec/ops/position_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import unittest
 
 import torch
@@ -18,6 +17,7 @@ from hypothesis import strategies as st
 
 from tzrec.ops import Kernel
 from tzrec.utils.test_util import (
+    cleanup_cuda_memory,
     generate_sparse_seq_len,
     get_test_dtypes,
     gpu_unavailable,
@@ -46,10 +46,7 @@ def _retry(max_attempts=3):
 @mark_ci_scope("h20", "gpu")
 class PositionEmbeddingsTest(unittest.TestCase):
     def teardown_example(self, example):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.memory_summary()  # prevent oom
+        cleanup_cuda_memory()
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore

--- a/tzrec/utils/test_util.py
+++ b/tzrec/utils/test_util.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import importlib.util
 import os
 import tempfile
@@ -130,6 +131,14 @@ def parameterized_name_func(func, num, p) -> str:
 def is_ci_nightly() -> bool:
     """Whether this is the nightly full run (``CI_NIGHTLY=true``)."""
     return os.environ.get("CI_NIGHTLY", "false").lower() == "true"
+
+
+def cleanup_cuda_memory() -> None:
+    """Release large CUDA cache reservations left by a test example."""
+    gc.collect()
+    if torch.cuda.is_available() and torch.cuda.memory_reserved() > 2**30:
+        torch.cuda.empty_cache()
+        torch.cuda.memory_summary()
 
 
 def make_test_dir(prefix: str = "tzrec_") -> str:


### PR DESCRIPTION
## What changed

Add a shared `cleanup_cuda_memory()` test helper that runs Python garbage collection after each Hypothesis example. When CUDA reserved memory exceeds 1 GiB, it releases unused allocator blocks with `empty_cache()` and retains the existing `memory_summary()` call.

`DlrmHSTUTest` and `UltraHSTUTest` now invoke the helper after every generated example. The six existing GPU operator test classes with the same cleanup sequence also use the shared helper so the threshold and cleanup behavior stay consistent.

Both model tests remove and reset their current AOT artifact directory after every Hypothesis example, with `unittest.tearDown()` retained as a fallback. UltraHSTU's three channel layouts are sampled directly by `@given` instead of wrapping three separate tests with `@parameterized.expand`; the combined strategy runs 20 examples.

## Why

AOT_INDUCTOR examples can leave several GiB in PyTorch's CUDA caching allocator. These model tests run multiple Hypothesis examples in one process, so reserved memory accumulated across examples and was inherited by later GPU-heavy tests, causing the nightly GPU lane to run out of memory.

Cleaning at the Hypothesis example boundary prevents large reservations from cascading into later cases. The 1 GiB threshold avoids unnecessary CUDA cache operations after small examples while still collecting unreachable Python objects every time. Per-example directory cleanup prevents DLRM and UltraHSTU examples from orphaning earlier compiled outputs under `tmp/`.

## Test Plan

- Verified helper behavior at the threshold: exactly 1 GiB skips CUDA cache cleanup; more than 1 GiB calls `empty_cache()` and `memory_summary()`
- `CI_NIGHTLY=true python -m unittest tzrec.models.dlrm_hstu_test.DlrmHSTUTest.test_dlrm_hstu` (20 examples; passed)
- `CI_NIGHTLY=true python -m unittest tzrec.models.ultra_hstu_test.UltraHSTUTest` (combined 20-example strategy; passed)
- Verified the `tmp/tzrec_*` directory count was unchanged before and after both model nightly tests
- `pre-commit run -a`
- `python scripts/pyre_check.py` (reported no critical type errors; the repository's `.pyre_configuration` emitted its existing invalid-JSON warning)
- Full `Unit Test Nightly` passed on commit `6a5ab0a3`; a new run was dispatched for commit `95c2fa58`