### PR TITLE
[bugfix] harden prediction pipeline lifecycle

### DIFF
--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -1344,7 +1344,7 @@ def predict(
     )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
     cancel_event: Event = Event()
-    expected_batches = 0
+    input_batches = 0
 
     def _forward(
         batch: Batch,
@@ -1418,7 +1418,7 @@ def predict(
                 batch = next(infer_iterator)
                 if i_step == 0:
                     predictions, reserves = _forward(batch)
-                    expected_batches += 1
+                    input_batches += 1
                     if output_cols is None:
                         output_cols = sorted(predictions.keys())
                     _write(predictions, reserves, output_cols)
@@ -1446,7 +1446,7 @@ def predict(
                         cancel_event,
                         "input producer",
                     )
-                    expected_batches += 1
+                    input_batches += 1
 
                 if is_local_rank_zero:
                     plogger.log(i_step)
@@ -1488,9 +1488,7 @@ def predict(
             except Exception:
                 logger.exception("Failed to stop the prediction profiler.")
 
-    predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, device
-    )
+    predict_util.commit_prediction_output(writer, pipeline_error, input_batches, device)
     if is_local_rank_zero:
         logger.info("Predict Finished.")
 
@@ -1638,7 +1636,7 @@ def predict_checkpoint(
     )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
     cancel_event: Event = Event()
-    expected_batches = 0
+    input_batches = 0
 
     def _write(
         predictions: Dict[str, torch.Tensor],
@@ -1691,7 +1689,7 @@ def predict_checkpoint(
                         torch.cuda.synchronize()
                     if i_step == 0:
                         output_cols = sorted(predictions.keys())
-                        expected_batches += 1
+                        input_batches += 1
                         _write(predictions, batch.reserves, output_cols)
                         t = Thread(
                             target=_write_loop,
@@ -1708,7 +1706,7 @@ def predict_checkpoint(
                             cancel_event,
                             "checkpoint output",
                         )
-                        expected_batches += 1
+                        input_batches += 1
                     if plogger and i_step % 100 == 0:
                         plogger.log(i_step)
                 except StopIteration:
@@ -1731,8 +1729,6 @@ def predict_checkpoint(
             pipeline_threads = [] if write_t is None else [write_t]
             predict_util.cleanup_pipeline([], pipeline_threads, [], cancel_event)
 
-    predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, device
-    )
+    predict_util.commit_prediction_output(writer, pipeline_error, input_batches, device)
 
     logger.info(f"Predict worker-{os.environ.get('RANK', '0')} Finished.")

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -16,7 +16,7 @@ import os
 from collections import OrderedDict
 from contextlib import nullcontext
 from queue import Queue
-from threading import Event, Lock, Thread
+from threading import Event, Thread
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pyarrow as pa
@@ -1164,8 +1164,8 @@ def _write_predictions(
     predictions: Dict[str, torch.Tensor],
     reserves: RecordBatchTensor,
     output_cols: List[str],
-) -> int:
-    """Write predictions and return the number of output rows."""
+) -> None:
+    """Write predictions."""
     output_dict = OrderedDict()
     repeat_offsets = None
     if TARGET_REPEAT_INTERLEAVE_KEY in predictions:
@@ -1196,22 +1196,6 @@ def _write_predictions(
         ):
             output_dict[k] = v
     writer.write(output_dict)
-    return _prediction_row_count(predictions, reserves)
-
-
-def _prediction_row_count(
-    predictions: Dict[str, torch.Tensor], reserves: RecordBatchTensor
-) -> int:
-    """Return input-row cardinality represented by one prediction result."""
-    reserve_batch_record = reserves.get()
-    if reserve_batch_record is not None:
-        return len(reserve_batch_record)
-    if TARGET_REPEAT_INTERLEAVE_KEY in predictions:
-        return predictions[TARGET_REPEAT_INTERLEAVE_KEY].numel()
-    for name, value in predictions.items():
-        if name != TARGET_REPEAT_INTERLEAVE_KEY and value.ndim > 0:
-            return value.size(0)
-    raise RuntimeError("Prediction output has no row cardinality.")
 
 
 def predict(
@@ -1355,22 +1339,18 @@ def predict(
     if predict_threads is None:
         predict_threads = max(data_config.num_workers, 1)
     data_queue: Queue[Optional[Batch]] = Queue(maxsize=predict_threads * 2)
-    pred_queue: Queue[
-        Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]]
-    ] = Queue(maxsize=predict_threads * 2)
+    pred_queue: Queue[Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor]]] = (
+        Queue(maxsize=predict_threads * 2)
+    )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
-    cancel_event = Event()
+    cancel_event: Event = Event()
     all_queues = [data_queue, pred_queue, failure_queue]
-    count_lock = Lock()
     expected_batches = 0
-    expected_rows = 0
     written_batches = 0
-    written_rows = 0
 
     def _forward(
         batch: Batch,
-    ) -> Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]:
-        nonlocal expected_rows
+    ) -> Tuple[Dict[str, torch.Tensor], RecordBatchTensor]:
         with torch.no_grad():
             parsed_inputs = batch.to_dict(sparse_dtype=torch.int64)
             if is_input_tile:
@@ -1380,30 +1360,16 @@ def predict(
             predictions = model(parsed_inputs, device)
             if device.type == "cuda":
                 predictions = {k: v.to("cpu") for k, v in predictions.items()}
-            row_count = _prediction_row_count(predictions, batch.reserves)
-            with count_lock:
-                expected_rows += row_count
-            return predictions, batch.reserves, row_count
+            return predictions, batch.reserves
 
     def _write(
         predictions: Dict[str, torch.Tensor],
         reserves: RecordBatchTensor,
-        expected_row_count: int,
         output_cols: List[str],
     ) -> None:
         nonlocal written_batches
-        nonlocal written_rows
-        output_row_count = _write_predictions(
-            writer, predictions, reserves, output_cols
-        )
-        if output_row_count != expected_row_count:
-            raise RuntimeError(
-                "Prediction batch row count changed before writing; "
-                f"expected={expected_row_count}, written={output_row_count}."
-            )
-        with count_lock:
-            written_batches += 1
-            written_rows += output_row_count
+        _write_predictions(writer, predictions, reserves, output_cols)
+        written_batches += 1
 
     def _write_loop(output_cols: List[str]) -> None:
         stage = "writer"
@@ -1414,7 +1380,8 @@ def predict(
                 )
                 if pred is None:
                     return
-                _write(*pred, output_cols)
+                predictions, reserves = pred
+                _write(predictions, reserves, output_cols)
         except predict_util.PredictPipelineCancelled:
             return
         except BaseException as error:
@@ -1451,18 +1418,18 @@ def predict(
 
     forward_t_list: List[Thread] = []
     write_t: Optional[Thread] = None
-    pipeline_succeeded = False
+    pipeline_error: Optional[BaseException] = None
     i_step = 0
     try:
         while True:
             try:
                 batch = next(infer_iterator)
                 if i_step == 0:
-                    predictions, reserves, row_count = _forward(batch)
+                    predictions, reserves = _forward(batch)
                     expected_batches += 1
                     if output_cols is None:
                         output_cols = sorted(predictions.keys())
-                    _write(predictions, reserves, row_count, output_cols)
+                    _write(predictions, reserves, output_cols)
                     for worker_id in range(predict_threads):
                         t = Thread(
                             target=_forward_loop,
@@ -1497,7 +1464,6 @@ def predict(
                 i_step += 1
                 if predict_steps is not None and i_step >= predict_steps:
                     break
-                predict_util.raise_background_failure(failure_queue)
             except StopIteration:
                 break
 
@@ -1519,12 +1485,16 @@ def predict(
                 health_check=_check_health,
             )
             predict_util.wait_for_pipeline([], [write_t], failure_queue, cancel_event)
-        pipeline_succeeded = True
     except predict_util.PredictPipelineCancelled as error:
-        predict_util.raise_background_failure(failure_queue, wait=True)
-        raise RuntimeError(
-            "Prediction pipeline was cancelled without an error."
-        ) from error
+        try:
+            predict_util.raise_background_failure(failure_queue, wait=True)
+            raise RuntimeError(
+                "Prediction pipeline was cancelled without an error."
+            ) from error
+        except Exception as cancel_error:
+            pipeline_error = cancel_error
+    except Exception as error:
+        pipeline_error = error
     finally:
         pipeline_threads = [*forward_t_list]
         if write_t is not None:
@@ -1536,13 +1506,8 @@ def predict(
             except Exception:
                 logger.exception("Failed to stop the prediction profiler.")
 
-    predict_util.validate_and_commit_writer(
-        writer,
-        pipeline_succeeded,
-        expected_batches,
-        expected_rows,
-        written_batches,
-        written_rows,
+    predict_util.commit_prediction_output(
+        writer, pipeline_error, expected_batches, written_batches, device
     )
     if is_local_rank_zero:
         logger.info("Predict Finished.")
@@ -1686,35 +1651,23 @@ def predict_checkpoint(
     else:
         raise ValueError("Predict checkpoint path should be specified.")
 
-    pred_queue: Queue[
-        Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]]
-    ] = Queue(maxsize=3)
+    pred_queue: Queue[Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor]]] = (
+        Queue(maxsize=3)
+    )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
-    cancel_event = Event()
+    cancel_event: Event = Event()
     all_queues = [pred_queue, failure_queue]
     expected_batches = 0
-    expected_rows = 0
     written_batches = 0
-    written_rows = 0
 
     def _write(
         predictions: Dict[str, torch.Tensor],
         reserves: RecordBatchTensor,
-        expected_row_count: int,
         output_cols: List[str],
     ) -> None:
         nonlocal written_batches
-        nonlocal written_rows
-        output_row_count = _write_predictions(
-            writer, predictions, reserves, output_cols
-        )
-        if output_row_count != expected_row_count:
-            raise RuntimeError(
-                "Prediction batch row count changed before writing; "
-                f"expected={expected_row_count}, written={output_row_count}."
-            )
+        _write_predictions(writer, predictions, reserves, output_cols)
         written_batches += 1
-        written_rows += output_row_count
 
     def _write_loop(output_cols: List[str]) -> None:
         stage = "writer"
@@ -1725,7 +1678,8 @@ def predict_checkpoint(
                 )
                 if pred is None:
                     return
-                _write(*pred, output_cols)
+                predictions, reserves = pred
+                _write(predictions, reserves, output_cols)
         except predict_util.PredictPipelineCancelled:
             return
         except BaseException as error:
@@ -1752,7 +1706,7 @@ def predict_checkpoint(
         plogger = ProgressLogger(desc=f"Predicting{desc_suffix}")
 
     write_t: Optional[Thread] = None
-    pipeline_succeeded = False
+    pipeline_error: Optional[BaseException] = None
     with torch.no_grad():
         i_step = 0
         try:
@@ -1763,15 +1717,8 @@ def predict_checkpoint(
                         torch.cuda.synchronize()
                     if i_step == 0:
                         output_cols = sorted(predictions.keys())
-                        row_count = _prediction_row_count(predictions, batch.reserves)
                         expected_batches += 1
-                        expected_rows += row_count
-                        _write(
-                            predictions,
-                            batch.reserves,
-                            row_count,
-                            output_cols,
-                        )
+                        _write(predictions, batch.reserves, output_cols)
                         t = Thread(
                             target=_write_loop,
                             args=(output_cols,),
@@ -1781,19 +1728,16 @@ def predict_checkpoint(
                         t.start()
                         write_t = t
                     elif not batch.dummy:
-                        row_count = _prediction_row_count(predictions, batch.reserves)
                         predict_util.queue_put_interruptibly(
                             pred_queue,
-                            (predictions, batch.reserves, row_count),
+                            (predictions, batch.reserves),
                             cancel_event,
                             "checkpoint output",
                             health_check=_check_health,
                         )
                         expected_batches += 1
-                        expected_rows += row_count
                     if plogger and i_step % 100 == 0:
                         plogger.log(i_step)
-                    predict_util.raise_background_failure(failure_queue)
                 except StopIteration:
                     break
             if plogger is not None:
@@ -1809,25 +1753,24 @@ def predict_checkpoint(
                 predict_util.wait_for_pipeline(
                     [], [write_t], failure_queue, cancel_event
                 )
-            pipeline_succeeded = True
         except predict_util.PredictPipelineCancelled as error:
-            predict_util.raise_background_failure(failure_queue, wait=True)
-            raise RuntimeError(
-                "Checkpoint prediction pipeline was cancelled without an error."
-            ) from error
+            try:
+                predict_util.raise_background_failure(failure_queue, wait=True)
+                raise RuntimeError(
+                    "Checkpoint prediction pipeline was cancelled without an error."
+                ) from error
+            except Exception as cancel_error:
+                pipeline_error = cancel_error
+        except Exception as error:
+            pipeline_error = error
         finally:
             pipeline_threads = [] if write_t is None else [write_t]
             predict_util.cleanup_pipeline(
                 [], pipeline_threads, all_queues, cancel_event
             )
 
-    predict_util.validate_and_commit_writer(
-        writer,
-        pipeline_succeeded,
-        expected_batches,
-        expected_rows,
-        written_batches,
-        written_rows,
+    predict_util.commit_prediction_output(
+        writer, pipeline_error, expected_batches, written_batches, device
     )
 
     logger.info(f"Predict worker-{os.environ.get('RANK', '0')} Finished.")

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -16,7 +16,7 @@ import os
 from collections import OrderedDict
 from contextlib import nullcontext
 from queue import Queue
-from threading import Thread
+from threading import Event, Lock, Thread
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pyarrow as pa
@@ -37,7 +37,6 @@ from torchrec.optim.optimizers import SGD, in_backward_optimizer_filter
 from tzrec.acc import aot_utils
 from tzrec.acc import utils as acc_utils
 from tzrec.constant import (
-    PREDICT_QUEUE_TIMEOUT,
     TARGET_REPEAT_INTERLEAVE_KEY,
     TENSORBOARD_SUMMARIES,
     TRAIN_EVAL_RESULT_FILENAME,
@@ -80,7 +79,7 @@ from tzrec.protos.feature_pb2 import FeatureConfig
 from tzrec.protos.model_pb2 import Kernel as KernelProto
 from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.protos.train_pb2 import TrainConfig
-from tzrec.utils import checkpoint_util, config_util
+from tzrec.utils import checkpoint_util, config_util, predict_util
 from tzrec.utils.delta_embedding_dump import DeltaEmbeddingDumper
 from tzrec.utils.dist_util import (
     DistributedModelParallel,
@@ -1165,7 +1164,8 @@ def _write_predictions(
     predictions: Dict[str, torch.Tensor],
     reserves: RecordBatchTensor,
     output_cols: List[str],
-) -> None:
+) -> int:
+    """Write predictions and return the number of output rows."""
     output_dict = OrderedDict()
     repeat_offsets = None
     if TARGET_REPEAT_INTERLEAVE_KEY in predictions:
@@ -1196,6 +1196,22 @@ def _write_predictions(
         ):
             output_dict[k] = v
     writer.write(output_dict)
+    return _prediction_row_count(predictions, reserves)
+
+
+def _prediction_row_count(
+    predictions: Dict[str, torch.Tensor], reserves: RecordBatchTensor
+) -> int:
+    """Return input-row cardinality represented by one prediction result."""
+    reserve_batch_record = reserves.get()
+    if reserve_batch_record is not None:
+        return len(reserve_batch_record)
+    if TARGET_REPEAT_INTERLEAVE_KEY in predictions:
+        return predictions[TARGET_REPEAT_INTERLEAVE_KEY].numel()
+    for name, value in predictions.items():
+        if name != TARGET_REPEAT_INTERLEAVE_KEY and value.ndim > 0:
+            return value.size(0)
+    raise RuntimeError("Prediction output has no row cardinality.")
 
 
 def predict(
@@ -1342,10 +1358,21 @@ def predict(
         predict_threads = max(data_config.num_workers, 1)
     data_queue: Queue[Optional[Batch]] = Queue(maxsize=predict_threads * 2)
     pred_queue: Queue[
-        Tuple[Optional[Dict[str, torch.Tensor]], Optional[RecordBatchTensor]]
+        Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]]
     ] = Queue(maxsize=predict_threads * 2)
+    failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
+    cancel_event = Event()
+    all_queues = [data_queue, pred_queue, failure_queue]
+    count_lock = Lock()
+    expected_batches = 0
+    expected_rows = 0
+    written_batches = 0
+    written_rows = 0
 
-    def _forward(batch: Batch) -> Tuple[Dict[str, torch.Tensor], RecordBatchTensor]:
+    def _forward(
+        batch: Batch,
+    ) -> Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]:
+        nonlocal expected_rows
         with torch.no_grad():
             parsed_inputs = batch.to_dict(sparse_dtype=torch.int64)
             if is_input_tile:
@@ -1355,48 +1382,115 @@ def predict(
             predictions = model(parsed_inputs, device)
             if device.type == "cuda":
                 predictions = {k: v.to("cpu") for k, v in predictions.items()}
-            return predictions, batch.reserves
+            row_count = _prediction_row_count(predictions, batch.reserves)
+            with count_lock:
+                expected_rows += row_count
+            return predictions, batch.reserves, row_count
+
+    def _write(
+        predictions: Dict[str, torch.Tensor],
+        reserves: RecordBatchTensor,
+        expected_row_count: int,
+        output_cols: List[str],
+    ) -> None:
+        nonlocal written_batches
+        nonlocal written_rows
+        output_row_count = _write_predictions(
+            writer, predictions, reserves, output_cols
+        )
+        if output_row_count != expected_row_count:
+            raise RuntimeError(
+                "Prediction batch row count changed before writing; "
+                f"expected={expected_row_count}, written={output_row_count}."
+            )
+        with count_lock:
+            written_batches += 1
+            written_rows += output_row_count
 
     def _write_loop(output_cols: List[str]) -> None:
-        while True:
-            predictions, reserves = pred_queue.get(timeout=PREDICT_QUEUE_TIMEOUT)
-            if predictions is None:
-                break
-            assert predictions is not None and reserves is not None
-            _write_predictions(writer, predictions, reserves, output_cols)
+        stage = "writer"
+        try:
+            while True:
+                pred = predict_util.queue_get_interruptibly(
+                    pred_queue, cancel_event, f"{stage} input"
+                )
+                if pred is None:
+                    return
+                _write(*pred, output_cols)
+        except predict_util.PredictPipelineCancelled:
+            return
+        except BaseException as error:
+            predict_util.report_failure(failure_queue, cancel_event, stage, None, error)
 
-    def _forward_loop() -> None:
-        while True:
-            batch = data_queue.get(timeout=PREDICT_QUEUE_TIMEOUT)
-            if batch is None:
-                break
-            assert batch is not None
-            pred = _forward(batch)
-            pred_queue.put(pred, timeout=PREDICT_QUEUE_TIMEOUT)
+    def _forward_loop(worker_id: int) -> None:
+        stage = "forward"
+        try:
+            while True:
+                batch = predict_util.queue_get_interruptibly(
+                    data_queue,
+                    cancel_event,
+                    f"{stage}[{worker_id}] input",
+                )
+                if batch is None:
+                    return
+                pred = _forward(batch)
+                predict_util.queue_put_interruptibly(
+                    pred_queue,
+                    pred,
+                    cancel_event,
+                    f"{stage}[{worker_id}] output",
+                )
+        except predict_util.PredictPipelineCancelled:
+            return
+        except BaseException as error:
+            predict_util.report_failure(
+                failure_queue, cancel_event, stage, worker_id, error
+            )
 
-    forward_t_list = []
-    write_t = None
+    def _check_health() -> None:
+        """Check background prediction threads from the main thread."""
+        predict_util.check_pipeline_health([], failure_queue, cancel_event)
+
+    forward_t_list: List[Thread] = []
+    write_t: Optional[Thread] = None
+    pipeline_succeeded = False
     i_step = 0
     try:
         while True:
             try:
                 batch = next(infer_iterator)
-
                 if i_step == 0:
-                    # lazy init writer and create write and forward thread
-                    predictions, reserves = _forward(batch)
+                    predictions, reserves, row_count = _forward(batch)
+                    expected_batches += 1
                     if output_cols is None:
                         output_cols = sorted(predictions.keys())
-                    _write_predictions(writer, predictions, reserves, output_cols)
-                    for _ in range(predict_threads):
-                        t = Thread(target=_forward_loop)
+                    _write(predictions, reserves, row_count, output_cols)
+                    for worker_id in range(predict_threads):
+                        t = Thread(
+                            target=_forward_loop,
+                            args=(worker_id,),
+                            name=f"predict-forward-{worker_id}",
+                            daemon=True,
+                        )
                         t.start()
                         forward_t_list.append(t)
-                    t = Thread(target=_write_loop, args=(output_cols,))
+                    t = Thread(
+                        target=_write_loop,
+                        args=(output_cols,),
+                        name="predict-writer",
+                        daemon=True,
+                    )
                     t.start()
                     write_t = t
                 else:
-                    data_queue.put(batch, timeout=PREDICT_QUEUE_TIMEOUT)
+                    predict_util.queue_put_interruptibly(
+                        data_queue,
+                        batch,
+                        cancel_event,
+                        "input producer",
+                        health_check=_check_health,
+                    )
+                    expected_batches += 1
 
                 if is_local_rank_zero:
                     plogger.log(i_step)
@@ -1405,33 +1499,53 @@ def predict(
                 i_step += 1
                 if predict_steps is not None and i_step >= predict_steps:
                     break
+                predict_util.raise_background_failure(failure_queue)
             except StopIteration:
                 break
-    finally:
-        for _ in range(len(forward_t_list)):
-            try:
-                data_queue.put(None, timeout=PREDICT_QUEUE_TIMEOUT)
-            except Exception as e:
-                logger.warning(f"Failed to send sentinel to data_queue: {e}")
-        for t in forward_t_list:
-            t.join(timeout=PREDICT_QUEUE_TIMEOUT)
-            if t.is_alive():
-                logger.warning(f"Forward thread {t.name} did not terminate in time.")
-        if write_t is not None:
-            try:
-                pred_queue.put((None, None), timeout=PREDICT_QUEUE_TIMEOUT)
-            except Exception as e:
-                logger.warning(f"Failed to send sentinel to pred_queue: {e}")
-            write_t.join(timeout=PREDICT_QUEUE_TIMEOUT)
-            if write_t.is_alive():
-                logger.warning("Write thread did not terminate in time.")
-        try:
-            writer.close()
-        except Exception as e:
-            logger.warning(f"Failed to close writer: {e}")
 
-    if is_profiling:
-        prof.stop()
+        for _ in range(len(forward_t_list)):
+            predict_util.queue_put_interruptibly(
+                data_queue,
+                None,
+                cancel_event,
+                "input completion",
+                health_check=_check_health,
+            )
+        predict_util.wait_for_pipeline([], forward_t_list, failure_queue, cancel_event)
+        if write_t is not None:
+            predict_util.queue_put_interruptibly(
+                pred_queue,
+                None,
+                cancel_event,
+                "writer completion",
+                health_check=_check_health,
+            )
+            predict_util.wait_for_pipeline([], [write_t], failure_queue, cancel_event)
+        pipeline_succeeded = True
+    except predict_util.PredictPipelineCancelled as error:
+        predict_util.raise_background_failure(failure_queue, wait=True)
+        raise RuntimeError(
+            "Prediction pipeline was cancelled without an error."
+        ) from error
+    finally:
+        pipeline_threads = [*forward_t_list]
+        if write_t is not None:
+            pipeline_threads.append(write_t)
+        predict_util.cleanup_pipeline([], pipeline_threads, all_queues, cancel_event)
+        if is_profiling:
+            try:
+                prof.stop()
+            except Exception:
+                logger.exception("Failed to stop the prediction profiler.")
+
+    predict_util.validate_and_commit_writer(
+        writer,
+        pipeline_succeeded,
+        expected_batches,
+        expected_rows,
+        written_batches,
+        written_rows,
+    )
     if is_local_rank_zero:
         logger.info("Predict Finished.")
 
@@ -1575,16 +1689,53 @@ def predict_checkpoint(
         raise ValueError("Predict checkpoint path should be specified.")
 
     pred_queue: Queue[
-        Tuple[Optional[Dict[str, torch.Tensor]], Optional[RecordBatchTensor]]
+        Optional[Tuple[Dict[str, torch.Tensor], RecordBatchTensor, int]]
     ] = Queue(maxsize=3)
+    failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
+    cancel_event = Event()
+    all_queues = [pred_queue, failure_queue]
+    expected_batches = 0
+    expected_rows = 0
+    written_batches = 0
+    written_rows = 0
+
+    def _write(
+        predictions: Dict[str, torch.Tensor],
+        reserves: RecordBatchTensor,
+        expected_row_count: int,
+        output_cols: List[str],
+    ) -> None:
+        nonlocal written_batches
+        nonlocal written_rows
+        output_row_count = _write_predictions(
+            writer, predictions, reserves, output_cols
+        )
+        if output_row_count != expected_row_count:
+            raise RuntimeError(
+                "Prediction batch row count changed before writing; "
+                f"expected={expected_row_count}, written={output_row_count}."
+            )
+        written_batches += 1
+        written_rows += output_row_count
 
     def _write_loop(output_cols: List[str]) -> None:
-        while True:
-            predictions, reserves = pred_queue.get(timeout=PREDICT_QUEUE_TIMEOUT)
-            if predictions is None:
-                break
-            assert predictions is not None and reserves is not None
-            _write_predictions(writer, predictions, reserves, output_cols)
+        stage = "writer"
+        try:
+            while True:
+                pred = predict_util.queue_get_interruptibly(
+                    pred_queue, cancel_event, f"{stage} input"
+                )
+                if pred is None:
+                    return
+                _write(*pred, output_cols)
+        except predict_util.PredictPipelineCancelled:
+            return
+        except BaseException as error:
+            predict_util.report_failure(failure_queue, cancel_event, stage, None, error)
+
+    def _check_health() -> None:
+        """Check the checkpoint prediction writer from the main thread."""
+        predict_util.check_pipeline_health([], failure_queue, cancel_event)
 
     pipeline = PredictPipelineSparseDist(
         model,
@@ -1602,7 +1753,8 @@ def predict_checkpoint(
     if is_local_rank_zero:
         plogger = ProgressLogger(desc=f"Predicting{desc_suffix}")
 
-    write_t = None
+    write_t: Optional[Thread] = None
+    pipeline_succeeded = False
     with torch.no_grad():
         i_step = 0
         try:
@@ -1612,37 +1764,72 @@ def predict_checkpoint(
                     if device.type == "cuda":
                         torch.cuda.synchronize()
                     if i_step == 0:
-                        # lazy init writer and create write thread
                         output_cols = sorted(predictions.keys())
-                        _write_predictions(
-                            writer, predictions, batch.reserves, output_cols
+                        row_count = _prediction_row_count(predictions, batch.reserves)
+                        expected_batches += 1
+                        expected_rows += row_count
+                        _write(
+                            predictions,
+                            batch.reserves,
+                            row_count,
+                            output_cols,
                         )
-                        t = Thread(target=_write_loop, args=(output_cols,))
+                        t = Thread(
+                            target=_write_loop,
+                            args=(output_cols,),
+                            name="checkpoint-predict-writer",
+                            daemon=True,
+                        )
                         t.start()
                         write_t = t
                     elif not batch.dummy:
-                        pred_queue.put(
-                            (predictions, batch.reserves),
-                            timeout=PREDICT_QUEUE_TIMEOUT,
+                        row_count = _prediction_row_count(predictions, batch.reserves)
+                        predict_util.queue_put_interruptibly(
+                            pred_queue,
+                            (predictions, batch.reserves, row_count),
+                            cancel_event,
+                            "checkpoint output",
+                            health_check=_check_health,
                         )
+                        expected_batches += 1
+                        expected_rows += row_count
                     if plogger and i_step % 100 == 0:
                         plogger.log(i_step)
+                    predict_util.raise_background_failure(failure_queue)
                 except StopIteration:
                     break
             if plogger is not None:
                 plogger.log(i_step)
-        finally:
             if write_t is not None:
-                try:
-                    pred_queue.put((None, None), timeout=PREDICT_QUEUE_TIMEOUT)
-                except Exception as e:
-                    logger.warning(f"Failed to send sentinel to pred_queue: {e}")
-                write_t.join(timeout=PREDICT_QUEUE_TIMEOUT)
-                if write_t.is_alive():
-                    logger.warning("Write thread did not terminate in time.")
-            try:
-                writer.close()
-            except Exception as e:
-                logger.warning(f"Failed to close writer: {e}")
+                predict_util.queue_put_interruptibly(
+                    pred_queue,
+                    None,
+                    cancel_event,
+                    "checkpoint writer completion",
+                    health_check=_check_health,
+                )
+                predict_util.wait_for_pipeline(
+                    [], [write_t], failure_queue, cancel_event
+                )
+            pipeline_succeeded = True
+        except predict_util.PredictPipelineCancelled as error:
+            predict_util.raise_background_failure(failure_queue, wait=True)
+            raise RuntimeError(
+                "Checkpoint prediction pipeline was cancelled without an error."
+            ) from error
+        finally:
+            pipeline_threads = [] if write_t is None else [write_t]
+            predict_util.cleanup_pipeline(
+                [], pipeline_threads, all_queues, cancel_event
+            )
+
+    predict_util.validate_and_commit_writer(
+        writer,
+        pipeline_succeeded,
+        expected_batches,
+        expected_rows,
+        written_batches,
+        written_rows,
+    )
 
     logger.info(f"Predict worker-{os.environ.get('RANK', '0')} Finished.")

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -1412,10 +1412,6 @@ def predict(
                 failure_queue, cancel_event, stage, worker_id, error
             )
 
-    def _check_health() -> None:
-        """Check background prediction threads from the main thread."""
-        predict_util.check_pipeline_health([], failure_queue, cancel_event)
-
     forward_t_list: List[Thread] = []
     write_t: Optional[Thread] = None
     pipeline_error: Optional[BaseException] = None
@@ -1453,7 +1449,6 @@ def predict(
                         batch,
                         cancel_event,
                         "input producer",
-                        health_check=_check_health,
                     )
                     expected_batches += 1
 
@@ -1473,7 +1468,6 @@ def predict(
                 None,
                 cancel_event,
                 "input completion",
-                health_check=_check_health,
             )
         predict_util.wait_for_pipeline([], forward_t_list, failure_queue, cancel_event)
         if write_t is not None:
@@ -1482,7 +1476,6 @@ def predict(
                 None,
                 cancel_event,
                 "writer completion",
-                health_check=_check_health,
             )
             predict_util.wait_for_pipeline([], [write_t], failure_queue, cancel_event)
     except predict_util.PredictPipelineCancelled as error:
@@ -1685,10 +1678,6 @@ def predict_checkpoint(
         except BaseException as error:
             predict_util.report_failure(failure_queue, cancel_event, stage, None, error)
 
-    def _check_health() -> None:
-        """Check the checkpoint prediction writer from the main thread."""
-        predict_util.check_pipeline_health([], failure_queue, cancel_event)
-
     pipeline = PredictPipelineSparseDist(
         model,
         None,
@@ -1733,7 +1722,6 @@ def predict_checkpoint(
                             (predictions, batch.reserves),
                             cancel_event,
                             "checkpoint output",
-                            health_check=_check_health,
                         )
                         expected_batches += 1
                     if plogger and i_step % 100 == 0:
@@ -1748,7 +1736,6 @@ def predict_checkpoint(
                     None,
                     cancel_event,
                     "checkpoint writer completion",
-                    health_check=_check_health,
                 )
                 predict_util.wait_for_pipeline(
                     [], [write_t], failure_queue, cancel_event

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -1478,22 +1478,15 @@ def predict(
                 "writer completion",
             )
             predict_util.wait_for_pipeline([], [write_t], failure_queue, cancel_event)
-    except predict_util.PredictPipelineCancelled as error:
-        try:
-            predict_util.raise_background_failure(failure_queue, wait=True)
-            raise RuntimeError(
-                "Prediction pipeline was cancelled without an error."
-            ) from error
-        except Exception as cancel_error:
-            pipeline_error = cancel_error
     except Exception as error:
-        pipeline_error = error
+        pipeline_error = predict_util.resolve_pipeline_error(error, failure_queue)
     finally:
         pipeline_threads = [*forward_t_list]
         if write_t is not None:
             pipeline_threads.append(write_t)
         predict_util.cleanup_pipeline([], pipeline_threads, all_queues, cancel_event)
         if is_profiling:
+            # nothing here may raise, or this rank skips the commit rendezvous.
             try:
                 prof.stop()
             except Exception:
@@ -1740,16 +1733,8 @@ def predict_checkpoint(
                 predict_util.wait_for_pipeline(
                     [], [write_t], failure_queue, cancel_event
                 )
-        except predict_util.PredictPipelineCancelled as error:
-            try:
-                predict_util.raise_background_failure(failure_queue, wait=True)
-                raise RuntimeError(
-                    "Checkpoint prediction pipeline was cancelled without an error."
-                ) from error
-            except Exception as cancel_error:
-                pipeline_error = cancel_error
         except Exception as error:
-            pipeline_error = error
+            pipeline_error = predict_util.resolve_pipeline_error(error, failure_queue)
         finally:
             pipeline_threads = [] if write_t is None else [write_t]
             predict_util.cleanup_pipeline(

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -1344,9 +1344,7 @@ def predict(
     )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
     cancel_event: Event = Event()
-    all_queues = [data_queue, pred_queue, failure_queue]
     expected_batches = 0
-    written_batches = 0
 
     def _forward(
         batch: Batch,
@@ -1367,9 +1365,7 @@ def predict(
         reserves: RecordBatchTensor,
         output_cols: List[str],
     ) -> None:
-        nonlocal written_batches
         _write_predictions(writer, predictions, reserves, output_cols)
-        written_batches += 1
 
     def _write_loop(output_cols: List[str]) -> None:
         stage = "writer"
@@ -1484,7 +1480,7 @@ def predict(
         pipeline_threads = [*forward_t_list]
         if write_t is not None:
             pipeline_threads.append(write_t)
-        predict_util.cleanup_pipeline([], pipeline_threads, all_queues, cancel_event)
+        predict_util.cleanup_pipeline([], pipeline_threads, [], cancel_event)
         if is_profiling:
             # nothing here may raise, or this rank skips the commit rendezvous.
             try:
@@ -1493,7 +1489,7 @@ def predict(
                 logger.exception("Failed to stop the prediction profiler.")
 
     predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, written_batches, device
+        writer, pipeline_error, expected_batches, device
     )
     if is_local_rank_zero:
         logger.info("Predict Finished.")
@@ -1642,18 +1638,14 @@ def predict_checkpoint(
     )
     failure_queue: Queue[predict_util.PredictPipelineFailure] = Queue()
     cancel_event: Event = Event()
-    all_queues = [pred_queue, failure_queue]
     expected_batches = 0
-    written_batches = 0
 
     def _write(
         predictions: Dict[str, torch.Tensor],
         reserves: RecordBatchTensor,
         output_cols: List[str],
     ) -> None:
-        nonlocal written_batches
         _write_predictions(writer, predictions, reserves, output_cols)
-        written_batches += 1
 
     def _write_loop(output_cols: List[str]) -> None:
         stage = "writer"
@@ -1737,12 +1729,10 @@ def predict_checkpoint(
             pipeline_error = predict_util.resolve_pipeline_error(error, failure_queue)
         finally:
             pipeline_threads = [] if write_t is None else [write_t]
-            predict_util.cleanup_pipeline(
-                [], pipeline_threads, all_queues, cancel_event
-            )
+            predict_util.cleanup_pipeline([], pipeline_threads, [], cancel_event)
 
     predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, written_batches, device
+        writer, pipeline_error, expected_batches, device
     )
 
     logger.info(f"Predict worker-{os.environ.get('RANK', '0')} Finished.")

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -18,13 +18,18 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import pyarrow as pa
 import torch
 
-from tzrec.main import _train_and_evaluate
+from tzrec.datasets.utils import RecordBatchTensor
+from tzrec.main import _train_and_evaluate, predict, predict_checkpoint
 from tzrec.optim.ema import DenseEMA
+from tzrec.protos.data_pb2 import DataConfig
 from tzrec.protos.eval_pb2 import EvalConfig
 from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.protos.optimizer_pb2 import DenseOptimizer, EMAConfig
+from tzrec.protos.pipeline_pb2 import EasyRecConfig
+from tzrec.utils import predict_util
 
 
 class MainTest(unittest.TestCase):
@@ -154,6 +159,183 @@ class MainTest(unittest.TestCase):
         self.assertTrue(model.module.model.on_train_end.called)
         for call in exporter.maybe_export.call_args_list:
             self.assertIsNone(call.kwargs["dense_ema"])
+
+
+class PredictionLifecycleTest(unittest.TestCase):
+    """Tests for prediction lifecycle wiring."""
+
+    def _batch(self, rows: int) -> mock.Mock:
+        batch = mock.Mock()
+        batch.reserves = RecordBatchTensor(pa.record_batch({"id": list(range(rows))}))
+        batch.to_dict.return_value = {}
+        batch.dummy = False
+        return batch
+
+    def _pipeline_config(self) -> EasyRecConfig:
+        return EasyRecConfig(
+            train_input_path="",
+            eval_input_path="",
+            model_dir="model",
+            data_config=DataConfig(dataset_type=3, num_workers=1),
+        )
+
+    def _run_predict(
+        self, dataloader: mock.Mock, writer: mock.Mock, model: mock.Mock
+    ) -> None:
+        with (
+            mock.patch.dict(os.environ, {"RANK": "1", "LOCAL_RANK": "1"}),
+            mock.patch(
+                "tzrec.main.init_process_group",
+                return_value=(torch.device("cpu"), "gloo"),
+            ),
+            mock.patch("tzrec.main.url_to_fs", return_value=(None, "model")),
+            mock.patch(
+                "tzrec.main.config_util.load_pipeline_config",
+                return_value=self._pipeline_config(),
+            ),
+            mock.patch("tzrec.main.acc_utils.allow_tf32_for_export"),
+            mock.patch("tzrec.main.acc_utils.is_trt_predict", return_value=False),
+            mock.patch("tzrec.main.acc_utils.is_aot_predict", return_value=False),
+            mock.patch(
+                "tzrec.main.acc_utils.is_input_tile_predict", return_value=False
+            ),
+            mock.patch("tzrec.main._create_features", return_value=[]),
+            mock.patch("tzrec.main.create_dataloader", return_value=dataloader),
+            mock.patch("tzrec.main.create_writer", return_value=writer),
+            mock.patch("tzrec.main.torch.jit.load", return_value=model),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01),
+        ):
+            predict(
+                "input",
+                "output",
+                "model",
+                reserved_columns="id",
+                writer_type="MockWriter",
+                predict_threads=1,
+            )
+
+    def _run_predict_checkpoint(self, pipeline: mock.Mock, writer: mock.Mock) -> None:
+        dataloader = mock.Mock()
+        dataloader.dataset.sampled_batch_size = 2
+        dataloader.get_iterator.return_value = iter([])
+        model = mock.Mock()
+        wrapped_model = mock.Mock()
+        distributed_model = mock.Mock()
+        distributed_model.device = torch.device("cpu")
+        ckpt_manager = mock.Mock()
+        planner = mock.Mock()
+        with (
+            mock.patch.dict(os.environ, {"RANK": "1", "LOCAL_RANK": "1"}),
+            mock.patch(
+                "tzrec.main.config_util.load_pipeline_config",
+                return_value=self._pipeline_config(),
+            ),
+            mock.patch(
+                "tzrec.main.init_process_group",
+                return_value=(torch.device("cpu"), "gloo"),
+            ),
+            mock.patch("tzrec.main.acc_utils.allow_tf32"),
+            mock.patch("tzrec.main._create_features", return_value=[]),
+            mock.patch("tzrec.main.create_dataloader", return_value=dataloader),
+            mock.patch("tzrec.main.create_writer", return_value=writer),
+            mock.patch("tzrec.main._create_model", return_value=model),
+            mock.patch("tzrec.main.PredictWrapper", return_value=wrapped_model),
+            mock.patch(
+                "tzrec.main.checkpoint_util.CheckpointManager",
+                return_value=ckpt_manager,
+            ),
+            mock.patch("tzrec.main.create_planner", return_value=planner),
+            mock.patch("tzrec.main.get_default_sharders", return_value=[]),
+            mock.patch(
+                "tzrec.main.DistributedModelParallel",
+                return_value=distributed_model,
+            ),
+            mock.patch("tzrec.main.config_util.use_dense_ema", return_value=False),
+            mock.patch("tzrec.main.PredictPipelineSparseDist", return_value=pipeline),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01),
+        ):
+            predict_checkpoint(
+                "pipeline.config",
+                "input",
+                "output",
+                checkpoint_path="checkpoint",
+                reserved_columns="id",
+                writer_type="MockWriter",
+                predict_steps=2,
+            )
+
+    def test_predict_counts_first_write_and_commits_once(self) -> None:
+        dataloader = mock.Mock()
+        dataloader.get_iterator.return_value = iter([self._batch(2), self._batch(3)])
+        writer = mock.Mock()
+        model = mock.Mock(
+            side_effect=[
+                {"score": torch.tensor([0.1, 0.2])},
+                {"score": torch.tensor([0.1, 0.2, 0.3])},
+            ]
+        )
+
+        self._run_predict(dataloader, writer, model)
+
+        self.assertEqual(writer.write.call_count, 2)
+        writer.close.assert_called_once_with()
+
+    def test_predict_background_failures_do_not_commit(self) -> None:
+        for stage in ("forward", "writer"):
+            with self.subTest(stage=stage):
+                dataloader = mock.Mock()
+                dataloader.get_iterator.return_value = iter(
+                    [self._batch(2), self._batch(2)]
+                )
+                writer = mock.Mock()
+                predictions = {"score": torch.tensor([0.1, 0.2])}
+                model = mock.Mock(
+                    side_effect=[predictions, predictions]
+                    if stage == "writer"
+                    else [predictions, RuntimeError("forward boom")]
+                )
+                if stage == "writer":
+                    writer.write.side_effect = [None, RuntimeError("writer boom")]
+
+                with self.assertRaises(
+                    predict_util.PredictPipelineStageError
+                ) as context:
+                    self._run_predict(dataloader, writer, model)
+
+                self.assertEqual(context.exception.failure.stage, stage)
+                self.assertEqual(context.exception.failure.message, f"{stage} boom")
+                writer.close.assert_not_called()
+
+    def test_predict_checkpoint_commits_only_after_writer_success(self) -> None:
+        for writer_fails in (False, True):
+            with self.subTest(writer_fails=writer_fails):
+                writer = mock.Mock()
+                if writer_fails:
+                    writer.write.side_effect = [
+                        None,
+                        RuntimeError("checkpoint writer boom"),
+                    ]
+                pipeline = mock.Mock()
+                pipeline.progress.side_effect = [
+                    ({"score": torch.tensor([0.1, 0.2])}, self._batch(2)),
+                    ({"score": torch.tensor([0.1, 0.2])}, self._batch(2)),
+                ]
+
+                if writer_fails:
+                    with self.assertRaises(
+                        predict_util.PredictPipelineStageError
+                    ) as context:
+                        self._run_predict_checkpoint(pipeline, writer)
+                    self.assertEqual(context.exception.failure.stage, "writer")
+                    self.assertEqual(
+                        context.exception.failure.message,
+                        "checkpoint writer boom",
+                    )
+                    writer.close.assert_not_called()
+                else:
+                    self._run_predict_checkpoint(pipeline, writer)
+                    self.assertEqual(writer.write.call_count, 2)
+                    writer.close.assert_called_once_with()
 
 
 class TrainStepCounterMultiPassTest(unittest.TestCase):

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pyarrow as pa
 import torch
+from parameterized import parameterized
 
 from tzrec.datasets.utils import RecordBatchTensor
 from tzrec.main import _train_and_evaluate, predict, predict_checkpoint
@@ -30,6 +31,7 @@ from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.protos.optimizer_pb2 import DenseOptimizer, EMAConfig
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import predict_util
+from tzrec.utils.test_util import parameterized_name_func
 
 
 class MainTest(unittest.TestCase):
@@ -180,7 +182,11 @@ class PredictionLifecycleTest(unittest.TestCase):
         )
 
     def _run_predict(
-        self, dataloader: mock.Mock, writer: mock.Mock, model: mock.Mock
+        self,
+        dataloader: mock.Mock,
+        writer: mock.Mock,
+        model: mock.Mock,
+        predict_threads: int = 1,
     ) -> None:
         with (
             mock.patch.dict(os.environ, {"RANK": "1", "LOCAL_RANK": "1"}),
@@ -211,7 +217,7 @@ class PredictionLifecycleTest(unittest.TestCase):
                 "model",
                 reserved_columns="id",
                 writer_type="MockWriter",
-                predict_threads=1,
+                predict_threads=predict_threads,
             )
 
     def _run_predict_checkpoint(self, pipeline: mock.Mock, writer: mock.Mock) -> None:
@@ -264,20 +270,21 @@ class PredictionLifecycleTest(unittest.TestCase):
                 predict_steps=2,
             )
 
-    def test_predict_counts_first_write_and_commits_once(self) -> None:
+    @parameterized.expand([[1], [2]], name_func=parameterized_name_func)
+    def test_predict_counts_first_write_and_commits_once(
+        self, predict_threads: int
+    ) -> None:
+        batch_count = predict_threads + 2
         dataloader = mock.Mock()
-        dataloader.get_iterator.return_value = iter([self._batch(2), self._batch(3)])
-        writer = mock.Mock()
-        model = mock.Mock(
-            side_effect=[
-                {"score": torch.tensor([0.1, 0.2])},
-                {"score": torch.tensor([0.1, 0.2, 0.3])},
-            ]
+        dataloader.get_iterator.return_value = iter(
+            [self._batch(2) for _ in range(batch_count)]
         )
+        writer = mock.Mock()
+        model = mock.Mock(return_value={"score": torch.tensor([0.1, 0.2])})
 
-        self._run_predict(dataloader, writer, model)
+        self._run_predict(dataloader, writer, model, predict_threads=predict_threads)
 
-        self.assertEqual(writer.write.call_count, 2)
+        self.assertEqual(writer.write.call_count, batch_count)
         writer.close.assert_called_once_with()
 
     def test_predict_background_failures_do_not_commit(self) -> None:

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -77,6 +77,7 @@ def _tdm_predict_data_worker(
     out_queue: Queue,
     is_first_layer: bool,
     worker_id: int,
+    output_drained_event: Any,
     cancel_event: Any,
     failure_queue: Queue,
 ) -> None:
@@ -98,7 +99,11 @@ def _tdm_predict_data_worker(
                     cancel_event,
                     f"{stage}[{worker_id}] completion",
                 )
-                break
+                # Keep shared-storage handles alive through deserialization.
+                while not output_drained_event.wait(timeout=1):
+                    if cancel_event.is_set():
+                        return
+                return
 
             record_batch = record_batch_t.get()
             if is_first_layer:
@@ -146,6 +151,7 @@ def _forward_loop(
         [Batch, RecordBatchTensor, pa.Array, int],
         Tuple[RecordBatchTensor, pa.Array],
     ],
+    input_drained_event: Any,
     cancel_event: Any,
     failure_queue: Queue,
 ) -> None:
@@ -167,6 +173,7 @@ def _forward_loop(
                 cancel_event,
                 f"{stage}[{layer_id}] output",
             )
+        input_drained_event.set()
         for _ in range(downstream_consumer_count):
             predict_util.queue_put_interruptibly(
                 pred_queue,
@@ -413,6 +420,9 @@ def tdm_retrieval(
     out_queues = [Queue(maxsize=2) for _ in range(max_level - first_recall_layer)]
     failure_queue = Queue()
     cancel_event = Event()
+    data_output_drained_events = [
+        Event() for _ in range(max_level - first_recall_layer)
+    ]
     all_queues = [*in_queues, *out_queues, failure_queue]
 
     data_p_list: List[Process] = []
@@ -434,6 +444,7 @@ def tdm_retrieval(
                         out_queues[i],
                         i == 0,
                         i * num_worker_per_level + j,
+                        data_output_drained_events[i],
                         cancel_event,
                         failure_queue,
                     ),
@@ -454,6 +465,7 @@ def tdm_retrieval(
                     num_worker_per_level,
                     downstream_consumer_count,
                     _forward,
+                    data_output_drained_events[i],
                     cancel_event,
                     failure_queue,
                 ),

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -13,14 +13,10 @@ import argparse
 import copy
 import math
 import os
-import queue as queue_lib
-import time
-import traceback
 from collections import OrderedDict
-from dataclasses import dataclass
 from multiprocessing import Event, Process, Queue
 from threading import Thread
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -28,151 +24,16 @@ import torch
 from torch import distributed as dist
 from torch.distributed import ReduceOp
 
-from tzrec.constant import PREDICT_QUEUE_TIMEOUT, Mode
+from tzrec.constant import Mode
 from tzrec.datasets.data_parser import DataParser
 from tzrec.datasets.dataset import BaseWriter, create_writer
 from tzrec.datasets.sampler import TDMPredictSampler
 from tzrec.datasets.utils import Batch, RecordBatchTensor
 from tzrec.main import _create_features, create_dataloader
 from tzrec.protos.data_pb2 import DatasetType
-from tzrec.utils import config_util
+from tzrec.utils import config_util, predict_util
 from tzrec.utils.dist_util import init_process_group
 from tzrec.utils.logging_util import ProgressLogger, logger
-
-_PIPELINE_POLL_INTERVAL = 1.0
-_PIPELINE_CLEANUP_TIMEOUT = 10.0
-_PIPELINE_TERMINATE_TIMEOUT = 5.0
-_PIPELINE_KILL_TIMEOUT = 5.0
-
-
-@dataclass(frozen=True)
-class _PipelineFailure:
-    """Serializable failure raised by a background pipeline stage."""
-
-    stage: str
-    worker_id: Optional[int]
-    exception_type: str
-    message: str
-    traceback: str
-
-
-class _PipelineCancelled(RuntimeError):
-    """Signal that a pipeline queue operation was cancelled."""
-
-
-class _PipelineStageError(RuntimeError):
-    """Failure propagated from a background pipeline stage."""
-
-    def __init__(self, failure: _PipelineFailure) -> None:
-        worker = "" if failure.worker_id is None else f"[{failure.worker_id}]"
-        super().__init__(
-            f"TDM retrieval {failure.stage}{worker} failed with "
-            f"{failure.exception_type}: {failure.message}\n{failure.traceback}"
-        )
-
-
-def _report_failure(
-    failure_queue: Queue,
-    cancel_event: Any,
-    stage: str,
-    worker_id: Optional[int],
-    error: BaseException,
-) -> None:
-    """Report the active exception and cancel the pipeline."""
-    failure = _PipelineFailure(
-        stage=stage,
-        worker_id=worker_id,
-        exception_type=type(error).__name__,
-        message=str(error),
-        traceback=traceback.format_exc(),
-    )
-    try:
-        failure_queue.put_nowait(failure)
-    except Exception:
-        logger.exception("Failed to report TDM retrieval pipeline failure.")
-    finally:
-        cancel_event.set()
-
-
-def _raise_background_failure(failure_queue: Queue, wait: bool = False) -> None:
-    """Raise the oldest reported pipeline failure, if present."""
-    try:
-        failure = failure_queue.get(timeout=_PIPELINE_POLL_INTERVAL if wait else 0)
-    except queue_lib.Empty:
-        return
-    raise _PipelineStageError(failure)
-
-
-def _check_pipeline_health(
-    processes: Sequence[Process], failure_queue: Queue, cancel_event: Any
-) -> None:
-    """Raise reported failures or unexpected child process exits."""
-    _raise_background_failure(failure_queue)
-    if cancel_event.is_set():
-        _raise_background_failure(failure_queue, wait=True)
-        raise RuntimeError("TDM retrieval pipeline was cancelled without an error.")
-    failed_processes = [
-        p for p in processes if p.exitcode is not None and p.exitcode != 0
-    ]
-    if failed_processes:
-        cancel_event.set()
-        _raise_background_failure(failure_queue, wait=True)
-        details = ", ".join(
-            f"pid={p.pid}, exitcode={p.exitcode}" for p in failed_processes
-        )
-        raise RuntimeError(f"TDM retrieval data worker failed: {details}.")
-
-
-def _queue_get(
-    data_queue: Queue,
-    cancel_event: Any,
-    stage: str,
-    timeout: float = PREDICT_QUEUE_TIMEOUT,
-    health_check: Optional[Callable[[], None]] = None,
-) -> Any:
-    """Get a queue item while remaining responsive to cancellation."""
-    deadline = time.monotonic() + timeout
-    while not cancel_event.is_set():
-        if health_check is not None:
-            health_check()
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError(
-                f"TDM retrieval {stage} stalled waiting for queue input "
-                f"for {timeout} seconds."
-            )
-        try:
-            return data_queue.get(timeout=min(_PIPELINE_POLL_INTERVAL, remaining))
-        except queue_lib.Empty:
-            continue
-    raise _PipelineCancelled(f"TDM retrieval {stage} was cancelled.")
-
-
-def _queue_put(
-    data_queue: Queue,
-    item: Any,
-    cancel_event: Any,
-    stage: str,
-    timeout: float = PREDICT_QUEUE_TIMEOUT,
-    health_check: Optional[Callable[[], None]] = None,
-) -> None:
-    """Put a queue item while remaining responsive to cancellation."""
-    deadline = time.monotonic() + timeout
-    while not cancel_event.is_set():
-        if health_check is not None:
-            health_check()
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError(
-                f"TDM retrieval {stage} stalled waiting for queue capacity "
-                f"for {timeout} seconds."
-            )
-        try:
-            data_queue.put(item, timeout=min(_PIPELINE_POLL_INTERVAL, remaining))
-            return
-        except queue_lib.Full:
-            continue
-    raise _PipelineCancelled(f"TDM retrieval {stage} was cancelled.")
 
 
 def update_data(
@@ -226,12 +87,12 @@ def _tdm_predict_data_worker(
         sampler.init_sampler(n_cluster)
 
         while True:
-            record_batch_t, node_ids = _queue_get(
+            record_batch_t, node_ids = predict_util.queue_get_interruptibly(
                 in_queue, cancel_event, f"{stage}[{worker_id}] input"
             )
 
             if record_batch_t is None:
-                _queue_put(
+                predict_util.queue_put_interruptibly(
                     out_queue,
                     (None, None, None),
                     cancel_event,
@@ -260,16 +121,18 @@ def _tdm_predict_data_worker(
             output_data = data_parser.parse(updated_inputs)
             batch = data_parser.to_batch(output_data, force_no_tile=True)
 
-            _queue_put(
+            predict_util.queue_put_interruptibly(
                 out_queue,
                 (batch, record_batch_t, updated_inputs[item_id_field]),
                 cancel_event,
                 f"{stage}[{worker_id}] output",
             )
-    except _PipelineCancelled:
+    except predict_util.PredictPipelineCancelled:
         return
     except BaseException as error:
-        _report_failure(failure_queue, cancel_event, stage, worker_id, error)
+        predict_util.report_failure(
+            failure_queue, cancel_event, stage, worker_id, error
+        )
         raise
 
 
@@ -291,30 +154,30 @@ def _forward_loop(
     try:
         completed_producers = 0
         while completed_producers < producer_count:
-            batch, record_batch_t, node_ids = _queue_get(
+            batch, record_batch_t, node_ids = predict_util.queue_get_interruptibly(
                 data_queue, cancel_event, f"{stage}[{layer_id}] input"
             )
             if batch is None:
                 completed_producers += 1
                 continue
             pred = forward_fn(batch, record_batch_t, node_ids, layer_id)
-            _queue_put(
+            predict_util.queue_put_interruptibly(
                 pred_queue,
                 pred,
                 cancel_event,
                 f"{stage}[{layer_id}] output",
             )
         for _ in range(downstream_consumer_count):
-            _queue_put(
+            predict_util.queue_put_interruptibly(
                 pred_queue,
                 (None, None),
                 cancel_event,
                 f"{stage}[{layer_id}] completion",
             )
-    except _PipelineCancelled:
+    except predict_util.PredictPipelineCancelled:
         return
     except BaseException as error:
-        _report_failure(failure_queue, cancel_event, stage, layer_id, error)
+        predict_util.report_failure(failure_queue, cancel_event, stage, layer_id, error)
 
 
 def _write_loop(
@@ -327,139 +190,16 @@ def _write_loop(
     stage = "writer"
     try:
         while True:
-            record_batch_t, node_ids = _queue_get(
+            record_batch_t, node_ids = predict_util.queue_get_interruptibly(
                 pred_queue, cancel_event, f"{stage} input"
             )
             if record_batch_t is None:
                 return
             write_fn(record_batch_t, node_ids)
-    except _PipelineCancelled:
+    except predict_util.PredictPipelineCancelled:
         return
     except BaseException as error:
-        _report_failure(failure_queue, cancel_event, stage, None, error)
-
-
-def _wait_for_pipeline(
-    processes: Sequence[Process],
-    threads: Sequence[Thread],
-    failure_queue: Queue,
-    cancel_event: Any,
-    timeout: float = PREDICT_QUEUE_TIMEOUT,
-) -> None:
-    """Wait for normal pipeline completion while monitoring failures."""
-    deadline = time.monotonic() + timeout
-    while True:
-        _check_pipeline_health(processes, failure_queue, cancel_event)
-
-        alive_processes = [p for p in processes if p.is_alive()]
-        alive_threads = [t for t in threads if t.is_alive()]
-        if not alive_processes and not alive_threads:
-            break
-        if time.monotonic() >= deadline:
-            process_ids = [p.pid for p in alive_processes]
-            thread_names = [t.name for t in alive_threads]
-            raise TimeoutError(
-                "TDM retrieval pipeline stalled during completion; "
-                f"processes={process_ids}, threads={thread_names}."
-            )
-        time.sleep(_PIPELINE_POLL_INTERVAL)
-
-    for process in processes:
-        process.join(timeout=0)
-    for thread in threads:
-        thread.join(timeout=0)
-    _raise_background_failure(failure_queue)
-
-
-def _cleanup_pipeline(
-    processes: Sequence[Process],
-    threads: Sequence[Thread],
-    queues: Sequence[Queue],
-    cancel_event: Any,
-) -> None:
-    """Cancel and reap pipeline components within bounded deadlines."""
-    cancel_event.set()
-    graceful_deadline = time.monotonic() + _PIPELINE_CLEANUP_TIMEOUT
-    while time.monotonic() < graceful_deadline:
-        if not any(p.is_alive() for p in processes) and not any(
-            t.is_alive() for t in threads
-        ):
-            break
-        time.sleep(_PIPELINE_POLL_INTERVAL)
-
-    surviving_processes = [p for p in processes if p.is_alive()]
-    for process in surviving_processes:
-        try:
-            process.terminate()
-        except Exception:
-            logger.exception("Failed to terminate retrieval process %s.", process.pid)
-
-    terminate_deadline = time.monotonic() + _PIPELINE_TERMINATE_TIMEOUT
-    while time.monotonic() < terminate_deadline and any(
-        p.is_alive() for p in surviving_processes
-    ):
-        time.sleep(_PIPELINE_POLL_INTERVAL)
-
-    surviving_processes = [p for p in surviving_processes if p.is_alive()]
-    for process in surviving_processes:
-        try:
-            process.kill()
-        except Exception:
-            logger.exception("Failed to kill retrieval process %s.", process.pid)
-
-    kill_deadline = time.monotonic() + _PIPELINE_KILL_TIMEOUT
-    while time.monotonic() < kill_deadline and any(
-        p.is_alive() for p in surviving_processes
-    ):
-        time.sleep(_PIPELINE_POLL_INTERVAL)
-    for process in surviving_processes:
-        if process.is_alive():
-            logger.warning("Retrieval process %s survived SIGKILL.", process.pid)
-
-    for process in processes:
-        try:
-            process.join(timeout=0)
-        except Exception:
-            logger.exception("Failed to reap retrieval process %s.", process.pid)
-    for thread in threads:
-        try:
-            thread.join(timeout=0)
-            if thread.is_alive():
-                logger.warning("Retrieval thread %s did not terminate.", thread.name)
-        except Exception:
-            logger.exception("Failed to join retrieval thread %s.", thread.name)
-    for data_queue in queues:
-        try:
-            cancel_join_thread = getattr(data_queue, "cancel_join_thread", None)
-            if cancel_join_thread is not None:
-                cancel_join_thread()
-            close = getattr(data_queue, "close", None)
-            if close is not None:
-                close()
-        except Exception:
-            logger.exception("Failed to close a retrieval pipeline queue.")
-
-
-def _validate_and_commit_writer(
-    writer: BaseWriter,
-    pipeline_succeeded: bool,
-    expected_batches: int,
-    expected_rows: int,
-    written_batches: int,
-    written_rows: int,
-) -> None:
-    """Commit output only after non-empty completeness validation."""
-    if not pipeline_succeeded:
-        raise RuntimeError("TDM retrieval pipeline failed; output was not committed.")
-    if expected_rows == 0:
-        raise RuntimeError("TDM retrieval input is empty; output was not committed.")
-    if expected_batches != written_batches or expected_rows != written_rows:
-        raise RuntimeError(
-            "TDM retrieval output is incomplete; "
-            f"submitted={expected_batches} batches/{expected_rows} rows, "
-            f"written={written_batches} batches/{written_rows} rows."
-        )
-    writer.close()
+        predict_util.report_failure(failure_queue, cancel_event, stage, None, error)
 
 
 def tdm_retrieval(
@@ -718,19 +458,22 @@ def tdm_retrieval(
             t.start()
             forward_t_list.append(t)
     except BaseException:
-        _cleanup_pipeline(
+        predict_util.cleanup_pipeline(
             data_p_list,
             forward_t_list,
             all_queues,
             cancel_event,
         )
         if is_profiling:
-            prof.stop()
+            try:
+                prof.stop()
+            except Exception:
+                logger.exception("Failed to stop the retrieval profiler.")
         raise
 
     def _check_health() -> None:
         """Check background pipeline health from the main thread."""
-        _check_pipeline_health(data_p_list, failure_queue, cancel_event)
+        predict_util.check_pipeline_health(data_p_list, failure_queue, cancel_event)
 
     try:
         while True:
@@ -739,7 +482,7 @@ def tdm_retrieval(
                 reserve_batch_record = batch.reserves.get()
                 if reserve_batch_record is None:
                     raise RuntimeError("TDM retrieval input has no reserved batch.")
-                _queue_put(
+                predict_util.queue_put_interruptibly(
                     in_queues[0],
                     (batch.reserves, None),
                     cancel_event,
@@ -750,7 +493,7 @@ def tdm_retrieval(
                 expected_rows += len(reserve_batch_record)
                 if i_step == 0:
                     # Initialize distributed writers synchronously on the first batch.
-                    record_batch_t, node_ids = _queue_get(
+                    record_batch_t, node_ids = predict_util.queue_get_interruptibly(
                         in_queues[-1],
                         cancel_event,
                         "first output",
@@ -773,12 +516,12 @@ def tdm_retrieval(
                 if is_profiling:
                     prof.step()
                 i_step += 1
-                _raise_background_failure(failure_queue)
+                predict_util.raise_background_failure(failure_queue)
             except StopIteration:
                 break
 
         for _ in range(num_worker_per_level):
-            _queue_put(
+            predict_util.queue_put_interruptibly(
                 in_queues[0],
                 (None, None),
                 cancel_event,
@@ -787,7 +530,7 @@ def tdm_retrieval(
             )
 
         if write_t is None:
-            record_batch_t, _ = _queue_get(
+            record_batch_t, _ = predict_util.queue_get_interruptibly(
                 in_queues[-1],
                 cancel_event,
                 "empty input completion",
@@ -799,10 +542,12 @@ def tdm_retrieval(
         pipeline_threads = [*forward_t_list]
         if write_t is not None:
             pipeline_threads.append(write_t)
-        _wait_for_pipeline(data_p_list, pipeline_threads, failure_queue, cancel_event)
+        predict_util.wait_for_pipeline(
+            data_p_list, pipeline_threads, failure_queue, cancel_event
+        )
         pipeline_succeeded = True
-    except _PipelineCancelled as error:
-        _raise_background_failure(failure_queue, wait=True)
+    except predict_util.PredictPipelineCancelled as error:
+        predict_util.raise_background_failure(failure_queue, wait=True)
         raise RuntimeError(
             "TDM retrieval pipeline was cancelled without an error."
         ) from error
@@ -810,14 +555,17 @@ def tdm_retrieval(
         pipeline_threads = [*forward_t_list]
         if write_t is not None:
             pipeline_threads.append(write_t)
-        _cleanup_pipeline(
+        predict_util.cleanup_pipeline(
             data_p_list,
             pipeline_threads,
             all_queues,
             cancel_event,
         )
         if is_profiling:
-            prof.stop()
+            try:
+                prof.stop()
+            except Exception:
+                logger.exception("Failed to stop the retrieval profiler.")
 
     if not pipeline_succeeded:
         raise RuntimeError("TDM retrieval pipeline did not complete successfully.")
@@ -833,7 +581,7 @@ def tdm_retrieval(
     global_written_batches = int(metric_t[2].cpu().item())
     global_written_rows = int(metric_t[3].cpu().item())
     global_recall = int(metric_t[4].cpu().item())
-    _validate_and_commit_writer(
+    predict_util.validate_and_commit_writer(
         writer,
         pipeline_succeeded,
         global_expected_batches,

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -557,16 +557,8 @@ def tdm_retrieval(
         predict_util.wait_for_pipeline(
             data_p_list, pipeline_t_list, failure_queue, cancel_event
         )
-    except predict_util.PredictPipelineCancelled as error:
-        try:
-            predict_util.raise_background_failure(failure_queue, wait=True)
-            raise RuntimeError(
-                "TDM retrieval pipeline was cancelled without an error."
-            ) from error
-        except Exception as cancel_error:
-            pipeline_error = cancel_error
     except Exception as error:
-        pipeline_error = error
+        pipeline_error = predict_util.resolve_pipeline_error(error, failure_queue)
     finally:
         predict_util.cleanup_pipeline(
             data_p_list,
@@ -575,6 +567,7 @@ def tdm_retrieval(
             cancel_event,
         )
         if is_profiling:
+            # nothing here may raise, or this rank skips the commit rendezvous.
             try:
                 prof.stop()
             except Exception:

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -81,6 +81,30 @@ def _tdm_predict_data_worker(
     cancel_event: Any,
     failure_queue: Queue,
 ) -> None:
+    """Sample one tree layer for the forward coordinator of that layer.
+
+    The worker samples candidates for every input batch until the input
+    sentinel arrives, forwards one completion sentinel downstream, and only
+    then waits for ``output_drained_event``. The wait is required because the
+    queued ``Batch`` and ``RecordBatchTensor`` payloads are backed by Torch
+    shared storage owned by this process: exiting before the forward
+    coordinator has deserialized them tears down the multiprocessing
+    resource-sharer endpoint. Cancellation is the abnormal escape.
+
+    Args:
+        sampler (TDMPredictSampler): sampler of tree nodes.
+        data_parser (DataParser): parser of sampled features.
+        first_recall_layer (int): first tree layer to recall.
+        n_cluster (int): tree cluster num.
+        in_queue (Queue): queue of upstream layer results.
+        out_queue (Queue): queue of sampled batches for this layer.
+        is_first_layer (bool): whether the worker serves the first layer.
+        worker_id (int): id of the worker.
+        output_drained_event (Event): set when this layer's forward
+            coordinator has consumed every queued payload.
+        cancel_event (Event): set when the pipeline is cancelled.
+        failure_queue (Queue): queue to report failures on.
+    """
     stage = "data worker"
     try:
         item_id_field = sampler._item_id_field
@@ -340,7 +364,6 @@ def tdm_retrieval(
     pos_prob_name: str = "probs1" if num_class == 2 else "probs"
 
     expected_batches = 0
-    expected_rows = 0
     written_batches = 0
     total = 0
     recall = 0
@@ -394,8 +417,6 @@ def tdm_retrieval(
         nonlocal recall
         output_dict = OrderedDict()
         reserve_batch_record = record_batch_t.get()
-        if reserve_batch_record is None:
-            raise RuntimeError("TDM retrieval output lost its reserved input batch.")
         gt_node_ids = reserve_batch_record[item_id_field]
         cur_batch_size = len(gt_node_ids)
         if reserved_cols is not None:
@@ -418,18 +439,23 @@ def tdm_retrieval(
 
     in_queues = [Queue(maxsize=2) for _ in range(max_level - first_recall_layer + 1)]
     out_queues = [Queue(maxsize=2) for _ in range(max_level - first_recall_layer)]
-    failure_queue = Queue()
-    cancel_event = Event()
-    data_output_drained_events = [
+    failure_queue: Any = Queue()
+    cancel_event: Any = Event()
+    data_output_drained_events: List[Any] = [
         Event() for _ in range(max_level - first_recall_layer)
     ]
     all_queues = [*in_queues, *out_queues, failure_queue]
 
     data_p_list: List[Process] = []
-    forward_t_list: List[Thread] = []
+    pipeline_t_list: List[Thread] = []
     write_t: Optional[Thread] = None
-    pipeline_succeeded = False
+    pipeline_error: Optional[BaseException] = None
     i_step = 0
+
+    def _check_health() -> None:
+        """Check background pipeline health from the main thread."""
+        predict_util.check_pipeline_health(data_p_list, failure_queue, cancel_event)
+
     try:
         for i in range(max_level - first_recall_layer):
             for j in range(num_worker_per_level):
@@ -473,32 +499,11 @@ def tdm_retrieval(
                 daemon=True,
             )
             t.start()
-            forward_t_list.append(t)
-    except BaseException:
-        predict_util.cleanup_pipeline(
-            data_p_list,
-            forward_t_list,
-            all_queues,
-            cancel_event,
-        )
-        if is_profiling:
-            try:
-                prof.stop()
-            except Exception:
-                logger.exception("Failed to stop the retrieval profiler.")
-        raise
+            pipeline_t_list.append(t)
 
-    def _check_health() -> None:
-        """Check background pipeline health from the main thread."""
-        predict_util.check_pipeline_health(data_p_list, failure_queue, cancel_event)
-
-    try:
         while True:
             try:
                 batch = next(infer_iterator)
-                reserve_batch_record = batch.reserves.get()
-                if reserve_batch_record is None:
-                    raise RuntimeError("TDM retrieval input has no reserved batch.")
                 predict_util.queue_put_interruptibly(
                     in_queues[0],
                     (batch.reserves, None),
@@ -507,7 +512,6 @@ def tdm_retrieval(
                     health_check=_check_health,
                 )
                 expected_batches += 1
-                expected_rows += len(reserve_batch_record)
                 if i_step == 0:
                     # Initialize distributed writers synchronously on the first batch.
                     record_batch_t, node_ids = predict_util.queue_get_interruptibly(
@@ -516,10 +520,6 @@ def tdm_retrieval(
                         "first output",
                         health_check=_check_health,
                     )
-                    if record_batch_t is None:
-                        raise RuntimeError(
-                            "TDM retrieval completed before producing its first output."
-                        )
                     _write(record_batch_t, node_ids)
                     write_t = Thread(
                         target=_write_loop,
@@ -528,12 +528,12 @@ def tdm_retrieval(
                         daemon=True,
                     )
                     write_t.start()
+                    pipeline_t_list.append(write_t)
                 if is_local_rank_zero:
                     plogger.log(i_step)
                 if is_profiling:
                     prof.step()
                 i_step += 1
-                predict_util.raise_background_failure(failure_queue)
             except StopIteration:
                 break
 
@@ -547,34 +547,30 @@ def tdm_retrieval(
             )
 
         if write_t is None:
-            record_batch_t, _ = predict_util.queue_get_interruptibly(
+            predict_util.queue_get_interruptibly(
                 in_queues[-1],
                 cancel_event,
                 "empty input completion",
                 health_check=_check_health,
             )
-            if record_batch_t is not None:
-                raise RuntimeError("Empty TDM retrieval produced unexpected output.")
 
-        pipeline_threads = [*forward_t_list]
-        if write_t is not None:
-            pipeline_threads.append(write_t)
         predict_util.wait_for_pipeline(
-            data_p_list, pipeline_threads, failure_queue, cancel_event
+            data_p_list, pipeline_t_list, failure_queue, cancel_event
         )
-        pipeline_succeeded = True
     except predict_util.PredictPipelineCancelled as error:
-        predict_util.raise_background_failure(failure_queue, wait=True)
-        raise RuntimeError(
-            "TDM retrieval pipeline was cancelled without an error."
-        ) from error
+        try:
+            predict_util.raise_background_failure(failure_queue, wait=True)
+            raise RuntimeError(
+                "TDM retrieval pipeline was cancelled without an error."
+            ) from error
+        except Exception as cancel_error:
+            pipeline_error = cancel_error
+    except Exception as error:
+        pipeline_error = error
     finally:
-        pipeline_threads = [*forward_t_list]
-        if write_t is not None:
-            pipeline_threads.append(write_t)
         predict_util.cleanup_pipeline(
             data_p_list,
-            pipeline_threads,
+            pipeline_t_list,
             all_queues,
             cancel_event,
         )
@@ -584,29 +580,13 @@ def tdm_retrieval(
             except Exception:
                 logger.exception("Failed to stop the retrieval profiler.")
 
-    if not pipeline_succeeded:
-        raise RuntimeError("TDM retrieval pipeline did not complete successfully.")
+    predict_util.commit_prediction_output(
+        writer, pipeline_error, expected_batches, written_batches, device
+    )
 
-    metric_t = torch.tensor(
-        [expected_batches, expected_rows, written_batches, total, recall],
-        dtype=torch.int64,
-        device=device,
-    )
+    metric_t = torch.tensor([total, recall], dtype=torch.int64, device=device)
     dist.all_reduce(metric_t, op=ReduceOp.SUM)
-    global_expected_batches = int(metric_t[0].cpu().item())
-    global_expected_rows = int(metric_t[1].cpu().item())
-    global_written_batches = int(metric_t[2].cpu().item())
-    global_written_rows = int(metric_t[3].cpu().item())
-    global_recall = int(metric_t[4].cpu().item())
-    predict_util.validate_and_commit_writer(
-        writer,
-        pipeline_succeeded,
-        global_expected_batches,
-        global_expected_rows,
-        global_written_batches,
-        global_written_rows,
-    )
-    recall_ratio = global_recall / global_written_rows
+    recall_ratio = int(metric_t[1].cpu().item()) / int(metric_t[0].cpu().item())
 
     if is_rank_zero:
         logger.info(f"Retrieval Finished. Recall:{recall_ratio}")

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -13,11 +13,14 @@ import argparse
 import copy
 import math
 import os
+import queue as queue_lib
 import time
+import traceback
 from collections import OrderedDict
-from multiprocessing import Process, Queue
+from dataclasses import dataclass
+from multiprocessing import Event, Process, Queue
 from threading import Thread
-from typing import Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -35,6 +38,141 @@ from tzrec.protos.data_pb2 import DatasetType
 from tzrec.utils import config_util
 from tzrec.utils.dist_util import init_process_group
 from tzrec.utils.logging_util import ProgressLogger, logger
+
+_PIPELINE_POLL_INTERVAL = 1.0
+_PIPELINE_CLEANUP_TIMEOUT = 10.0
+_PIPELINE_TERMINATE_TIMEOUT = 5.0
+_PIPELINE_KILL_TIMEOUT = 5.0
+
+
+@dataclass(frozen=True)
+class _PipelineFailure:
+    """Serializable failure raised by a background pipeline stage."""
+
+    stage: str
+    worker_id: Optional[int]
+    exception_type: str
+    message: str
+    traceback: str
+
+
+class _PipelineCancelled(RuntimeError):
+    """Signal that a pipeline queue operation was cancelled."""
+
+
+class _PipelineStageError(RuntimeError):
+    """Failure propagated from a background pipeline stage."""
+
+    def __init__(self, failure: _PipelineFailure) -> None:
+        worker = "" if failure.worker_id is None else f"[{failure.worker_id}]"
+        super().__init__(
+            f"TDM retrieval {failure.stage}{worker} failed with "
+            f"{failure.exception_type}: {failure.message}\n{failure.traceback}"
+        )
+
+
+def _report_failure(
+    failure_queue: Queue,
+    cancel_event: Any,
+    stage: str,
+    worker_id: Optional[int],
+    error: BaseException,
+) -> None:
+    """Report the active exception and cancel the pipeline."""
+    failure = _PipelineFailure(
+        stage=stage,
+        worker_id=worker_id,
+        exception_type=type(error).__name__,
+        message=str(error),
+        traceback=traceback.format_exc(),
+    )
+    try:
+        failure_queue.put_nowait(failure)
+    except Exception:
+        logger.exception("Failed to report TDM retrieval pipeline failure.")
+    finally:
+        cancel_event.set()
+
+
+def _raise_background_failure(failure_queue: Queue, wait: bool = False) -> None:
+    """Raise the oldest reported pipeline failure, if present."""
+    try:
+        failure = failure_queue.get(timeout=_PIPELINE_POLL_INTERVAL if wait else 0)
+    except queue_lib.Empty:
+        return
+    raise _PipelineStageError(failure)
+
+
+def _check_pipeline_health(
+    processes: Sequence[Process], failure_queue: Queue, cancel_event: Any
+) -> None:
+    """Raise reported failures or unexpected child process exits."""
+    _raise_background_failure(failure_queue)
+    if cancel_event.is_set():
+        _raise_background_failure(failure_queue, wait=True)
+        raise RuntimeError("TDM retrieval pipeline was cancelled without an error.")
+    failed_processes = [
+        p for p in processes if p.exitcode is not None and p.exitcode != 0
+    ]
+    if failed_processes:
+        cancel_event.set()
+        _raise_background_failure(failure_queue, wait=True)
+        details = ", ".join(
+            f"pid={p.pid}, exitcode={p.exitcode}" for p in failed_processes
+        )
+        raise RuntimeError(f"TDM retrieval data worker failed: {details}.")
+
+
+def _queue_get(
+    data_queue: Queue,
+    cancel_event: Any,
+    stage: str,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+    health_check: Optional[Callable[[], None]] = None,
+) -> Any:
+    """Get a queue item while remaining responsive to cancellation."""
+    deadline = time.monotonic() + timeout
+    while not cancel_event.is_set():
+        if health_check is not None:
+            health_check()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"TDM retrieval {stage} stalled waiting for queue input "
+                f"for {timeout} seconds."
+            )
+        try:
+            return data_queue.get(timeout=min(_PIPELINE_POLL_INTERVAL, remaining))
+        except queue_lib.Empty:
+            continue
+    raise _PipelineCancelled(f"TDM retrieval {stage} was cancelled.")
+
+
+def _queue_put(
+    data_queue: Queue,
+    item: Any,
+    cancel_event: Any,
+    stage: str,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+    health_check: Optional[Callable[[], None]] = None,
+) -> None:
+    """Put a queue item while remaining responsive to cancellation."""
+    deadline = time.monotonic() + timeout
+    while not cancel_event.is_set():
+        if health_check is not None:
+            health_check()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"TDM retrieval {stage} stalled waiting for queue capacity "
+                f"for {timeout} seconds."
+            )
+        try:
+            data_queue.put(item, timeout=min(_PIPELINE_POLL_INTERVAL, remaining))
+            return
+        except queue_lib.Full:
+            continue
+    raise _PipelineCancelled(f"TDM retrieval {stage} was cancelled.")
 
 
 def update_data(
@@ -78,44 +216,250 @@ def _tdm_predict_data_worker(
     out_queue: Queue,
     is_first_layer: bool,
     worker_id: int,
+    cancel_event: Any,
+    failure_queue: Queue,
 ) -> None:
-    item_id_field = sampler._item_id_field
-    sampler.init(worker_id)
-    sampler.init_sampler(n_cluster)
+    stage = "data worker"
+    try:
+        item_id_field = sampler._item_id_field
+        sampler.init(worker_id)
+        sampler.init_sampler(n_cluster)
 
+        while True:
+            record_batch_t, node_ids = _queue_get(
+                in_queue, cancel_event, f"{stage}[{worker_id}] input"
+            )
+
+            if record_batch_t is None:
+                _queue_put(
+                    out_queue,
+                    (None, None, None),
+                    cancel_event,
+                    f"{stage}[{worker_id}] completion",
+                )
+                break
+
+            record_batch = record_batch_t.get()
+            if is_first_layer:
+                sampler.init_sampler(1)
+
+                gt_node_ids = record_batch[item_id_field]
+                cur_batch_size = len(gt_node_ids)
+                node_ids = sampler.get(
+                    {item_id_field: pa.array([-1] * cur_batch_size)}
+                )[item_id_field]
+
+                # skip layers before first_recall_layer
+                sampler.init_sampler(n_cluster)
+                for _ in range(1, first_recall_layer):
+                    sampled_result_dict = sampler.get({item_id_field: node_ids})
+                    node_ids = sampled_result_dict[item_id_field]
+
+            sampled_result_dict = sampler.get({item_id_field: node_ids})
+            updated_inputs = update_data(record_batch, sampled_result_dict)
+            output_data = data_parser.parse(updated_inputs)
+            batch = data_parser.to_batch(output_data, force_no_tile=True)
+
+            _queue_put(
+                out_queue,
+                (batch, record_batch_t, updated_inputs[item_id_field]),
+                cancel_event,
+                f"{stage}[{worker_id}] output",
+            )
+    except _PipelineCancelled:
+        return
+    except BaseException as error:
+        _report_failure(failure_queue, cancel_event, stage, worker_id, error)
+        raise
+
+
+def _forward_loop(
+    data_queue: Queue,
+    pred_queue: Queue,
+    layer_id: int,
+    producer_count: int,
+    downstream_consumer_count: int,
+    forward_fn: Callable[
+        [Batch, RecordBatchTensor, pa.Array, int],
+        Tuple[RecordBatchTensor, pa.Array],
+    ],
+    cancel_event: Any,
+    failure_queue: Queue,
+) -> None:
+    """Forward one tree layer and propagate normal completion downstream."""
+    stage = "forward"
+    try:
+        completed_producers = 0
+        while completed_producers < producer_count:
+            batch, record_batch_t, node_ids = _queue_get(
+                data_queue, cancel_event, f"{stage}[{layer_id}] input"
+            )
+            if batch is None:
+                completed_producers += 1
+                continue
+            pred = forward_fn(batch, record_batch_t, node_ids, layer_id)
+            _queue_put(
+                pred_queue,
+                pred,
+                cancel_event,
+                f"{stage}[{layer_id}] output",
+            )
+        for _ in range(downstream_consumer_count):
+            _queue_put(
+                pred_queue,
+                (None, None),
+                cancel_event,
+                f"{stage}[{layer_id}] completion",
+            )
+    except _PipelineCancelled:
+        return
+    except BaseException as error:
+        _report_failure(failure_queue, cancel_event, stage, layer_id, error)
+
+
+def _write_loop(
+    pred_queue: Queue,
+    write_fn: Callable[[RecordBatchTensor, pa.Array], None],
+    cancel_event: Any,
+    failure_queue: Queue,
+) -> None:
+    """Write completed retrieval batches until normal completion."""
+    stage = "writer"
+    try:
+        while True:
+            record_batch_t, node_ids = _queue_get(
+                pred_queue, cancel_event, f"{stage} input"
+            )
+            if record_batch_t is None:
+                return
+            write_fn(record_batch_t, node_ids)
+    except _PipelineCancelled:
+        return
+    except BaseException as error:
+        _report_failure(failure_queue, cancel_event, stage, None, error)
+
+
+def _wait_for_pipeline(
+    processes: Sequence[Process],
+    threads: Sequence[Thread],
+    failure_queue: Queue,
+    cancel_event: Any,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+) -> None:
+    """Wait for normal pipeline completion while monitoring failures."""
+    deadline = time.monotonic() + timeout
     while True:
-        record_batch_t, node_ids = in_queue.get(timeout=PREDICT_QUEUE_TIMEOUT)
+        _check_pipeline_health(processes, failure_queue, cancel_event)
 
-        if record_batch_t is None:
-            out_queue.put((None, None, None), timeout=PREDICT_QUEUE_TIMEOUT)
-            time.sleep(10)
+        alive_processes = [p for p in processes if p.is_alive()]
+        alive_threads = [t for t in threads if t.is_alive()]
+        if not alive_processes and not alive_threads:
             break
+        if time.monotonic() >= deadline:
+            process_ids = [p.pid for p in alive_processes]
+            thread_names = [t.name for t in alive_threads]
+            raise TimeoutError(
+                "TDM retrieval pipeline stalled during completion; "
+                f"processes={process_ids}, threads={thread_names}."
+            )
+        time.sleep(_PIPELINE_POLL_INTERVAL)
 
-        record_batch = record_batch_t.get()
-        if is_first_layer:
-            sampler.init_sampler(1)
+    for process in processes:
+        process.join(timeout=0)
+    for thread in threads:
+        thread.join(timeout=0)
+    _raise_background_failure(failure_queue)
 
-            gt_node_ids = record_batch[item_id_field]
-            cur_batch_size = len(gt_node_ids)
-            node_ids = sampler.get({item_id_field: pa.array([-1] * cur_batch_size)})[
-                item_id_field
-            ]
 
-            # skip layers before first_recall_layer
-            sampler.init_sampler(n_cluster)
-            for _ in range(1, first_recall_layer):
-                sampled_result_dict = sampler.get({item_id_field: node_ids})
-                node_ids = sampled_result_dict[item_id_field]
+def _cleanup_pipeline(
+    processes: Sequence[Process],
+    threads: Sequence[Thread],
+    queues: Sequence[Queue],
+    cancel_event: Any,
+) -> None:
+    """Cancel and reap pipeline components within bounded deadlines."""
+    cancel_event.set()
+    graceful_deadline = time.monotonic() + _PIPELINE_CLEANUP_TIMEOUT
+    while time.monotonic() < graceful_deadline:
+        if not any(p.is_alive() for p in processes) and not any(
+            t.is_alive() for t in threads
+        ):
+            break
+        time.sleep(_PIPELINE_POLL_INTERVAL)
 
-        sampled_result_dict = sampler.get({item_id_field: node_ids})
-        updated_inputs = update_data(record_batch, sampled_result_dict)
-        output_data = data_parser.parse(updated_inputs)
-        batch = data_parser.to_batch(output_data, force_no_tile=True)
+    surviving_processes = [p for p in processes if p.is_alive()]
+    for process in surviving_processes:
+        try:
+            process.terminate()
+        except Exception:
+            logger.exception("Failed to terminate retrieval process %s.", process.pid)
 
-        out_queue.put(
-            (batch, record_batch_t, updated_inputs[item_id_field]),
-            timeout=PREDICT_QUEUE_TIMEOUT,
+    terminate_deadline = time.monotonic() + _PIPELINE_TERMINATE_TIMEOUT
+    while time.monotonic() < terminate_deadline and any(
+        p.is_alive() for p in surviving_processes
+    ):
+        time.sleep(_PIPELINE_POLL_INTERVAL)
+
+    surviving_processes = [p for p in surviving_processes if p.is_alive()]
+    for process in surviving_processes:
+        try:
+            process.kill()
+        except Exception:
+            logger.exception("Failed to kill retrieval process %s.", process.pid)
+
+    kill_deadline = time.monotonic() + _PIPELINE_KILL_TIMEOUT
+    while time.monotonic() < kill_deadline and any(
+        p.is_alive() for p in surviving_processes
+    ):
+        time.sleep(_PIPELINE_POLL_INTERVAL)
+    for process in surviving_processes:
+        if process.is_alive():
+            logger.warning("Retrieval process %s survived SIGKILL.", process.pid)
+
+    for process in processes:
+        try:
+            process.join(timeout=0)
+        except Exception:
+            logger.exception("Failed to reap retrieval process %s.", process.pid)
+    for thread in threads:
+        try:
+            thread.join(timeout=0)
+            if thread.is_alive():
+                logger.warning("Retrieval thread %s did not terminate.", thread.name)
+        except Exception:
+            logger.exception("Failed to join retrieval thread %s.", thread.name)
+    for data_queue in queues:
+        try:
+            cancel_join_thread = getattr(data_queue, "cancel_join_thread", None)
+            if cancel_join_thread is not None:
+                cancel_join_thread()
+            close = getattr(data_queue, "close", None)
+            if close is not None:
+                close()
+        except Exception:
+            logger.exception("Failed to close a retrieval pipeline queue.")
+
+
+def _validate_and_commit_writer(
+    writer: BaseWriter,
+    pipeline_succeeded: bool,
+    expected_batches: int,
+    expected_rows: int,
+    written_batches: int,
+    written_rows: int,
+) -> None:
+    """Commit output only after non-empty completeness validation."""
+    if not pipeline_succeeded:
+        raise RuntimeError("TDM retrieval pipeline failed; output was not committed.")
+    if expected_rows == 0:
+        raise RuntimeError("TDM retrieval input is empty; output was not committed.")
+    if expected_batches != written_batches or expected_rows != written_rows:
+        raise RuntimeError(
+            "TDM retrieval output is incomplete; "
+            f"submitted={expected_batches} batches/{expected_rows} rows, "
+            f"written={written_batches} batches/{written_rows} rows."
         )
+    writer.close()
 
 
 def tdm_retrieval(
@@ -243,6 +587,9 @@ def tdm_retrieval(
     num_class = pipeline_config.model_config.num_class
     pos_prob_name: str = "probs1" if num_class == 2 else "probs"
 
+    expected_batches = 0
+    expected_rows = 0
+    written_batches = 0
     total = 0
     recall = 0
 
@@ -289,29 +636,14 @@ def tdm_retrieval(
 
             return record_batch_t, node_ids
 
-    def _forward_loop(data_queue: Queue, pred_queue: Queue, layer_id: int) -> None:
-        stop_cnt = 0
-        while True:
-            batch, record_batch_t, node_ids = data_queue.get(
-                timeout=PREDICT_QUEUE_TIMEOUT
-            )
-            if batch is None:
-                stop_cnt += 1
-                if stop_cnt == num_worker_per_level:
-                    for _ in range(num_worker_per_level):
-                        pred_queue.put((None, None), timeout=PREDICT_QUEUE_TIMEOUT)
-                    break
-                else:
-                    continue
-            assert batch is not None
-            pred = _forward(batch, record_batch_t, node_ids, layer_id)
-            pred_queue.put(pred, timeout=PREDICT_QUEUE_TIMEOUT)
-
     def _write(record_batch_t: RecordBatchTensor, node_ids: pa.Array) -> None:
+        nonlocal written_batches
         nonlocal total
         nonlocal recall
         output_dict = OrderedDict()
         reserve_batch_record = record_batch_t.get()
+        if reserve_batch_record is None:
+            raise RuntimeError("TDM retrieval output lost its reserved input batch.")
         gt_node_ids = reserve_batch_record[item_id_field]
         cur_batch_size = len(gt_node_ids)
         if reserved_cols is not None:
@@ -328,88 +660,189 @@ def tdm_retrieval(
             ),
             axis=1,
         )
+        written_batches += 1
         total += cur_batch_size
         recall += np.sum(retrieval_result)
 
-    def _write_loop(pred_queue: Queue) -> None:
-        while True:
-            record_batch_t, node_ids = pred_queue.get(timeout=PREDICT_QUEUE_TIMEOUT)
-            if record_batch_t is None:
-                break
-            _write(record_batch_t, node_ids)
-
     in_queues = [Queue(maxsize=2) for _ in range(max_level - first_recall_layer + 1)]
     out_queues = [Queue(maxsize=2) for _ in range(max_level - first_recall_layer)]
+    failure_queue = Queue()
+    cancel_event = Event()
+    all_queues = [*in_queues, *out_queues, failure_queue]
 
-    data_p_list = []
-    for i in range(max_level - first_recall_layer):
-        for j in range(num_worker_per_level):
-            p = Process(
-                target=_tdm_predict_data_worker,
-                args=(
-                    predict_sampler,
-                    parser,
-                    first_recall_layer,
-                    n_cluster,
-                    in_queues[i],
-                    out_queues[i],
-                    i == 0,
-                    i * num_worker_per_level + j,
-                ),
-            )
-            p.start()
-            data_p_list.append(p)
-
-    forward_t_list = []
-    for i in range(max_level - first_recall_layer):
-        t = Thread(
-            target=_forward_loop,
-            args=(out_queues[i], in_queues[i + 1], i + first_recall_layer),
-        )
-        t.start()
-        forward_t_list.append(t)
-
-    write_t = None
+    data_p_list: List[Process] = []
+    forward_t_list: List[Thread] = []
+    write_t: Optional[Thread] = None
+    pipeline_succeeded = False
     i_step = 0
-    while True:
-        try:
-            batch = next(infer_iterator)
-            in_queues[0].put((batch.reserves, None), timeout=PREDICT_QUEUE_TIMEOUT)
-            if i_step == 0:
-                # lazy init writer and create write thread
-                record_batch_t, node_ids = in_queues[-1].get(
-                    timeout=PREDICT_QUEUE_TIMEOUT
+    try:
+        for i in range(max_level - first_recall_layer):
+            for j in range(num_worker_per_level):
+                p = Process(
+                    target=_tdm_predict_data_worker,
+                    args=(
+                        predict_sampler,
+                        parser,
+                        first_recall_layer,
+                        n_cluster,
+                        in_queues[i],
+                        out_queues[i],
+                        i == 0,
+                        i * num_worker_per_level + j,
+                        cancel_event,
+                        failure_queue,
+                    ),
                 )
-                _write(record_batch_t, node_ids)
-                write_t = Thread(target=_write_loop, args=(in_queues[-1],))
-                write_t.start()
-            if is_local_rank_zero:
-                plogger.log(i_step)
-            if is_profiling:
-                prof.step()
-            i_step += 1
-        except StopIteration:
-            break
+                p.start()
+                data_p_list.append(p)
 
-    for _ in range(num_worker_per_level):
-        in_queues[0].put((None, None), timeout=PREDICT_QUEUE_TIMEOUT)
-    for p in data_p_list:
-        p.join()
-    for t in forward_t_list:
-        t.join()
-    assert write_t is not None
-    write_t.join()
-    writer.close()
+        for i in range(max_level - first_recall_layer):
+            downstream_consumer_count = (
+                num_worker_per_level if i < max_level - first_recall_layer - 1 else 1
+            )
+            t = Thread(
+                target=_forward_loop,
+                args=(
+                    out_queues[i],
+                    in_queues[i + 1],
+                    i + first_recall_layer,
+                    num_worker_per_level,
+                    downstream_consumer_count,
+                    _forward,
+                    cancel_event,
+                    failure_queue,
+                ),
+                name=f"tdm-forward-{i + first_recall_layer}",
+                daemon=True,
+            )
+            t.start()
+            forward_t_list.append(t)
+    except BaseException:
+        _cleanup_pipeline(
+            data_p_list,
+            forward_t_list,
+            all_queues,
+            cancel_event,
+        )
+        if is_profiling:
+            prof.stop()
+        raise
 
-    total_t = torch.tensor(total, device=device)
-    recall_t = torch.tensor(recall, device=device)
-    dist.all_reduce(total_t, op=ReduceOp.SUM)
-    dist.all_reduce(recall_t, op=ReduceOp.SUM)
-    # pyre-ignore [6]
-    recall_ratio = recall_t.cpu().item() / total_t.cpu().item()
+    def _check_health() -> None:
+        """Check background pipeline health from the main thread."""
+        _check_pipeline_health(data_p_list, failure_queue, cancel_event)
 
-    if is_profiling:
-        prof.stop()
+    try:
+        while True:
+            try:
+                batch = next(infer_iterator)
+                reserve_batch_record = batch.reserves.get()
+                if reserve_batch_record is None:
+                    raise RuntimeError("TDM retrieval input has no reserved batch.")
+                _queue_put(
+                    in_queues[0],
+                    (batch.reserves, None),
+                    cancel_event,
+                    "input producer",
+                    health_check=_check_health,
+                )
+                expected_batches += 1
+                expected_rows += len(reserve_batch_record)
+                if i_step == 0:
+                    # Initialize distributed writers synchronously on the first batch.
+                    record_batch_t, node_ids = _queue_get(
+                        in_queues[-1],
+                        cancel_event,
+                        "first output",
+                        health_check=_check_health,
+                    )
+                    if record_batch_t is None:
+                        raise RuntimeError(
+                            "TDM retrieval completed before producing its first output."
+                        )
+                    _write(record_batch_t, node_ids)
+                    write_t = Thread(
+                        target=_write_loop,
+                        args=(in_queues[-1], _write, cancel_event, failure_queue),
+                        name="tdm-writer",
+                        daemon=True,
+                    )
+                    write_t.start()
+                if is_local_rank_zero:
+                    plogger.log(i_step)
+                if is_profiling:
+                    prof.step()
+                i_step += 1
+                _raise_background_failure(failure_queue)
+            except StopIteration:
+                break
+
+        for _ in range(num_worker_per_level):
+            _queue_put(
+                in_queues[0],
+                (None, None),
+                cancel_event,
+                "input completion",
+                health_check=_check_health,
+            )
+
+        if write_t is None:
+            record_batch_t, _ = _queue_get(
+                in_queues[-1],
+                cancel_event,
+                "empty input completion",
+                health_check=_check_health,
+            )
+            if record_batch_t is not None:
+                raise RuntimeError("Empty TDM retrieval produced unexpected output.")
+
+        pipeline_threads = [*forward_t_list]
+        if write_t is not None:
+            pipeline_threads.append(write_t)
+        _wait_for_pipeline(data_p_list, pipeline_threads, failure_queue, cancel_event)
+        pipeline_succeeded = True
+    except _PipelineCancelled as error:
+        _raise_background_failure(failure_queue, wait=True)
+        raise RuntimeError(
+            "TDM retrieval pipeline was cancelled without an error."
+        ) from error
+    finally:
+        pipeline_threads = [*forward_t_list]
+        if write_t is not None:
+            pipeline_threads.append(write_t)
+        _cleanup_pipeline(
+            data_p_list,
+            pipeline_threads,
+            all_queues,
+            cancel_event,
+        )
+        if is_profiling:
+            prof.stop()
+
+    if not pipeline_succeeded:
+        raise RuntimeError("TDM retrieval pipeline did not complete successfully.")
+
+    metric_t = torch.tensor(
+        [expected_batches, expected_rows, written_batches, total, recall],
+        dtype=torch.int64,
+        device=device,
+    )
+    dist.all_reduce(metric_t, op=ReduceOp.SUM)
+    global_expected_batches = int(metric_t[0].cpu().item())
+    global_expected_rows = int(metric_t[1].cpu().item())
+    global_written_batches = int(metric_t[2].cpu().item())
+    global_written_rows = int(metric_t[3].cpu().item())
+    global_recall = int(metric_t[4].cpu().item())
+    _validate_and_commit_writer(
+        writer,
+        pipeline_succeeded,
+        global_expected_batches,
+        global_expected_rows,
+        global_written_batches,
+        global_written_rows,
+    )
+    recall_ratio = global_recall / global_written_rows
+
     if is_rank_zero:
         logger.info(f"Retrieval Finished. Recall:{recall_ratio}")
 

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -363,7 +363,7 @@ def tdm_retrieval(
     num_class = pipeline_config.model_config.num_class
     pos_prob_name: str = "probs1" if num_class == 2 else "probs"
 
-    expected_batches = 0
+    input_batches = 0
     total = 0
     recall = 0
 
@@ -508,7 +508,7 @@ def tdm_retrieval(
                     "input producer",
                     health_check=_check_health,
                 )
-                expected_batches += 1
+                input_batches += 1
                 if i_step == 0:
                     # Initialize distributed writers synchronously on the first batch.
                     record_batch_t, node_ids = predict_util.queue_get_interruptibly(
@@ -570,9 +570,7 @@ def tdm_retrieval(
             except Exception:
                 logger.exception("Failed to stop the retrieval profiler.")
 
-    predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, device
-    )
+    predict_util.commit_prediction_output(writer, pipeline_error, input_batches, device)
 
     metric_t = torch.tensor([total, recall], dtype=torch.int64, device=device)
     dist.all_reduce(metric_t, op=ReduceOp.SUM)

--- a/tzrec/tools/tdm/retrieval.py
+++ b/tzrec/tools/tdm/retrieval.py
@@ -364,7 +364,6 @@ def tdm_retrieval(
     pos_prob_name: str = "probs1" if num_class == 2 else "probs"
 
     expected_batches = 0
-    written_batches = 0
     total = 0
     recall = 0
 
@@ -412,7 +411,6 @@ def tdm_retrieval(
             return record_batch_t, node_ids
 
     def _write(record_batch_t: RecordBatchTensor, node_ids: pa.Array) -> None:
-        nonlocal written_batches
         nonlocal total
         nonlocal recall
         output_dict = OrderedDict()
@@ -433,7 +431,6 @@ def tdm_retrieval(
             ),
             axis=1,
         )
-        written_batches += 1
         total += cur_batch_size
         recall += np.sum(retrieval_result)
 
@@ -574,7 +571,7 @@ def tdm_retrieval(
                 logger.exception("Failed to stop the retrieval profiler.")
 
     predict_util.commit_prediction_output(
-        writer, pipeline_error, expected_batches, written_batches, device
+        writer, pipeline_error, expected_batches, device
     )
 
     metric_t = torch.tensor([total, recall], dtype=torch.int64, device=device)

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -9,14 +9,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
 import queue
 import threading
 import time
 import unittest
 from unittest import mock
 
+import pyarrow as pa
 from parameterized import parameterized
 
+from tzrec.datasets.utils import Batch, RecordBatchTensor
 from tzrec.tools.tdm import retrieval
 from tzrec.utils import predict_util
 from tzrec.utils.test_util import parameterized_name_func
@@ -27,6 +30,27 @@ class _FailingSampler:
 
     def init(self, worker_id):
         raise ValueError("worker boom")
+
+
+class _PassingSampler:
+    _item_id_field = "item_id"
+
+    def init(self, worker_id):
+        return None
+
+    def init_sampler(self, n_cluster):
+        return None
+
+    def get(self, input_data):
+        return {"item_id": pa.array([2])}
+
+
+class _PassingParser:
+    def parse(self, input_data):
+        return input_data
+
+    def to_batch(self, output_data, force_no_tile=False):
+        return Batch()
 
 
 class _StubbornProcess:
@@ -60,6 +84,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
             pred_queue = queue.Queue(maxsize=2 if downstream_count == 1 else 0)
             cancel_event = threading.Event()
             failure_queue = queue.Queue()
+            input_drained_event = threading.Event()
             for _ in range(worker_count):
                 data_queue.put((None, None, None))
 
@@ -70,6 +95,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
                 worker_count,
                 downstream_count,
                 mock.Mock(),
+                input_drained_event,
                 cancel_event,
                 failure_queue,
             )
@@ -79,6 +105,51 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
                 self.assertEqual(pred_queue.get_nowait(), (None, None))
             self.assertFalse(cancel_event.is_set())
             self.assertTrue(failure_queue.empty())
+            self.assertTrue(input_drained_event.is_set())
+
+    def test_data_worker_keeps_shared_storage_alive_until_drained(self):
+        in_queue = multiprocessing.Queue()
+        out_queue = multiprocessing.Queue()
+        output_drained_event = multiprocessing.Event()
+        cancel_event = multiprocessing.Event()
+        failure_queue = multiprocessing.Queue()
+        record_batch_t = RecordBatchTensor(pa.record_batch({"item_id": [1]}))
+        in_queue.put((record_batch_t, pa.array([1])))
+        in_queue.put((None, None))
+        worker = multiprocessing.Process(
+            target=retrieval._tdm_predict_data_worker,
+            args=(
+                _PassingSampler(),
+                _PassingParser(),
+                1,
+                2,
+                in_queue,
+                out_queue,
+                False,
+                0,
+                output_drained_event,
+                cancel_event,
+                failure_queue,
+            ),
+        )
+        worker.start()
+
+        batch, output_record_batch_t, node_ids = out_queue.get(timeout=2)
+        self.assertIsInstance(batch, Batch)
+        self.assertEqual(output_record_batch_t.get()["item_id"].to_pylist(), [1])
+        self.assertEqual(node_ids.to_pylist(), [2])
+        self.assertEqual(out_queue.get(timeout=1), (None, None, None))
+        self.assertTrue(worker.is_alive())
+        output_drained_event.set()
+        worker.join(timeout=2)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(worker.exitcode, 0)
+        self.assertFalse(cancel_event.is_set())
+        self.assertTrue(failure_queue.empty())
+        for data_queue in (in_queue, out_queue, failure_queue):
+            data_queue.close()
+            data_queue.join_thread()
 
     @parameterized.expand(
         [["worker"], ["forward"], ["writer"]],
@@ -100,6 +171,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
                     queue.Queue(),
                     True,
                     7,
+                    threading.Event(),
                     cancel_event,
                     failure_queue,
                 )
@@ -113,6 +185,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
                 1,
                 1,
                 mock.Mock(side_effect=ValueError("forward boom")),
+                threading.Event(),
                 cancel_event,
                 failure_queue,
             )

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -212,7 +212,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
         self.assertIn("ValueError", str(error.exception))
         with self.assertRaises(predict_util.PredictPipelineStageError):
             predict_util.commit_prediction_output(
-                writer, error.exception, 1, 1, torch.device("cpu")
+                writer, error.exception, 1, torch.device("cpu")
             )
         writer.close.assert_not_called()
 

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+import time
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from tzrec.tools.tdm import retrieval
+from tzrec.utils.test_util import parameterized_name_func
+
+
+class _FailingSampler:
+    _item_id_field = "item_id"
+
+    def init(self, worker_id):
+        raise ValueError("worker boom")
+
+
+class _StubbornProcess:
+    def __init__(self):
+        self.pid = 123
+        self.exitcode = None
+        self.terminate_called = False
+        self.kill_called = False
+        self._alive = True
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self.terminate_called = True
+
+    def kill(self):
+        self.kill_called = True
+        self._alive = False
+        self.exitcode = -9
+
+    def join(self, timeout=None):
+        return None
+
+
+class TDMRetrievalLifecycleTest(unittest.TestCase):
+    @parameterized.expand([[1], [2], [4], [8]], name_func=parameterized_name_func)
+    def test_normal_sentinel_fanout(self, worker_count):
+        for downstream_count in (worker_count, 1):
+            data_queue = queue.Queue()
+            pred_queue = queue.Queue(maxsize=2 if downstream_count == 1 else 0)
+            cancel_event = threading.Event()
+            failure_queue = queue.Queue()
+            for _ in range(worker_count):
+                data_queue.put((None, None, None))
+
+            retrieval._forward_loop(
+                data_queue,
+                pred_queue,
+                3,
+                worker_count,
+                downstream_count,
+                mock.Mock(),
+                cancel_event,
+                failure_queue,
+            )
+
+            self.assertEqual(pred_queue.qsize(), downstream_count)
+            for _ in range(downstream_count):
+                self.assertEqual(pred_queue.get_nowait(), (None, None))
+            self.assertFalse(cancel_event.is_set())
+            self.assertTrue(failure_queue.empty())
+
+    @parameterized.expand(
+        [["worker"], ["forward"], ["writer"]],
+        name_func=parameterized_name_func,
+    )
+    def test_stage_failure_is_propagated_without_commit(self, stage):
+        cancel_event = threading.Event()
+        failure_queue = queue.Queue()
+        writer = mock.Mock()
+
+        if stage == "worker":
+            with self.assertRaisesRegex(ValueError, "worker boom"):
+                retrieval._tdm_predict_data_worker(
+                    _FailingSampler(),
+                    mock.Mock(),
+                    1,
+                    2,
+                    queue.Queue(),
+                    queue.Queue(),
+                    True,
+                    7,
+                    cancel_event,
+                    failure_queue,
+                )
+        elif stage == "forward":
+            data_queue = queue.Queue()
+            data_queue.put((object(), object(), object()))
+            retrieval._forward_loop(
+                data_queue,
+                queue.Queue(),
+                3,
+                1,
+                1,
+                mock.Mock(side_effect=ValueError("forward boom")),
+                cancel_event,
+                failure_queue,
+            )
+        else:
+            pred_queue = queue.Queue()
+            pred_queue.put((object(), object()))
+            retrieval._write_loop(
+                pred_queue,
+                mock.Mock(side_effect=ValueError("writer boom")),
+                cancel_event,
+                failure_queue,
+            )
+
+        self.assertTrue(cancel_event.is_set())
+        with self.assertRaises(retrieval._PipelineStageError) as error:
+            retrieval._raise_background_failure(failure_queue)
+        self.assertIn(f"{stage} boom", str(error.exception))
+        self.assertIn("ValueError", str(error.exception))
+        with self.assertRaisesRegex(RuntimeError, "not committed"):
+            retrieval._validate_and_commit_writer(writer, False, 1, 1, 1, 1)
+        writer.close.assert_not_called()
+
+    def test_full_queue_is_interruptible_and_cleanup_is_bounded(self):
+        data_queue = queue.Queue(maxsize=1)
+        data_queue.put("full")
+        cancel_event = threading.Event()
+
+        def cancel():
+            time.sleep(0.02)
+            cancel_event.set()
+
+        cancel_thread = threading.Thread(target=cancel)
+        cancel_thread.start()
+        with mock.patch.object(retrieval, "_PIPELINE_POLL_INTERVAL", 0.01):
+            with self.assertRaises(retrieval._PipelineCancelled):
+                retrieval._queue_put(
+                    data_queue, "blocked", cancel_event, "test queue", timeout=1
+                )
+            with self.assertRaisesRegex(TimeoutError, "test stall"):
+                retrieval._queue_put(
+                    data_queue,
+                    "blocked",
+                    threading.Event(),
+                    "test stall",
+                    timeout=0.02,
+                )
+            failed_process = _StubbornProcess()
+            failed_process._alive = False
+            failed_process.exitcode = -9
+            failed_event = threading.Event()
+            with self.assertRaisesRegex(RuntimeError, "exitcode=-9"):
+                retrieval._check_pipeline_health(
+                    [failed_process], queue.Queue(), failed_event
+                )
+            self.assertTrue(failed_event.is_set())
+        cancel_thread.join(timeout=1)
+
+        process = _StubbornProcess()
+        pipeline_queue = mock.Mock()
+        with (
+            mock.patch.object(retrieval, "_PIPELINE_CLEANUP_TIMEOUT", 0),
+            mock.patch.object(retrieval, "_PIPELINE_TERMINATE_TIMEOUT", 0),
+            mock.patch.object(retrieval, "_PIPELINE_KILL_TIMEOUT", 0),
+        ):
+            retrieval._cleanup_pipeline(
+                [process], [], [pipeline_queue], threading.Event()
+            )
+        self.assertTrue(process.terminate_called)
+        self.assertTrue(process.kill_called)
+        pipeline_queue.cancel_join_thread.assert_called_once_with()
+        pipeline_queue.close.assert_called_once_with()
+
+    def test_commit_requires_complete_nonempty_success(self):
+        writer = mock.Mock()
+        retrieval._validate_and_commit_writer(writer, True, 2, 8, 2, 8)
+        writer.close.assert_called_once_with()
+
+        invalid_cases = [
+            (False, 2, 8, 2, 8),
+            (True, 0, 0, 0, 0),
+            (True, 2, 8, 1, 4),
+        ]
+        for args in invalid_cases:
+            failed_writer = mock.Mock()
+            with self.assertRaises(RuntimeError):
+                retrieval._validate_and_commit_writer(failed_writer, *args)
+            failed_writer.close.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -18,6 +18,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from tzrec.tools.tdm import retrieval
+from tzrec.utils import predict_util
 from tzrec.utils.test_util import parameterized_name_func
 
 
@@ -126,12 +127,12 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
             )
 
         self.assertTrue(cancel_event.is_set())
-        with self.assertRaises(retrieval._PipelineStageError) as error:
-            retrieval._raise_background_failure(failure_queue)
+        with self.assertRaises(predict_util.PredictPipelineStageError) as error:
+            predict_util.raise_background_failure(failure_queue)
         self.assertIn(f"{stage} boom", str(error.exception))
         self.assertIn("ValueError", str(error.exception))
         with self.assertRaisesRegex(RuntimeError, "not committed"):
-            retrieval._validate_and_commit_writer(writer, False, 1, 1, 1, 1)
+            predict_util.validate_and_commit_writer(writer, False, 1, 1, 1, 1)
         writer.close.assert_not_called()
 
     def test_full_queue_is_interruptible_and_cleanup_is_bounded(self):
@@ -145,13 +146,13 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
 
         cancel_thread = threading.Thread(target=cancel)
         cancel_thread.start()
-        with mock.patch.object(retrieval, "_PIPELINE_POLL_INTERVAL", 0.01):
-            with self.assertRaises(retrieval._PipelineCancelled):
-                retrieval._queue_put(
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            with self.assertRaises(predict_util.PredictPipelineCancelled):
+                predict_util.queue_put_interruptibly(
                     data_queue, "blocked", cancel_event, "test queue", timeout=1
                 )
             with self.assertRaisesRegex(TimeoutError, "test stall"):
-                retrieval._queue_put(
+                predict_util.queue_put_interruptibly(
                     data_queue,
                     "blocked",
                     threading.Event(),
@@ -163,7 +164,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
             failed_process.exitcode = -9
             failed_event = threading.Event()
             with self.assertRaisesRegex(RuntimeError, "exitcode=-9"):
-                retrieval._check_pipeline_health(
+                predict_util.check_pipeline_health(
                     [failed_process], queue.Queue(), failed_event
                 )
             self.assertTrue(failed_event.is_set())
@@ -172,11 +173,11 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
         process = _StubbornProcess()
         pipeline_queue = mock.Mock()
         with (
-            mock.patch.object(retrieval, "_PIPELINE_CLEANUP_TIMEOUT", 0),
-            mock.patch.object(retrieval, "_PIPELINE_TERMINATE_TIMEOUT", 0),
-            mock.patch.object(retrieval, "_PIPELINE_KILL_TIMEOUT", 0),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_CLEANUP_TIMEOUT", 0),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_TERMINATE_TIMEOUT", 0),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_KILL_TIMEOUT", 0),
         ):
-            retrieval._cleanup_pipeline(
+            predict_util.cleanup_pipeline(
                 [process], [], [pipeline_queue], threading.Event()
             )
         self.assertTrue(process.terminate_called)
@@ -186,7 +187,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
 
     def test_commit_requires_complete_nonempty_success(self):
         writer = mock.Mock()
-        retrieval._validate_and_commit_writer(writer, True, 2, 8, 2, 8)
+        predict_util.validate_and_commit_writer(writer, True, 2, 8, 2, 8)
         writer.close.assert_called_once_with()
 
         invalid_cases = [
@@ -197,7 +198,7 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
         for args in invalid_cases:
             failed_writer = mock.Mock()
             with self.assertRaises(RuntimeError):
-                retrieval._validate_and_commit_writer(failed_writer, *args)
+                predict_util.validate_and_commit_writer(failed_writer, *args)
             failed_writer.close.assert_not_called()
 
 

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -10,19 +10,27 @@
 # limitations under the License.
 
 import multiprocessing
+import os
 import queue
 import threading
-import time
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import pyarrow as pa
+import torch
 from parameterized import parameterized
 
 from tzrec.datasets.utils import Batch, RecordBatchTensor
+from tzrec.protos.data_pb2 import DataConfig
+from tzrec.protos.pipeline_pb2 import EasyRecConfig
+from tzrec.protos.sampler_pb2 import TDMSampler
 from tzrec.tools.tdm import retrieval
 from tzrec.utils import predict_util
 from tzrec.utils.test_util import parameterized_name_func
+
+_BATCH_SIZE = 2
+_SAMPLE_PER_BATCH = 8
 
 
 class _FailingSampler:
@@ -51,6 +59,27 @@ class _PassingParser:
 
     def to_batch(self, output_data, force_no_tile=False):
         return Batch()
+
+
+class _RetrievalSampler:
+    """Sampler stub expanding every input batch to a fixed candidate count."""
+
+    _item_id_field = "item_id"
+
+    def init(self, worker_id):
+        return None
+
+    def init_cluster(self, num_client_per_rank):
+        return None
+
+    def launch_server(self):
+        return None
+
+    def init_sampler(self, n_cluster):
+        return None
+
+    def get(self, input_data):
+        return {"item_id": pa.array(list(range(_SAMPLE_PER_BATCH)))}
 
 
 class _StubbornProcess:
@@ -204,75 +233,131 @@ class TDMRetrievalLifecycleTest(unittest.TestCase):
             predict_util.raise_background_failure(failure_queue)
         self.assertIn(f"{stage} boom", str(error.exception))
         self.assertIn("ValueError", str(error.exception))
-        with self.assertRaisesRegex(RuntimeError, "not committed"):
-            predict_util.validate_and_commit_writer(writer, False, 1, 1, 1, 1)
+        with self.assertRaises(predict_util.PredictPipelineStageError):
+            predict_util.commit_prediction_output(
+                writer, error.exception, 1, 1, torch.device("cpu")
+            )
         writer.close.assert_not_called()
 
-    def test_full_queue_is_interruptible_and_cleanup_is_bounded(self):
-        data_queue = queue.Queue(maxsize=1)
-        data_queue.put("full")
-        cancel_event = threading.Event()
 
-        def cancel():
-            time.sleep(0.02)
-            cancel_event.set()
+class TDMRetrievalTest(unittest.TestCase):
+    """Tests for the ``tdm_retrieval`` queue topology, end to end."""
 
-        cancel_thread = threading.Thread(target=cancel)
-        cancel_thread.start()
-        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
-            with self.assertRaises(predict_util.PredictPipelineCancelled):
-                predict_util.queue_put_interruptibly(
-                    data_queue, "blocked", cancel_event, "test queue", timeout=1
+    def _batch(self):
+        return SimpleNamespace(
+            reserves=RecordBatchTensor(
+                pa.record_batch(
+                    {
+                        "item_id": list(range(_BATCH_SIZE)),
+                        "user_id": list(range(_BATCH_SIZE)),
+                    }
                 )
-            with self.assertRaisesRegex(TimeoutError, "test stall"):
-                predict_util.queue_put_interruptibly(
-                    data_queue,
-                    "blocked",
-                    threading.Event(),
-                    "test stall",
-                    timeout=0.02,
-                )
-            failed_process = _StubbornProcess()
-            failed_process._alive = False
-            failed_process.exitcode = -9
-            failed_event = threading.Event()
-            with self.assertRaisesRegex(RuntimeError, "exitcode=-9"):
-                predict_util.check_pipeline_health(
-                    [failed_process], queue.Queue(), failed_event
-                )
-            self.assertTrue(failed_event.is_set())
-        cancel_thread.join(timeout=1)
-
-        process = _StubbornProcess()
-        pipeline_queue = mock.Mock()
-        with (
-            mock.patch.object(predict_util, "_PREDICT_PIPELINE_CLEANUP_TIMEOUT", 0),
-            mock.patch.object(predict_util, "_PREDICT_PIPELINE_TERMINATE_TIMEOUT", 0),
-            mock.patch.object(predict_util, "_PREDICT_PIPELINE_KILL_TIMEOUT", 0),
-        ):
-            predict_util.cleanup_pipeline(
-                [process], [], [pipeline_queue], threading.Event()
             )
-        self.assertTrue(process.terminate_called)
-        self.assertTrue(process.kill_called)
-        pipeline_queue.cancel_join_thread.assert_called_once_with()
-        pipeline_queue.close.assert_called_once_with()
+        )
 
-    def test_commit_requires_complete_nonempty_success(self):
+    def _pipeline_config(self):
+        return EasyRecConfig(
+            data_config=DataConfig(
+                dataset_type=3,
+                num_workers=1,
+                tdm_sampler=TDMSampler(
+                    item_input_path="item",
+                    edge_input_path="edge",
+                    predict_edge_input_path="predict_edge",
+                    item_id_field="item_id",
+                    layer_num_sample=[1, 2, 4, 8],
+                ),
+            )
+        )
+
+    def _run_retrieval(
+        self, batch_count: int, writer: mock.Mock, num_worker_per_level: int
+    ) -> None:
+        def bounded(fn):
+            """Fail fast instead of stalling for the production queue timeout."""
+
+            def wrapper(*args, **kwargs):
+                kwargs.setdefault("timeout", 20)
+                return fn(*args, **kwargs)
+
+            return wrapper
+
+        dataloader = mock.Mock()
+        dataloader.get_iterator.return_value = iter(
+            [self._batch() for _ in range(batch_count)]
+        )
+        model = mock.Mock(return_value={"probs": torch.rand(_SAMPLE_PER_BATCH)})
+        with (
+            mock.patch.dict(os.environ, {"RANK": "1", "LOCAL_RANK": "1"}),
+            mock.patch(
+                "tzrec.tools.tdm.retrieval.init_process_group",
+                return_value=(torch.device("cpu"), "gloo"),
+            ),
+            mock.patch("tzrec.tools.tdm.retrieval.dist"),
+            mock.patch(
+                "tzrec.tools.tdm.retrieval.config_util.load_pipeline_config",
+                return_value=self._pipeline_config(),
+            ),
+            mock.patch("tzrec.tools.tdm.retrieval._create_features", return_value=[]),
+            mock.patch(
+                "tzrec.tools.tdm.retrieval.create_dataloader", return_value=dataloader
+            ),
+            mock.patch("tzrec.tools.tdm.retrieval.create_writer", return_value=writer),
+            mock.patch(
+                "tzrec.tools.tdm.retrieval.TDMPredictSampler",
+                return_value=_RetrievalSampler(),
+            ),
+            mock.patch(
+                "tzrec.tools.tdm.retrieval.DataParser", return_value=_PassingParser()
+            ),
+            mock.patch("tzrec.tools.tdm.retrieval.torch.jit.load", return_value=model),
+            mock.patch.object(
+                predict_util,
+                "queue_get_interruptibly",
+                bounded(predict_util.queue_get_interruptibly),
+            ),
+            mock.patch.object(
+                predict_util,
+                "queue_put_interruptibly",
+                bounded(predict_util.queue_put_interruptibly),
+            ),
+            mock.patch.object(
+                predict_util,
+                "wait_for_pipeline",
+                bounded(predict_util.wait_for_pipeline),
+            ),
+        ):
+            retrieval.tdm_retrieval(
+                predict_input_path="input",
+                predict_output_path="output",
+                scripted_model_path="model",
+                recall_num=1,
+                n_cluster=2,
+                reserved_columns="user_id",
+                writer_type="MockWriter",
+                num_worker_per_level=num_worker_per_level,
+            )
+
+    @parameterized.expand([[1], [4]], name_func=parameterized_name_func)
+    def test_retrieval_writes_every_batch_and_commits_once(self, num_worker_per_level):
         writer = mock.Mock()
-        predict_util.validate_and_commit_writer(writer, True, 2, 8, 2, 8)
+        batch_count = 3
+
+        self._run_retrieval(batch_count, writer, num_worker_per_level)
+
+        self.assertEqual(writer.write.call_count, batch_count)
+        recall_ids = writer.write.call_args.args[0]["recall_ids"]
+        self.assertEqual(len(recall_ids), _BATCH_SIZE)
         writer.close.assert_called_once_with()
 
-        invalid_cases = [
-            (False, 2, 8, 2, 8),
-            (True, 0, 0, 0, 0),
-            (True, 2, 8, 1, 4),
-        ]
-        for args in invalid_cases:
-            failed_writer = mock.Mock()
-            with self.assertRaises(RuntimeError):
-                predict_util.validate_and_commit_writer(failed_writer, *args)
-            failed_writer.close.assert_not_called()
+    def test_empty_input_drains_without_commit(self):
+        writer = mock.Mock()
+
+        with self.assertRaisesRegex(RuntimeError, "empty"):
+            self._run_retrieval(0, writer, num_worker_per_level=2)
+
+        writer.write.assert_not_called()
+        writer.close.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tzrec/tools/tdm/retrieval_test.py
+++ b/tzrec/tools/tdm/retrieval_test.py
@@ -82,29 +82,6 @@ class _RetrievalSampler:
         return {"item_id": pa.array(list(range(_SAMPLE_PER_BATCH)))}
 
 
-class _StubbornProcess:
-    def __init__(self):
-        self.pid = 123
-        self.exitcode = None
-        self.terminate_called = False
-        self.kill_called = False
-        self._alive = True
-
-    def is_alive(self):
-        return self._alive
-
-    def terminate(self):
-        self.terminate_called = True
-
-    def kill(self):
-        self.kill_called = True
-        self._alive = False
-        self.exitcode = -9
-
-    def join(self, timeout=None):
-        return None
-
-
 class TDMRetrievalLifecycleTest(unittest.TestCase):
     @parameterized.expand([[1], [2], [4], [8]], name_func=parameterized_name_func)
     def test_normal_sentinel_fanout(self, worker_count):

--- a/tzrec/utils/predict_util.py
+++ b/tzrec/utils/predict_util.py
@@ -200,6 +200,24 @@ def queue_put_interruptibly(
     raise PredictPipelineCancelled(f"Prediction pipeline {stage} was cancelled.")
 
 
+def _any_alive(processes: Sequence[Process], threads: Sequence[Thread]) -> bool:
+    """Report whether any pipeline component is still running."""
+    return any(process.is_alive() for process in processes) or any(
+        thread.is_alive() for thread in threads
+    )
+
+
+def _poll_until(predicate: Callable[[], bool], timeout: float) -> bool:
+    """Wait for a predicate within one deadline, polling at the pipeline rate."""
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(_PREDICT_PIPELINE_POLL_INTERVAL, remaining))
+    return True
+
+
 def wait_for_pipeline(
     processes: Sequence[Process],
     threads: Sequence[Thread],
@@ -208,23 +226,18 @@ def wait_for_pipeline(
     timeout: float = PREDICT_QUEUE_TIMEOUT,
 ) -> None:
     """Wait boundedly for normal completion while monitoring failures."""
-    deadline = time.monotonic() + timeout
-    while True:
-        check_pipeline_health(processes, failure_queue, cancel_event)
-        alive_processes = [process for process in processes if process.is_alive()]
-        alive_threads = [thread for thread in threads if thread.is_alive()]
-        if not alive_processes and not alive_threads:
-            break
 
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            process_ids = [process.pid for process in alive_processes]
-            thread_names = [thread.name for thread in alive_threads]
-            raise TimeoutError(
-                "Prediction pipeline stalled during completion; "
-                f"processes={process_ids}, threads={thread_names}."
-            )
-        time.sleep(min(_PREDICT_PIPELINE_POLL_INTERVAL, remaining))
+    def _completed() -> bool:
+        """Report completion, raising whatever the background stages hit."""
+        check_pipeline_health(processes, failure_queue, cancel_event)
+        return not _any_alive(processes, threads)
+
+    if not _poll_until(_completed, timeout):
+        raise TimeoutError(
+            "Prediction pipeline stalled during completion; "
+            f"processes={[p.pid for p in processes if p.is_alive()]}, "
+            f"threads={[t.name for t in threads if t.is_alive()]}."
+        )
 
     for process in processes:
         process.join(timeout=0)
@@ -242,53 +255,21 @@ def cleanup_pipeline(
 ) -> None:
     """Cancel and reap prediction pipeline components within bounded deadlines."""
     cancel_event.set()
-    graceful_deadline = time.monotonic() + _PREDICT_PIPELINE_CLEANUP_TIMEOUT
-    while time.monotonic() < graceful_deadline:
-        if not any(process.is_alive() for process in processes) and not any(
-            thread.is_alive() for thread in threads
-        ):
-            break
-        time.sleep(
-            min(
-                _PREDICT_PIPELINE_POLL_INTERVAL,
-                max(0, graceful_deadline - time.monotonic()),
-            )
-        )
+    _poll_until(
+        lambda: not _any_alive(processes, threads), _PREDICT_PIPELINE_CLEANUP_TIMEOUT
+    )
 
-    surviving_processes = [process for process in processes if process.is_alive()]
-    for process in surviving_processes:
+    terminated = [process for process in processes if process.is_alive()]
+    for process in terminated:
         process.terminate()
+    _poll_until(
+        lambda: not _any_alive(terminated, []), _PREDICT_PIPELINE_TERMINATE_TIMEOUT
+    )
 
-    terminate_deadline = time.monotonic() + _PREDICT_PIPELINE_TERMINATE_TIMEOUT
-    while time.monotonic() < terminate_deadline and any(
-        process.is_alive() for process in surviving_processes
-    ):
-        time.sleep(
-            min(
-                _PREDICT_PIPELINE_POLL_INTERVAL,
-                max(0, terminate_deadline - time.monotonic()),
-            )
-        )
-
-    surviving_processes = [
-        process for process in surviving_processes if process.is_alive()
-    ]
-    for process in surviving_processes:
+    killed = [process for process in terminated if process.is_alive()]
+    for process in killed:
         process.kill()
-
-    kill_deadline = time.monotonic() + _PREDICT_PIPELINE_KILL_TIMEOUT
-    while time.monotonic() < kill_deadline and any(
-        process.is_alive() for process in surviving_processes
-    ):
-        time.sleep(
-            min(
-                _PREDICT_PIPELINE_POLL_INTERVAL,
-                max(0, kill_deadline - time.monotonic()),
-            )
-        )
-    for process in surviving_processes:
-        if process.is_alive():
-            logger.warning("Prediction process %s survived kill().", process.pid)
+    _poll_until(lambda: not _any_alive(killed, []), _PREDICT_PIPELINE_KILL_TIMEOUT)
 
     for process in processes:
         process.join(timeout=0)
@@ -300,12 +281,8 @@ def cleanup_pipeline(
             )
     for data_queue in queues:
         try:
-            cancel_join_thread = getattr(data_queue, "cancel_join_thread", None)
-            if cancel_join_thread is not None:
-                cancel_join_thread()
-            close = getattr(data_queue, "close", None)
-            if close is not None:
-                close()
+            data_queue.cancel_join_thread()
+            data_queue.close()
         except Exception:
             logger.exception("Failed to close a prediction pipeline queue.")
 
@@ -314,10 +291,9 @@ def commit_prediction_output(
     writer: Any,
     pipeline_error: Optional[BaseException],
     expected_batches: int,
-    written_batches: int,
     device: torch.device,
 ) -> None:
-    """Commit prediction output only when every rank produced complete output.
+    """Commit prediction output only when every rank succeeded.
 
     Every rank must call this, including ranks whose pipeline failed, because
     ``writer.close()`` participates in a collective for distributed writers.
@@ -330,15 +306,15 @@ def commit_prediction_output(
         writer (BaseWriter): output writer to commit.
         pipeline_error (BaseException, optional): failure of the local pipeline.
         expected_batches (int): batches submitted to the local pipeline.
-        written_batches (int): batches written by the local writer.
         device (torch.device): device used to reduce the outcome across ranks.
     """
-    succeeded = pipeline_error is None and expected_batches == written_batches
-    global_succeeded = succeeded
+    global_succeeded = pipeline_error is None
     global_batches = expected_batches
     if dist.is_initialized() and dist.get_world_size() > 1:
         outcome = torch.tensor(
-            [int(succeeded), expected_batches], dtype=torch.int64, device=device
+            [int(pipeline_error is None), expected_batches],
+            dtype=torch.int64,
+            device=device,
         )
         dist.all_reduce(outcome, op=ReduceOp.SUM)
         global_succeeded = int(outcome[0].item()) == dist.get_world_size()
@@ -346,15 +322,9 @@ def commit_prediction_output(
 
     if pipeline_error is not None:
         raise pipeline_error
-    if expected_batches != written_batches:
-        raise RuntimeError(
-            f"Prediction output is incomplete; submitted={expected_batches} "
-            f"batches, written={written_batches} batches."
-        )
     if not global_succeeded:
         raise RuntimeError(
-            "Prediction pipeline failed or wrote incomplete output on another "
-            "rank; output was not committed."
+            "Prediction pipeline failed on another rank; output was not committed."
         )
     if global_batches == 0:
         raise RuntimeError("Prediction input is empty; output was not committed.")

--- a/tzrec/utils/predict_util.py
+++ b/tzrec/utils/predict_util.py
@@ -13,14 +13,18 @@ import queue as queue_lib
 import time
 import traceback
 from dataclasses import dataclass
-from multiprocessing import Process, Queue
+from multiprocessing import Process
 from threading import Thread
 from typing import Any, Callable, Optional, Sequence
+
+import torch
+from torch import distributed as dist
+from torch.distributed import ReduceOp
 
 from tzrec.constant import PREDICT_QUEUE_TIMEOUT
 from tzrec.utils.logging_util import logger
 
-_PREDICT_PIPELINE_POLL_INTERVAL = 1.0
+_PREDICT_PIPELINE_POLL_INTERVAL = 0.1
 _PREDICT_PIPELINE_CLEANUP_TIMEOUT = 10.0
 _PREDICT_PIPELINE_TERMINATE_TIMEOUT = 5.0
 _PREDICT_PIPELINE_KILL_TIMEOUT = 5.0
@@ -54,7 +58,7 @@ class PredictPipelineStageError(RuntimeError):
 
 
 def report_failure(
-    failure_queue: Queue,
+    failure_queue: Any,
     cancel_event: Any,
     stage: str,
     worker_id: Optional[int],
@@ -76,7 +80,7 @@ def report_failure(
         cancel_event.set()
 
 
-def raise_background_failure(failure_queue: Queue, wait: bool = False) -> None:
+def raise_background_failure(failure_queue: Any, wait: bool = False) -> None:
     """Raise the oldest reported prediction failure, if present."""
     try:
         failure = failure_queue.get(
@@ -88,7 +92,7 @@ def raise_background_failure(failure_queue: Queue, wait: bool = False) -> None:
 
 
 def check_pipeline_health(
-    processes: Sequence[Process], failure_queue: Queue, cancel_event: Any
+    processes: Sequence[Process], failure_queue: Any, cancel_event: Any
 ) -> None:
     """Raise reported failures, cancellation, or failed child exits."""
     raise_background_failure(failure_queue)
@@ -112,7 +116,7 @@ def check_pipeline_health(
 
 
 def queue_get_interruptibly(
-    data_queue: Queue,
+    data_queue: Any,
     cancel_event: Any,
     stage: str,
     timeout: float = PREDICT_QUEUE_TIMEOUT,
@@ -139,7 +143,7 @@ def queue_get_interruptibly(
 
 
 def queue_put_interruptibly(
-    data_queue: Queue,
+    data_queue: Any,
     item: Any,
     cancel_event: Any,
     stage: str,
@@ -170,7 +174,7 @@ def queue_put_interruptibly(
 def wait_for_pipeline(
     processes: Sequence[Process],
     threads: Sequence[Thread],
-    failure_queue: Queue,
+    failure_queue: Any,
     cancel_event: Any,
     timeout: float = PREDICT_QUEUE_TIMEOUT,
 ) -> None:
@@ -208,23 +212,11 @@ def cleanup_pipeline(
     cancel_event: Any,
 ) -> None:
     """Cancel and reap prediction pipeline components within bounded deadlines."""
-
-    def _is_alive(component: Any, kind: str) -> bool:
-        """Return component liveness without allowing cleanup to raise."""
-        try:
-            return component.is_alive()
-        except Exception:
-            logger.exception("Failed to inspect prediction %s liveness.", kind)
-            return False
-
-    try:
-        cancel_event.set()
-    except Exception:
-        logger.exception("Failed to cancel the prediction pipeline.")
+    cancel_event.set()
     graceful_deadline = time.monotonic() + _PREDICT_PIPELINE_CLEANUP_TIMEOUT
     while time.monotonic() < graceful_deadline:
-        if not any(_is_alive(process, "process") for process in processes) and not any(
-            _is_alive(thread, "thread") for thread in threads
+        if not any(process.is_alive() for process in processes) and not any(
+            thread.is_alive() for thread in threads
         ):
             break
         time.sleep(
@@ -234,18 +226,13 @@ def cleanup_pipeline(
             )
         )
 
-    surviving_processes = [
-        process for process in processes if _is_alive(process, "process")
-    ]
+    surviving_processes = [process for process in processes if process.is_alive()]
     for process in surviving_processes:
-        try:
-            process.terminate()
-        except Exception:
-            logger.exception("Failed to terminate prediction process %s.", process.pid)
+        process.terminate()
 
     terminate_deadline = time.monotonic() + _PREDICT_PIPELINE_TERMINATE_TIMEOUT
     while time.monotonic() < terminate_deadline and any(
-        _is_alive(process, "process") for process in surviving_processes
+        process.is_alive() for process in surviving_processes
     ):
         time.sleep(
             min(
@@ -255,17 +242,14 @@ def cleanup_pipeline(
         )
 
     surviving_processes = [
-        process for process in surviving_processes if _is_alive(process, "process")
+        process for process in surviving_processes if process.is_alive()
     ]
     for process in surviving_processes:
-        try:
-            process.kill()
-        except Exception:
-            logger.exception("Failed to kill prediction process %s.", process.pid)
+        process.kill()
 
     kill_deadline = time.monotonic() + _PREDICT_PIPELINE_KILL_TIMEOUT
     while time.monotonic() < kill_deadline and any(
-        _is_alive(process, "process") for process in surviving_processes
+        process.is_alive() for process in surviving_processes
     ):
         time.sleep(
             min(
@@ -274,23 +258,17 @@ def cleanup_pipeline(
             )
         )
     for process in surviving_processes:
-        if _is_alive(process, "process"):
+        if process.is_alive():
             logger.warning("Prediction process %s survived kill().", process.pid)
 
     for process in processes:
-        try:
-            process.join(timeout=0)
-        except Exception:
-            logger.exception("Failed to reap prediction process %s.", process.pid)
+        process.join(timeout=0)
     for thread in threads:
-        try:
-            thread.join(timeout=0)
-            if _is_alive(thread, "thread"):
-                logger.warning(
-                    "Daemon prediction thread %s did not terminate.", thread.name
-                )
-        except Exception:
-            logger.exception("Failed to join prediction thread %s.", thread.name)
+        thread.join(timeout=0)
+        if thread.is_alive():
+            logger.warning(
+                "Daemon prediction thread %s did not terminate.", thread.name
+            )
     for data_queue in queues:
         try:
             cancel_join_thread = getattr(data_queue, "cancel_join_thread", None)
@@ -303,28 +281,52 @@ def cleanup_pipeline(
             logger.exception("Failed to close a prediction pipeline queue.")
 
 
-def validate_and_commit_writer(
+def commit_prediction_output(
     writer: Any,
-    pipeline_succeeded: bool,
+    pipeline_error: Optional[BaseException],
     expected_batches: int,
-    expected_rows: int,
     written_batches: int,
-    written_rows: int,
-    allow_empty: bool = False,
+    device: torch.device,
 ) -> None:
-    """Validate complete output before committing it with ``writer.close()``.
+    """Commit prediction output only when every rank produced complete output.
 
-    Withholding ``close()`` prevents a commit but does not necessarily remove
-    files already written by a local file writer.
+    Every rank must call this, including ranks whose pipeline failed, because
+    ``writer.close()`` participates in a collective for distributed writers.
+    A rank without input is normal for uneven sharding, but an input that is
+    empty on every rank is an error. Withholding ``close()`` prevents a commit
+    but does not necessarily remove files already written by a local file
+    writer.
+
+    Args:
+        writer (BaseWriter): output writer to commit.
+        pipeline_error (BaseException, optional): failure of the local pipeline.
+        expected_batches (int): batches submitted to the local pipeline.
+        written_batches (int): batches written by the local writer.
+        device (torch.device): device used to reduce the outcome across ranks.
     """
-    if not pipeline_succeeded:
-        raise RuntimeError("Prediction pipeline failed; output was not committed.")
-    if not allow_empty and (expected_batches == 0 or expected_rows == 0):
-        raise RuntimeError("Prediction input is empty; output was not committed.")
-    if expected_batches != written_batches or expected_rows != written_rows:
-        raise RuntimeError(
-            "Prediction output is incomplete; "
-            f"submitted={expected_batches} batches/{expected_rows} rows, "
-            f"written={written_batches} batches/{written_rows} rows."
+    succeeded = pipeline_error is None and expected_batches == written_batches
+    global_succeeded = succeeded
+    global_batches = expected_batches
+    if dist.is_initialized() and dist.get_world_size() > 1:
+        outcome = torch.tensor(
+            [int(succeeded), expected_batches], dtype=torch.int64, device=device
         )
+        dist.all_reduce(outcome, op=ReduceOp.SUM)
+        global_succeeded = int(outcome[0].item()) == dist.get_world_size()
+        global_batches = int(outcome[1].item())
+
+    if pipeline_error is not None:
+        raise pipeline_error
+    if expected_batches != written_batches:
+        raise RuntimeError(
+            f"Prediction output is incomplete; submitted={expected_batches} "
+            f"batches, written={written_batches} batches."
+        )
+    if not global_succeeded:
+        raise RuntimeError(
+            "Prediction pipeline failed or wrote incomplete output on another "
+            "rank; output was not committed."
+        )
+    if global_batches == 0:
+        raise RuntimeError("Prediction input is empty; output was not committed.")
     writer.close()

--- a/tzrec/utils/predict_util.py
+++ b/tzrec/utils/predict_util.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue as queue_lib
+import time
+import traceback
+from dataclasses import dataclass
+from multiprocessing import Process, Queue
+from threading import Thread
+from typing import Any, Callable, Optional, Sequence
+
+from tzrec.constant import PREDICT_QUEUE_TIMEOUT
+from tzrec.utils.logging_util import logger
+
+_PREDICT_PIPELINE_POLL_INTERVAL = 1.0
+_PREDICT_PIPELINE_CLEANUP_TIMEOUT = 10.0
+_PREDICT_PIPELINE_TERMINATE_TIMEOUT = 5.0
+_PREDICT_PIPELINE_KILL_TIMEOUT = 5.0
+
+
+@dataclass(frozen=True)
+class PredictPipelineFailure:
+    """Serializable failure raised by a background prediction stage."""
+
+    stage: str
+    worker_id: Optional[int]
+    exception_type: str
+    message: str
+    traceback: str
+
+
+class PredictPipelineCancelled(RuntimeError):
+    """Signal cooperative prediction-pipeline cancellation."""
+
+
+class PredictPipelineStageError(RuntimeError):
+    """Failure propagated from a background prediction stage."""
+
+    def __init__(self, failure: PredictPipelineFailure) -> None:
+        worker = "" if failure.worker_id is None else f"[{failure.worker_id}]"
+        self.failure = failure
+        super().__init__(
+            f"Prediction pipeline {failure.stage}{worker} failed with "
+            f"{failure.exception_type}: {failure.message}\n{failure.traceback}"
+        )
+
+
+def report_failure(
+    failure_queue: Queue,
+    cancel_event: Any,
+    stage: str,
+    worker_id: Optional[int],
+    error: BaseException,
+) -> None:
+    """Publish the active exception and cancel the prediction pipeline."""
+    failure = PredictPipelineFailure(
+        stage=stage,
+        worker_id=worker_id,
+        exception_type=type(error).__name__,
+        message=str(error),
+        traceback=traceback.format_exc(),
+    )
+    try:
+        failure_queue.put_nowait(failure)
+    except Exception:
+        logger.exception("Failed to report a prediction pipeline failure.")
+    finally:
+        cancel_event.set()
+
+
+def raise_background_failure(failure_queue: Queue, wait: bool = False) -> None:
+    """Raise the oldest reported prediction failure, if present."""
+    try:
+        failure = failure_queue.get(
+            timeout=_PREDICT_PIPELINE_POLL_INTERVAL if wait else 0
+        )
+    except queue_lib.Empty:
+        return
+    raise PredictPipelineStageError(failure)
+
+
+def check_pipeline_health(
+    processes: Sequence[Process], failure_queue: Queue, cancel_event: Any
+) -> None:
+    """Raise reported failures, cancellation, or failed child exits."""
+    raise_background_failure(failure_queue)
+    if cancel_event.is_set():
+        raise_background_failure(failure_queue, wait=True)
+        raise RuntimeError("Prediction pipeline was cancelled without an error.")
+
+    failed_processes = [
+        process
+        for process in processes
+        if process.exitcode is not None and process.exitcode != 0
+    ]
+    if failed_processes:
+        cancel_event.set()
+        raise_background_failure(failure_queue, wait=True)
+        details = ", ".join(
+            f"pid={process.pid}, exitcode={process.exitcode}"
+            for process in failed_processes
+        )
+        raise RuntimeError(f"Prediction pipeline child process failed: {details}.")
+
+
+def queue_get_interruptibly(
+    data_queue: Queue,
+    cancel_event: Any,
+    stage: str,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+    health_check: Optional[Callable[[], None]] = None,
+) -> Any:
+    """Get a queue item within one deadline while checking pipeline health."""
+    deadline = time.monotonic() + timeout
+    while not cancel_event.is_set():
+        if health_check is not None:
+            health_check()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Prediction pipeline {stage} stalled waiting for queue input "
+                f"for {timeout} seconds."
+            )
+        try:
+            return data_queue.get(
+                timeout=min(_PREDICT_PIPELINE_POLL_INTERVAL, remaining)
+            )
+        except queue_lib.Empty:
+            continue
+    raise PredictPipelineCancelled(f"Prediction pipeline {stage} was cancelled.")
+
+
+def queue_put_interruptibly(
+    data_queue: Queue,
+    item: Any,
+    cancel_event: Any,
+    stage: str,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+    health_check: Optional[Callable[[], None]] = None,
+) -> None:
+    """Put a queue item within one deadline while checking pipeline health."""
+    deadline = time.monotonic() + timeout
+    while not cancel_event.is_set():
+        if health_check is not None:
+            health_check()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Prediction pipeline {stage} stalled waiting for queue capacity "
+                f"for {timeout} seconds."
+            )
+        try:
+            data_queue.put(
+                item, timeout=min(_PREDICT_PIPELINE_POLL_INTERVAL, remaining)
+            )
+            return
+        except queue_lib.Full:
+            continue
+    raise PredictPipelineCancelled(f"Prediction pipeline {stage} was cancelled.")
+
+
+def wait_for_pipeline(
+    processes: Sequence[Process],
+    threads: Sequence[Thread],
+    failure_queue: Queue,
+    cancel_event: Any,
+    timeout: float = PREDICT_QUEUE_TIMEOUT,
+) -> None:
+    """Wait boundedly for normal completion while monitoring failures."""
+    deadline = time.monotonic() + timeout
+    while True:
+        check_pipeline_health(processes, failure_queue, cancel_event)
+        alive_processes = [process for process in processes if process.is_alive()]
+        alive_threads = [thread for thread in threads if thread.is_alive()]
+        if not alive_processes and not alive_threads:
+            break
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            process_ids = [process.pid for process in alive_processes]
+            thread_names = [thread.name for thread in alive_threads]
+            raise TimeoutError(
+                "Prediction pipeline stalled during completion; "
+                f"processes={process_ids}, threads={thread_names}."
+            )
+        time.sleep(min(_PREDICT_PIPELINE_POLL_INTERVAL, remaining))
+
+    for process in processes:
+        process.join(timeout=0)
+    for thread in threads:
+        thread.join(timeout=0)
+    check_pipeline_health(processes, failure_queue, cancel_event)
+    raise_background_failure(failure_queue, wait=bool(processes))
+
+
+def cleanup_pipeline(
+    processes: Sequence[Process],
+    threads: Sequence[Thread],
+    queues: Sequence[Any],
+    cancel_event: Any,
+) -> None:
+    """Cancel and reap prediction pipeline components within bounded deadlines."""
+
+    def _is_alive(component: Any, kind: str) -> bool:
+        """Return component liveness without allowing cleanup to raise."""
+        try:
+            return component.is_alive()
+        except Exception:
+            logger.exception("Failed to inspect prediction %s liveness.", kind)
+            return False
+
+    try:
+        cancel_event.set()
+    except Exception:
+        logger.exception("Failed to cancel the prediction pipeline.")
+    graceful_deadline = time.monotonic() + _PREDICT_PIPELINE_CLEANUP_TIMEOUT
+    while time.monotonic() < graceful_deadline:
+        if not any(_is_alive(process, "process") for process in processes) and not any(
+            _is_alive(thread, "thread") for thread in threads
+        ):
+            break
+        time.sleep(
+            min(
+                _PREDICT_PIPELINE_POLL_INTERVAL,
+                max(0, graceful_deadline - time.monotonic()),
+            )
+        )
+
+    surviving_processes = [
+        process for process in processes if _is_alive(process, "process")
+    ]
+    for process in surviving_processes:
+        try:
+            process.terminate()
+        except Exception:
+            logger.exception("Failed to terminate prediction process %s.", process.pid)
+
+    terminate_deadline = time.monotonic() + _PREDICT_PIPELINE_TERMINATE_TIMEOUT
+    while time.monotonic() < terminate_deadline and any(
+        _is_alive(process, "process") for process in surviving_processes
+    ):
+        time.sleep(
+            min(
+                _PREDICT_PIPELINE_POLL_INTERVAL,
+                max(0, terminate_deadline - time.monotonic()),
+            )
+        )
+
+    surviving_processes = [
+        process for process in surviving_processes if _is_alive(process, "process")
+    ]
+    for process in surviving_processes:
+        try:
+            process.kill()
+        except Exception:
+            logger.exception("Failed to kill prediction process %s.", process.pid)
+
+    kill_deadline = time.monotonic() + _PREDICT_PIPELINE_KILL_TIMEOUT
+    while time.monotonic() < kill_deadline and any(
+        _is_alive(process, "process") for process in surviving_processes
+    ):
+        time.sleep(
+            min(
+                _PREDICT_PIPELINE_POLL_INTERVAL,
+                max(0, kill_deadline - time.monotonic()),
+            )
+        )
+    for process in surviving_processes:
+        if _is_alive(process, "process"):
+            logger.warning("Prediction process %s survived kill().", process.pid)
+
+    for process in processes:
+        try:
+            process.join(timeout=0)
+        except Exception:
+            logger.exception("Failed to reap prediction process %s.", process.pid)
+    for thread in threads:
+        try:
+            thread.join(timeout=0)
+            if _is_alive(thread, "thread"):
+                logger.warning(
+                    "Daemon prediction thread %s did not terminate.", thread.name
+                )
+        except Exception:
+            logger.exception("Failed to join prediction thread %s.", thread.name)
+    for data_queue in queues:
+        try:
+            cancel_join_thread = getattr(data_queue, "cancel_join_thread", None)
+            if cancel_join_thread is not None:
+                cancel_join_thread()
+            close = getattr(data_queue, "close", None)
+            if close is not None:
+                close()
+        except Exception:
+            logger.exception("Failed to close a prediction pipeline queue.")
+
+
+def validate_and_commit_writer(
+    writer: Any,
+    pipeline_succeeded: bool,
+    expected_batches: int,
+    expected_rows: int,
+    written_batches: int,
+    written_rows: int,
+    allow_empty: bool = False,
+) -> None:
+    """Validate complete output before committing it with ``writer.close()``.
+
+    Withholding ``close()`` prevents a commit but does not necessarily remove
+    files already written by a local file writer.
+    """
+    if not pipeline_succeeded:
+        raise RuntimeError("Prediction pipeline failed; output was not committed.")
+    if not allow_empty and (expected_batches == 0 or expected_rows == 0):
+        raise RuntimeError("Prediction input is empty; output was not committed.")
+    if expected_batches != written_batches or expected_rows != written_rows:
+        raise RuntimeError(
+            "Prediction output is incomplete; "
+            f"submitted={expected_batches} batches/{expected_rows} rows, "
+            f"written={written_batches} batches/{written_rows} rows."
+        )
+    writer.close()

--- a/tzrec/utils/predict_util.py
+++ b/tzrec/utils/predict_util.py
@@ -80,15 +80,44 @@ def report_failure(
         cancel_event.set()
 
 
-def raise_background_failure(failure_queue: Any, wait: bool = False) -> None:
-    """Raise the oldest reported prediction failure, if present."""
+def _background_failure(
+    failure_queue: Any, wait: bool
+) -> Optional[PredictPipelineStageError]:
+    """Return the oldest reported prediction failure, if present."""
     try:
         failure = failure_queue.get(
             timeout=_PREDICT_PIPELINE_POLL_INTERVAL if wait else 0
         )
     except queue_lib.Empty:
-        return
-    raise PredictPipelineStageError(failure)
+        return None
+    return PredictPipelineStageError(failure)
+
+
+def raise_background_failure(failure_queue: Any, wait: bool = False) -> None:
+    """Raise the oldest reported prediction failure, if present."""
+    error = _background_failure(failure_queue, wait)
+    if error is not None:
+        raise error
+
+
+def resolve_pipeline_error(error: Exception, failure_queue: Any) -> Exception:
+    """Replace a cancellation with the background failure that caused it.
+
+    Cancellation reaches the main thread as ``PredictPipelineCancelled`` from
+    whichever queue wait noticed it, which says nothing about why the pipeline
+    stopped. Call this while the failure queue is still open, before
+    ``cleanup_pipeline`` closes it.
+
+    Args:
+        error (Exception): failure raised out of the pipeline body.
+        failure_queue (Queue): queue background stages report failures on.
+
+    Returns:
+        the reported background failure, or the original error.
+    """
+    if not isinstance(error, PredictPipelineCancelled):
+        return error
+    return _background_failure(failure_queue, wait=True) or error
 
 
 def check_pipeline_health(

--- a/tzrec/utils/predict_util.py
+++ b/tzrec/utils/predict_util.py
@@ -290,7 +290,7 @@ def cleanup_pipeline(
 def commit_prediction_output(
     writer: Any,
     pipeline_error: Optional[BaseException],
-    expected_batches: int,
+    input_batches: int,
     device: torch.device,
 ) -> None:
     """Commit prediction output only when every rank succeeded.
@@ -305,14 +305,14 @@ def commit_prediction_output(
     Args:
         writer (BaseWriter): output writer to commit.
         pipeline_error (BaseException, optional): failure of the local pipeline.
-        expected_batches (int): batches submitted to the local pipeline.
+        input_batches (int): input batches submitted to the local pipeline.
         device (torch.device): device used to reduce the outcome across ranks.
     """
     global_succeeded = pipeline_error is None
-    global_batches = expected_batches
+    global_batches = input_batches
     if dist.is_initialized() and dist.get_world_size() > 1:
         outcome = torch.tensor(
-            [int(pipeline_error is None), expected_batches],
+            [int(pipeline_error is None), input_batches],
             dtype=torch.int64,
             device=device,
         )

--- a/tzrec/utils/predict_util_test.py
+++ b/tzrec/utils/predict_util_test.py
@@ -142,6 +142,33 @@ class PredictUtilTest(unittest.TestCase):
         self.assertIn('raise ValueError(f"{stage} boom")', failure.traceback)
         self.assertIn(f"ValueError: {stage} boom", failure.traceback)
 
+    def test_cancellation_resolves_to_the_background_failure(self):
+        failure_queue = queue.Queue()
+        cancelled = predict_util.PredictPipelineCancelled("input producer cancelled")
+
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            # cancellation without a report stays as-is: it names the stalled stage.
+            self.assertIs(
+                predict_util.resolve_pipeline_error(cancelled, failure_queue), cancelled
+            )
+
+            try:
+                raise ValueError("forward boom")
+            except ValueError as error:
+                predict_util.report_failure(
+                    failure_queue, threading.Event(), "forward", 0, error
+                )
+            resolved = predict_util.resolve_pipeline_error(cancelled, failure_queue)
+            self.assertIsInstance(resolved, predict_util.PredictPipelineStageError)
+            self.assertEqual(resolved.failure.stage, "forward")
+            self.assertEqual(resolved.failure.message, "forward boom")
+
+            # a real pipeline error is never replaced.
+            timeout = TimeoutError("writer stalled")
+            self.assertIs(
+                predict_util.resolve_pipeline_error(timeout, failure_queue), timeout
+            )
+
     def test_failed_child_process_is_detected(self):
         process = _StubbornProcess([])
         process._alive = False

--- a/tzrec/utils/predict_util_test.py
+++ b/tzrec/utils/predict_util_test.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+import time
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from tzrec.utils import predict_util
+from tzrec.utils.test_util import parameterized_name_func
+
+
+class _RecordingEvent:
+    def __init__(self, events):
+        self._events = events
+        self._set = False
+
+    def set(self):
+        self._events.append("cancel")
+        self._set = True
+
+    def is_set(self):
+        return self._set
+
+
+class _StubbornProcess:
+    def __init__(self, events):
+        self.pid = 123
+        self.exitcode = None
+        self._events = events
+        self._alive = True
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self._events.append("terminate")
+
+    def kill(self):
+        self._events.append("kill")
+        self._alive = False
+        self.exitcode = -9
+
+    def join(self, timeout=None):
+        self._events.append(("join", timeout))
+
+
+class PredictUtilTest(unittest.TestCase):
+    def test_blocked_queue_operations_are_cancelled(self):
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            cancel_event = threading.Event()
+            timer = threading.Timer(0.02, cancel_event.set)
+            timer.start()
+            with self.assertRaises(predict_util.PredictPipelineCancelled):
+                predict_util.queue_get_interruptibly(
+                    queue.Queue(), cancel_event, "blocked get", timeout=1
+                )
+            timer.join(timeout=1)
+
+            full_queue = queue.Queue(maxsize=1)
+            full_queue.put("full")
+            cancel_event = threading.Event()
+            timer = threading.Timer(0.02, cancel_event.set)
+            timer.start()
+            with self.assertRaises(predict_util.PredictPipelineCancelled):
+                predict_util.queue_put_interruptibly(
+                    full_queue,
+                    "blocked",
+                    cancel_event,
+                    "blocked put",
+                    timeout=1,
+                )
+            timer.join(timeout=1)
+
+    def test_full_queue_uses_one_total_timeout(self):
+        full_queue = queue.Queue(maxsize=1)
+        full_queue.put("full")
+        started = time.monotonic()
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            with self.assertRaisesRegex(
+                TimeoutError, "output queue.*queue capacity.*0.03"
+            ):
+                predict_util.queue_put_interruptibly(
+                    full_queue,
+                    "blocked",
+                    threading.Event(),
+                    "output queue",
+                    timeout=0.03,
+                )
+        elapsed = time.monotonic() - started
+        self.assertGreaterEqual(elapsed, 0.025)
+        self.assertLess(elapsed, 0.2)
+
+    @parameterized.expand(
+        [["forward", 8], ["writer", None]],
+        name_func=parameterized_name_func,
+    )
+    def test_background_failure_preserves_context(self, stage, worker_id):
+        failure_queue = queue.Queue()
+        cancel_event = threading.Event()
+        try:
+            raise ValueError(f"{stage} boom")
+        except ValueError as error:
+            predict_util.report_failure(
+                failure_queue, cancel_event, stage, worker_id, error
+            )
+
+        self.assertTrue(cancel_event.is_set())
+        with self.assertRaises(predict_util.PredictPipelineStageError) as raised:
+            predict_util.check_pipeline_health([], failure_queue, cancel_event)
+        failure = raised.exception.failure
+        self.assertEqual(failure.stage, stage)
+        self.assertEqual(failure.worker_id, worker_id)
+        self.assertEqual(failure.exception_type, "ValueError")
+        self.assertEqual(failure.message, f"{stage} boom")
+        self.assertIn('raise ValueError(f"{stage} boom")', failure.traceback)
+        self.assertIn(f"ValueError: {stage} boom", failure.traceback)
+
+    @parameterized.expand([[1], [4]], name_func=parameterized_name_func)
+    def test_multi_worker_completion_drains_before_commit(self, worker_count):
+        input_queue = queue.Queue()
+        output_queue = queue.Queue(maxsize=2)
+        failure_queue = queue.Queue()
+        cancel_event = threading.Event()
+        submitted = list(range(6))
+        written = []
+
+        for value in submitted:
+            input_queue.put(value)
+        for _ in range(worker_count):
+            input_queue.put(None)
+
+        def forward(worker_id):
+            try:
+                while True:
+                    value = predict_util.queue_get_interruptibly(
+                        input_queue, cancel_event, f"forward[{worker_id}] input"
+                    )
+                    if value is None:
+                        return
+                    predict_util.queue_put_interruptibly(
+                        output_queue,
+                        value,
+                        cancel_event,
+                        f"forward[{worker_id}] output",
+                    )
+            except predict_util.PredictPipelineCancelled:
+                return
+            except BaseException as error:
+                predict_util.report_failure(
+                    failure_queue, cancel_event, "forward", worker_id, error
+                )
+
+        def write():
+            try:
+                while True:
+                    value = predict_util.queue_get_interruptibly(
+                        output_queue, cancel_event, "writer input"
+                    )
+                    if value is None:
+                        return
+                    written.append(value)
+            except predict_util.PredictPipelineCancelled:
+                return
+            except BaseException as error:
+                predict_util.report_failure(
+                    failure_queue, cancel_event, "writer", None, error
+                )
+
+        forward_threads = [
+            threading.Thread(
+                target=forward,
+                args=(worker_id,),
+                name=f"forward-{worker_id}",
+                daemon=True,
+            )
+            for worker_id in range(worker_count)
+        ]
+        writer_thread = threading.Thread(target=write, name="writer", daemon=True)
+        threads = [*forward_threads, writer_thread]
+        for thread in threads:
+            thread.start()
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            predict_util.wait_for_pipeline(
+                [], forward_threads, failure_queue, cancel_event, timeout=1
+            )
+            predict_util.queue_put_interruptibly(
+                output_queue,
+                None,
+                cancel_event,
+                "writer completion",
+                timeout=1,
+            )
+            predict_util.wait_for_pipeline(
+                [], [writer_thread], failure_queue, cancel_event, timeout=1
+            )
+
+        writer = mock.Mock()
+        predict_util.validate_and_commit_writer(
+            writer, True, len(submitted), len(submitted), len(written), len(written)
+        )
+        self.assertEqual(sorted(written), submitted)
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        writer.close.assert_called_once_with()
+
+    def test_invalid_output_never_commits(self):
+        invalid_cases = [
+            (False, 1, 1, 1, 1),
+            (True, 0, 0, 0, 0),
+            (True, 2, 2, 1, 2),
+            (True, 2, 2, 2, 1),
+        ]
+        for args in invalid_cases:
+            with self.subTest(args=args):
+                writer = mock.Mock()
+                with self.assertRaises(RuntimeError):
+                    predict_util.validate_and_commit_writer(writer, *args)
+                writer.close.assert_not_called()
+
+    def test_cleanup_cancels_terminates_kills_and_reaps(self):
+        events = []
+        cancel_event = _RecordingEvent(events)
+        process = _StubbornProcess(events)
+        thread = mock.Mock()
+        thread.name = "stuck-writer"
+        thread.is_alive.return_value = True
+        pipeline_queue = mock.Mock()
+        pipeline_queue.close.side_effect = RuntimeError("close boom")
+
+        with (
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_CLEANUP_TIMEOUT", 0),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_TERMINATE_TIMEOUT", 0),
+            mock.patch.object(predict_util, "_PREDICT_PIPELINE_KILL_TIMEOUT", 0),
+            mock.patch.object(predict_util.logger, "exception") as log_exception,
+        ):
+            predict_util.cleanup_pipeline(
+                [process], [thread], [pipeline_queue], cancel_event
+            )
+
+        self.assertEqual(events[:3], ["cancel", "terminate", "kill"])
+        self.assertIn(("join", 0), events)
+        thread.join.assert_called_once_with(timeout=0)
+        pipeline_queue.cancel_join_thread.assert_called_once_with()
+        pipeline_queue.close.assert_called_once_with()
+        log_exception.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/utils/predict_util_test.py
+++ b/tzrec/utils/predict_util_test.py
@@ -15,6 +15,7 @@ import time
 import unittest
 from unittest import mock
 
+import torch
 from parameterized import parameterized
 
 from tzrec.utils import predict_util
@@ -82,6 +83,20 @@ class PredictUtilTest(unittest.TestCase):
                     timeout=1,
                 )
             timer.join(timeout=1)
+
+    def test_empty_queue_uses_one_total_timeout(self):
+        started = time.monotonic()
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            with self.assertRaisesRegex(TimeoutError, "input queue.*queue input.*0.03"):
+                predict_util.queue_get_interruptibly(
+                    queue.Queue(),
+                    threading.Event(),
+                    "input queue",
+                    timeout=0.03,
+                )
+        elapsed = time.monotonic() - started
+        self.assertGreaterEqual(elapsed, 0.025)
+        self.assertLess(elapsed, 0.2)
 
     def test_full_queue_uses_one_total_timeout(self):
         full_queue = queue.Queue(maxsize=1)
@@ -207,25 +222,61 @@ class PredictUtilTest(unittest.TestCase):
             )
 
         writer = mock.Mock()
-        predict_util.validate_and_commit_writer(
-            writer, True, len(submitted), len(submitted), len(written), len(written)
+        predict_util.commit_prediction_output(
+            writer, None, len(submitted), len(written), torch.device("cpu")
         )
         self.assertEqual(sorted(written), submitted)
         self.assertTrue(all(not thread.is_alive() for thread in threads))
         writer.close.assert_called_once_with()
 
+    def test_local_failure_reraises_original_error(self):
+        writer = mock.Mock()
+        error = ValueError("forward boom")
+        with self.assertRaises(ValueError) as raised:
+            predict_util.commit_prediction_output(
+                writer, error, 2, 2, torch.device("cpu")
+            )
+        self.assertIs(raised.exception, error)
+        writer.close.assert_not_called()
+
     def test_invalid_output_never_commits(self):
-        invalid_cases = [
-            (False, 1, 1, 1, 1),
-            (True, 0, 0, 0, 0),
-            (True, 2, 2, 1, 2),
-            (True, 2, 2, 2, 1),
-        ]
-        for args in invalid_cases:
-            with self.subTest(args=args):
+        invalid_cases = [(2, 1), (0, 0)]
+        for expected_batches, written_batches in invalid_cases:
+            with self.subTest(expected_batches=expected_batches):
                 writer = mock.Mock()
                 with self.assertRaises(RuntimeError):
-                    predict_util.validate_and_commit_writer(writer, *args)
+                    predict_util.commit_prediction_output(
+                        writer,
+                        None,
+                        expected_batches,
+                        written_batches,
+                        torch.device("cpu"),
+                    )
+                writer.close.assert_not_called()
+
+    @parameterized.expand(
+        [[0, False], [1, True]],
+        name_func=parameterized_name_func,
+    )
+    def test_commit_follows_the_other_rank(self, peer_succeeded, expect_commit):
+        writer = mock.Mock()
+        with mock.patch.object(predict_util, "dist") as dist:
+            dist.is_initialized.return_value = True
+            dist.get_world_size.return_value = 2
+            dist.all_reduce.side_effect = lambda outcome, op: outcome.add_(
+                torch.tensor([peer_succeeded, 3], dtype=torch.int64)
+            )
+            if expect_commit:
+                # an empty local shard is normal when input files are uneven.
+                predict_util.commit_prediction_output(
+                    writer, None, 0, 0, torch.device("cpu")
+                )
+                writer.close.assert_called_once_with()
+            else:
+                with self.assertRaisesRegex(RuntimeError, "another rank"):
+                    predict_util.commit_prediction_output(
+                        writer, None, 0, 0, torch.device("cpu")
+                    )
                 writer.close.assert_not_called()
 
     def test_cleanup_cancels_terminates_kills_and_reaps(self):

--- a/tzrec/utils/predict_util_test.py
+++ b/tzrec/utils/predict_util_test.py
@@ -142,6 +142,18 @@ class PredictUtilTest(unittest.TestCase):
         self.assertIn('raise ValueError(f"{stage} boom")', failure.traceback)
         self.assertIn(f"ValueError: {stage} boom", failure.traceback)
 
+    def test_failed_child_process_is_detected(self):
+        process = _StubbornProcess([])
+        process._alive = False
+        process.exitcode = -9
+        cancel_event = threading.Event()
+        with mock.patch.object(predict_util, "_PREDICT_PIPELINE_POLL_INTERVAL", 0.01):
+            with self.assertRaisesRegex(RuntimeError, "exitcode=-9"):
+                predict_util.check_pipeline_health(
+                    [process], queue.Queue(), cancel_event
+                )
+        self.assertTrue(cancel_event.is_set())
+
     @parameterized.expand([[1], [4]], name_func=parameterized_name_func)
     def test_multi_worker_completion_drains_before_commit(self, worker_count):
         input_queue = queue.Queue()

--- a/tzrec/utils/predict_util_test.py
+++ b/tzrec/utils/predict_util_test.py
@@ -262,7 +262,7 @@ class PredictUtilTest(unittest.TestCase):
 
         writer = mock.Mock()
         predict_util.commit_prediction_output(
-            writer, None, len(submitted), len(written), torch.device("cpu")
+            writer, None, len(submitted), torch.device("cpu")
         )
         self.assertEqual(sorted(written), submitted)
         self.assertTrue(all(not thread.is_alive() for thread in threads))
@@ -272,26 +272,15 @@ class PredictUtilTest(unittest.TestCase):
         writer = mock.Mock()
         error = ValueError("forward boom")
         with self.assertRaises(ValueError) as raised:
-            predict_util.commit_prediction_output(
-                writer, error, 2, 2, torch.device("cpu")
-            )
+            predict_util.commit_prediction_output(writer, error, 2, torch.device("cpu"))
         self.assertIs(raised.exception, error)
         writer.close.assert_not_called()
 
-    def test_invalid_output_never_commits(self):
-        invalid_cases = [(2, 1), (0, 0)]
-        for expected_batches, written_batches in invalid_cases:
-            with self.subTest(expected_batches=expected_batches):
-                writer = mock.Mock()
-                with self.assertRaises(RuntimeError):
-                    predict_util.commit_prediction_output(
-                        writer,
-                        None,
-                        expected_batches,
-                        written_batches,
-                        torch.device("cpu"),
-                    )
-                writer.close.assert_not_called()
+    def test_empty_input_never_commits(self):
+        writer = mock.Mock()
+        with self.assertRaisesRegex(RuntimeError, "empty"):
+            predict_util.commit_prediction_output(writer, None, 0, torch.device("cpu"))
+        writer.close.assert_not_called()
 
     @parameterized.expand(
         [[0, False], [1, True]],
@@ -308,13 +297,13 @@ class PredictUtilTest(unittest.TestCase):
             if expect_commit:
                 # an empty local shard is normal when input files are uneven.
                 predict_util.commit_prediction_output(
-                    writer, None, 0, 0, torch.device("cpu")
+                    writer, None, 0, torch.device("cpu")
                 )
                 writer.close.assert_called_once_with()
             else:
                 with self.assertRaisesRegex(RuntimeError, "another rank"):
                     predict_util.commit_prediction_output(
-                        writer, None, 0, 0, torch.device("cpu")
+                        writer, None, 0, torch.device("cpu")
                     )
                 writer.close.assert_not_called()
 

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"


### PR DESCRIPTION
## Summary

- Fix TDM completion routing so intermediate layers fan out one sentinel per downstream worker while the final single writer receives exactly one sentinel.
- Share the model-agnostic prediction lifecycle across TDM retrieval, scripted-model prediction, and checkpoint prediction.
- Propagate worker, forward, and writer failures with their original exception type, message, stage identity, and traceback.
- Make queue waits interruptible, guarantee bounded cleanup, and commit the writer collectively so every rank commits or aborts together.
- Keep TDM producer processes alive until their forward coordinator has deserialized every queued batch from that layer.

## Root Cause

TDM's final forward stage emitted `num_worker_per_level` sentinels into a bounded queue consumed by one writer. The writer exited after its first sentinel, allowing the remaining sentinels to fill the queue and strand upstream work.

The original prediction lifecycle also used blocking queue operations, did not reliably surface background exceptions, could wait indefinitely during shutdown, and closed the writer from `finally`, which could commit partial output after failure.

After those failures became visible, CI exposed a separate producer-lifetime race: TDM workers could enqueue `Batch` objects backed by Torch shared storage and exit before the forward thread finished unpickling them. The multiprocessing resource-sharer endpoint then disappeared, raising `FileNotFoundError` or `ConnectionResetError`. Each producer layer now waits for its forward coordinator to consume all producer sentinels, which proves every earlier queue payload has been deserialized; cancellation remains the abnormal escape path.

## Implementation

The shared lifecycle in `tzrec/utils/predict_util.py` provides:

- a serializable failure record and the main-thread stage error it raises as;
- traceback-preserving failure reporting and cooperative cancellation;
- interruptible queue get/put operations;
- bounded completion waiting and cleanup;
- a collective commit, reached on both the success and failure paths.

Model loading, feature parsing, TDM sampling and traversal, per-layer top-k, recall calculation, AOT/TensorRT behavior, output formatting, and checkpoint-specific forwarding remain in their existing owners.

Normal scripted prediction uses one input sentinel per forward worker, waits for every forward worker to finish, and then sends one sentinel to the writer. TDM coordinates one drain event per producer layer so shared-storage handles remain valid through deserialization. Existing synchronous first-forward and first-write behavior is preserved.

### Collective commit

`commit_prediction_output` takes the local pipeline failure rather than a success flag. `OdpsWriter.close()` joins a `dist.gather_object` collective, so the commit decision cannot be rank-local: a rank that skipped `close()` would leave its peers blocked there until the process-group timeout. Every rank therefore reaches the same call on both the success and failure paths, all-reduces its outcome and input batch count, and only then raises its own original exception or commits.

Passing the error into the helper is what makes that participation unskippable. A separate reduce helper called by each site before an early `raise` was the alternative, and it reintroduces exactly the divergence it is meant to remove.

Two consequences of the reduction:

- A rank with no input is normal under uneven sharding and no longer fails the job; only an input that is empty on every rank is an error.
- `KeyboardInterrupt` and `SystemExit` deliberately bypass the rendezvous, since a peer may never join it.

### What the lifecycle deliberately does not do

Output accounting is limited to what is observable. Row counting in `predict()` and `predict_checkpoint()` compared a count against itself — both sides called the same pure `_prediction_row_count` on the same objects — and cost up to three `RecordBatchTensor.get()` calls per batch, each a full `pa.ipc.read_record_batch`, where master decoded once. Submitted-versus-written batch counts were unreachable in the same way: a batch can only go missing if a stage drops it without raising, and the only silent return in any stage loop is on cancellation, which always follows a reported failure. Only the input batch count survives, because the empty-input check needs it. TDM keeps its row counters, since both sides already decode the reserved batch for their own work and `total` is the recall denominator.

The child-process health hook is passed only where it can observe something. `check_pipeline_health` adds signal solely through its exitcode branch, which catches a worker killed without reporting; scripted and checkpoint prediction run their stages as threads, and a thread that dies always sets the cancel event first, so the interruptible queue wait already surfaces the identical exception. Measured: thread failure raises the same `PredictPipelineStageError` in 0.05 s with or without the hook, while a `SIGKILL`ed child is reported in 0.01 s with it and stalls to the queue timeout without it.

Cancellation is resolved rather than re-raised. It reaches the main thread as `PredictPipelineCancelled` from whichever queue wait noticed the flag, which names the stalled stage but not the failure behind it, so `resolve_pipeline_error` swaps in the reported failure while the failure queue is still open. Keeping the cancellation when nothing was reported is intentional: the alternative fallback error could only fire if `report_failure` failed to enqueue, and it carried less information than the cancellation it replaced.

Nothing in the `finally` blocks may raise, including `prof.stop()`, or the rank would skip the commit rendezvous and hang its peers.

## Impact

Prediction pipelines now fail promptly with the original background context, drain valid output before normal shutdown, clean up within bounded deadlines, and leave failed ODPS write sessions uncommitted on every rank. TDM retrieval supports clean shutdown with one or multiple workers per level without losing multiprocessing shared-storage handles.

Behavior changes worth calling out:

- `wait_for_pipeline` raises `TimeoutError` where the old code joined per thread and only warned. A healthy-but-slow drain that previously completed with a warning can now fail the run; the old warning path could also commit partial output.
- An input that is empty on every rank now raises instead of finishing silently. A single rank with no input is unaffected.

## Test Plan

- `PYTHONPATH=. python -m unittest tzrec.utils.predict_util_test tzrec.tools.tdm.retrieval_test tzrec.main_test` — 32 tests.
- `PYTHONPATH=. python -m unittest tzrec.tests.match_integration_test.MatchIntegrationTest.test_tdm_train_eval_export` — 2-rank `torchrun`, ~171 s.
- `pre-commit run --files tzrec/main.py tzrec/main_test.py tzrec/tools/tdm/retrieval.py tzrec/tools/tdm/retrieval_test.py tzrec/utils/predict_util.py tzrec/utils/predict_util_test.py`
- The `tdm_retrieval()` test drives the real multi-level queue chain with stubbed sampler, parser, dataloader, model, and writer, covering the synchronous first write and the empty-input drain. Reintroducing the sentinel-fanout bug makes it fail with `stalled during completion; threads=['tdm-forward-3']`. It uses `num_worker_per_level=4` on purpose: with two workers the `maxsize=2` queue absorbs the stray sentinel and the regression stays hidden.
- Two-rank `torchrun` checks of the commit rendezvous: with one rank failing, both ranks exit in ~0.2 s, each with its own error and neither committing; with one rank receiving an empty shard, both ranks commit.
- `cleanup_pipeline` timed against a live uncooperative child: 10 s graceful wait, then `SIGTERM`, reaped with `exitcode=-15`.
- `python scripts/pyre_check.py` reports no errors in the changed regions. Note that `.pyre_configuration` has contained a trailing comma since #311, so the script currently no-ops on an invalid-JSON error; the check above was run with that fixed locally and not committed.

## Limitations

- The available ODPS API has no explicit abort operation; failed sessions remain uncommitted and expire service-side.
- Withholding `close()` does not necessarily remove files already emitted by a local file writer.
- Python cannot forcibly stop a daemon thread blocked in native code; child processes are forcibly terminated and reaped after bounded waits.
- If `writer.close()` itself fails on rank 0 only, peers proceed into the recall all-reduce and block until the process-group timeout. This exposure predates the PR and is unchanged.
