### PR TITLE
[bugfix] require HSTU candidate sequence export config

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -141,6 +141,15 @@ def export_model(
     `data_input_path` (optional): override for the predict-mode dataloader
     input path; falls back to `pipeline_config.train_input_path` when None.
     """
+    model_type = pipeline_config.model_config.WhichOneof("model")
+    if model_type in ("dlrm_hstu", "ultra_hstu") and (
+        not additional_export_config or "cand_seq_pk" not in additional_export_config
+    ):
+        raise ValueError(
+            "additional_export_config must contain cand_seq_pk when exporting "
+            f"{model_type}."
+        )
+
     use_rtp = env_util.use_rtp()
     use_dist_embedding = acc_utils.use_distributed_embedding()
     if use_rtp:


### PR DESCRIPTION
## Summary

Require `additional_export_config` to contain `cand_seq_pk` when exporting `dlrm_hstu` or `ultra_hstu`.

## Why

Generic additional export config forwarding did not enforce the serving metadata required by HSTU ranking models. An export could therefore complete without `cand_seq_pk` and produce an incomplete `model_acc.json`.

The validation is placed at the shared export boundary so it applies consistently to normal, RTP, and distributed embedding exports.

## Impact

Invalid DLRM-HSTU and ULTRA-HSTU exports now fail with a clear `ValueError` before selecting an export implementation. Other model types are unchanged.

## Test Plan

- `PYTHONPATH=. conda run -n tzrec130 pre-commit run --files tzrec/utils/export_util.py`
- `git diff --check`
- Verified both HSTU model types reject missing, empty, or unrelated additional export config and accept a config containing `cand_seq_pk`.
