### PR TITLE
[bugfix] stream npz export to DFS without local temp file

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -16,7 +16,6 @@ import operator
 import os
 import re
 import shutil
-import tempfile
 from collections import OrderedDict, defaultdict
 from queue import Queue
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
@@ -68,7 +67,7 @@ from tzrec.features.feature import (
 from tzrec.modules.utils import BaseModule
 from tzrec.protos import model_pb2
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
-from tzrec.utils import checkpoint_util, config_util, env_util, quant_util
+from tzrec.utils import checkpoint_util, config_util, env_util, npz_util, quant_util
 from tzrec.utils.dist_util import DistributedModelParallel, init_process_group
 from tzrec.utils.filesystem_util import url_to_fs
 from tzrec.utils.fx_util import (
@@ -1555,17 +1554,10 @@ def export_distributed_embedding(
     )
     local_tensor_name = f"sparse_embeddings-{rank:02d}-of-{world_size:02d}"
     save_dir_sparse = f"{save_dir}/sparse"
-    if not os.path.exists(save_dir_sparse):
-        os.makedirs(save_dir_sparse)
+    os.makedirs(save_dir_sparse, exist_ok=True)
     local_tensor_path = os.path.join(save_dir_sparse, f"{local_tensor_name}.npz")
     logger.info(f"save sparse tensors to {local_tensor_path}")
-
-    # OSS mounted file system may have problem in file seek, so first
-    # save to a temp file then move to target path
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f:
-        temp_path = f.name
-        np.savez(f, **local_tensor)
-    shutil.move(temp_path, local_tensor_path)
+    npz_util.savez_streaming(local_tensor_path, local_tensor)
 
     if dynamic_local_tensor:
         dynamic_tensor_name = f"sparse_dynamic_embedding-{rank:02d}-of-{world_size:02d}"
@@ -1573,10 +1565,7 @@ def export_distributed_embedding(
             save_dir_sparse, f"{dynamic_tensor_name}.npz"
         )
         logger.info(f"save dynamic sparse tensors to {dynamic_tensor_path}")
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f:
-            np.savez(f, **dynamic_local_tensor)
-            temp_path = f.name
-        shutil.move(temp_path, dynamic_tensor_path)
+        npz_util.savez_streaming(dynamic_tensor_path, dynamic_local_tensor)
 
     with open(os.path.join(save_dir_sparse, f"{local_tensor_name}.json"), "w") as f:
         json.dump(emb_meta, f, indent=4)

--- a/tzrec/utils/npz_util.py
+++ b/tzrec/utils/npz_util.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Streaming npz writer for seek-broken distributed filesystems.
+
+``np.savez`` writes a zip and then seeks back to patch each entry's local file
+header with its crc32/sizes. On an OSS-mounted filesystem that seek breaks, so
+export today stages a local temp file and moves it into place -- which can
+overflow local disk for large dynamic embedding shards.
+
+This module writes an npz directly to the target path with no seek on the
+output file and no local temp file, by forcing CPython ``zipfile`` into
+streaming mode: each entry carries a bit-3 data descriptor (crc/sizes after the
+payload) and the central directory is appended at the end. The output is
+readable by ``np.load`` and by libzip (the TorchRecProcessor npz reader), which
+locate entries through the central directory and ignore the local header
+crc/sizes.
+"""
+
+import errno
+import os
+import zipfile
+from typing import Any, Mapping
+
+import numpy as np
+
+
+class _Unseekable:
+    """Writable binary stream wrapper that forces zipfile into streaming mode.
+
+    CPython ``ZipFile`` probes seekability on open in ``"w"`` mode by calling
+    ``tell()`` then ``seek()``; raising ``ESPIPE`` from ``seek`` flips it into
+    unseekable mode, after which it emits bit-3 data descriptors instead of
+    seeking back to rewrite local headers.
+
+    Attributes:
+        _fp: The underlying writable binary file object.
+        _n: Running count of bytes written, returned from ``tell`` so the
+            counter stays correct whether or not zipfile wraps this object in
+            its own ``_Tellable`` adapter.
+    """
+
+    def __init__(self, fp: Any) -> None:
+        self._fp = fp
+        self._n = 0
+
+    def write(self, data: bytes) -> int:
+        """Write *data* through to the underlying stream and count bytes."""
+        n = self._fp.write(data)
+        self._n += len(data) if n is None else n
+        return n
+
+    def flush(self) -> None:
+        """Flush the underlying stream."""
+        self._fp.flush()
+
+    def seekable(self) -> bool:
+        """Report the stream as unseekable so zipfile uses data descriptors."""
+        return False
+
+    def seek(self, *args: Any, **kwargs: Any) -> int:
+        """Reject seeks; zipfile catches this and switches to streaming mode."""
+        raise OSError(errno.ESPIPE, "unseekable output stream")
+
+    def tell(self) -> int:
+        """Return the running write offset without touching the stream."""
+        return self._n
+
+    def close(self) -> None:
+        """Close the underlying stream."""
+        self._fp.close()
+
+
+def savez_streaming(path: str, arrays: Mapping[str, Any]) -> None:
+    """Write *arrays* (name -> array-like) to *path* as an npz, fully streaming.
+
+    Entry naming and ``.npy`` payload match ``np.savez`` (entry ``"<name>.npy"``,
+    ``ZIP_STORED``, C-order little-endian), so the output is interchangeable with
+    ``np.savez`` for readers that go through the central directory (``np.load``,
+    libzip). Unlike ``np.savez`` it never seeks the output file and uses no
+    local temp file, making it safe on OSS-mounted filesystems and immune to
+    local-disk overflow on large shards.
+
+    A ``<path>.part`` file is streamed first and renamed into place on success,
+    so a crashed export leaves a ``.part`` file that the serving shard-discovery
+    regex (anchored on ``.npz$``) never matches.
+
+    Args:
+        path: Destination ``.npz`` path on the (possibly seek-broken) DFS mount.
+        arrays: Mapping of entry name to array-like value (numpy or torch
+            tensor); names must not carry a ``.npy`` suffix, it is appended.
+    """
+    part = f"{path}.part"
+    with open(part, "wb") as raw:
+        fp = _Unseekable(raw)
+        with zipfile.ZipFile(fp, "w", allowZip64=True) as zf:
+            for name, arr in arrays.items():
+                # force_zip64 keeps entries > ZIP64_LIMIT from raising and
+                # matches np.savez, which forces zip64 on every entry.
+                with zf.open(f"{name}.npy", "w", force_zip64=True) as ent:
+                    np.save(ent, arr)
+    os.rename(part, path)

--- a/tzrec/utils/npz_util.py
+++ b/tzrec/utils/npz_util.py
@@ -25,8 +25,10 @@ locate entries through the central directory and ignore the local header
 crc/sizes.
 """
 
+import contextlib
 import errno
 import os
+import uuid
 import zipfile
 from typing import Any, Mapping
 
@@ -82,29 +84,44 @@ class _Unseekable:
 def savez_streaming(path: str, arrays: Mapping[str, Any]) -> None:
     """Write *arrays* (name -> array-like) to *path* as an npz, fully streaming.
 
-    Entry naming and ``.npy`` payload match ``np.savez`` (entry ``"<name>.npy"``,
-    ``ZIP_STORED``, C-order little-endian), so the output is interchangeable with
-    ``np.savez`` for readers that go through the central directory (``np.load``,
-    libzip). Unlike ``np.savez`` it never seeks the output file and uses no
-    local temp file, making it safe on OSS-mounted filesystems and immune to
-    local-disk overflow on large shards.
+    Entry naming and payload match ``np.savez``: each value is written as entry
+    ``"<name>.npy"``, ``ZIP_STORED``, with NumPy's standard ``.npy``
+    serialization, so the output is interchangeable with ``np.savez`` for
+    readers that go through the central directory (``np.load``, libzip).
+    Unlike ``np.savez`` it never seeks the output file and uses no local temp
+    file, making it safe on OSS-mounted filesystems and immune to local-disk
+    overflow on large shards.
 
-    A ``<path>.part`` file is streamed first and renamed into place on success,
-    so a crashed export leaves a ``.part`` file that the serving shard-discovery
-    regex (anchored on ``.npz$``) never matches.
+    A unique ``<path>.part.<uuid>`` sibling is streamed first and renamed into
+    place only after it is complete and closed, so neither an in-flight nor a
+    crashed export is visible to the serving shard-discovery regex (anchored
+    on ``.npz$``); the staging file is unlinked if writing or renaming fails.
+    The publish assumes rename is atomic and cheap (a hierarchical-namespace
+    OSS bucket or a POSIX DFS); on a non-HNS OSS mount rename degrades to a
+    server-side copy-and-delete, which is slower and briefly doubles the
+    shard's DFS usage but still never stages the payload on local disk.
 
     Args:
         path: Destination ``.npz`` path on the (possibly seek-broken) DFS mount.
         arrays: Mapping of entry name to array-like value (numpy or torch
             tensor); names must not carry a ``.npy`` suffix, it is appended.
     """
-    part = f"{path}.part"
-    with open(part, "wb") as raw:
-        fp = _Unseekable(raw)
-        with zipfile.ZipFile(fp, "w", allowZip64=True) as zf:
-            for name, arr in arrays.items():
-                # force_zip64 keeps entries > ZIP64_LIMIT from raising and
-                # matches np.savez, which forces zip64 on every entry.
-                with zf.open(f"{name}.npy", "w", force_zip64=True) as ent:
-                    np.save(ent, arr)
-    os.rename(part, path)
+    part = f"{path}.part.{uuid.uuid4().hex}"
+    # "xb" creates the staging file exclusively, never over an existing path
+    # or symlink, so it is always owned by this writer; only after it exists
+    # may failure cleanup unlink it.
+    raw = open(part, "xb")
+    try:
+        with raw:
+            fp = _Unseekable(raw)
+            with zipfile.ZipFile(fp, "w", allowZip64=True) as zf:
+                for name, arr in arrays.items():
+                    # force_zip64 keeps entries > ZIP64_LIMIT from raising and
+                    # matches np.savez, which forces zip64 on every entry.
+                    with zf.open(f"{name}.npy", "w", force_zip64=True) as ent:
+                        np.save(ent, arr)
+        os.replace(part, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(part)
+        raise

--- a/tzrec/utils/npz_util_test.py
+++ b/tzrec/utils/npz_util_test.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import struct
+import unittest
+import zipfile
+from unittest import mock
+
+import numpy as np
+from parameterized import parameterized
+
+from tzrec.utils import npz_util
+from tzrec.utils.test_util import make_test_dir, parameterized_name_func
+
+
+class NpzUtilTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = make_test_dir()
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _path(self, name: str = "out.npz") -> str:
+        return os.path.join(self.test_dir, name)
+
+    @parameterized.expand(
+        [
+            ("float32_2d", np.float32, (3, 4)),
+            ("int64_1d", np.int64, (5,)),
+            ("uint8_2d", np.uint8, (2, 4)),
+            ("float64_1d", np.float64, (7,)),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_savez_streaming_roundtrip(self, _name, dtype, shape):
+        arrays = {
+            "model.ebc.user_id_emb": np.arange(np.prod(shape), dtype=dtype).reshape(
+                shape
+            ),
+            "user_id_emb.keys": np.arange(shape[0], dtype=np.int64),
+            "user_id_emb.scores": np.arange(shape[0], dtype=np.int64),
+        }
+        path = self._path()
+        npz_util.savez_streaming(path, arrays)
+
+        loaded = np.load(path)
+        for k, arr in arrays.items():
+            got = loaded[f"{k}.npy"]
+            self.assertEqual(got.dtype, arr.dtype)
+            self.assertEqual(got.shape, arr.shape)
+            np.testing.assert_array_equal(got, arr)
+
+    def test_interchangeable_with_np_savez(self):
+        arrays = {
+            "a": np.arange(12, dtype=np.float32).reshape(3, 4),
+            "b": np.array([1, 2, 3], dtype=np.int64),
+        }
+        stream_path = self._path("stream.npz")
+        savez_path = self._path("savez.npz")
+        npz_util.savez_streaming(stream_path, arrays)
+        np.savez(savez_path, **arrays)
+
+        stream_loaded = {k: v for k, v in np.load(stream_path).items()}
+        savez_loaded = {k: v for k, v in np.load(savez_path).items()}
+        self.assertEqual(set(stream_loaded), set(savez_loaded))
+        for k in stream_loaded:
+            np.testing.assert_array_equal(stream_loaded[k], savez_loaded[k])
+
+    def test_uses_streaming_data_descriptor_and_zip64(self):
+        # gp_flag bit 3 (data descriptor) => zipfile did not seek back to patch
+        # the local header; version_needed 45 => zip64, required for large shards.
+        path = self._path()
+        npz_util.savez_streaming(path, {"a": np.zeros(4, dtype=np.float32)})
+        with open(path, "rb") as f:
+            self.assertEqual(f.read(4), b"PK\x03\x04")
+            version_needed = struct.unpack("<H", f.read(2))[0]
+            gp_flag = struct.unpack("<H", f.read(2))[0]
+        self.assertTrue(gp_flag & 0x08, f"bit-3 not set: gp_flag=0x{gp_flag:04x}")
+        self.assertEqual(version_needed, 45)
+
+    def test_large_entry_zip64_path(self):
+        # Lower the zip64 threshold so a small array exercises the >2GiB
+        # central-directory/EOCD64 machinery without allocating gigabytes.
+        arr = np.arange(1000, dtype=np.uint8)
+        path = self._path()
+        with mock.patch("zipfile.ZIP64_LIMIT", 64):
+            npz_util.savez_streaming(path, {"big": arr})
+        np.testing.assert_array_equal(np.load(path)["big.npy"], arr)
+        with zipfile.ZipFile(path) as zf:
+            self.assertIsNone(zf.testzip())
+
+    def test_part_file_not_left_on_success(self):
+        path = self._path()
+        npz_util.savez_streaming(path, {"a": np.zeros(2, dtype=np.float32)})
+        self.assertTrue(os.path.exists(path))
+        self.assertFalse(os.path.exists(f"{path}.part"))
+
+    def test_overwrite_existing(self):
+        path = self._path()
+        npz_util.savez_streaming(path, {"a": np.zeros(2, dtype=np.float32)})
+        new_arr = np.array([5.0, 6.0], dtype=np.float32)
+        npz_util.savez_streaming(path, {"a": new_arr})
+        np.testing.assert_array_equal(np.load(path)["a.npy"], new_arr)
+
+    def test_empty_mapping(self):
+        path = self._path()
+        npz_util.savez_streaming(path, {})
+        with zipfile.ZipFile(path) as zf:
+            self.assertEqual(zf.namelist(), [])
+            self.assertIsNone(zf.testzip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/utils/npz_util_test.py
+++ b/tzrec/utils/npz_util_test.py
@@ -9,11 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
+import io
 import os
 import shutil
 import struct
+import subprocess
 import unittest
 import zipfile
+import zlib
 from unittest import mock
 
 import numpy as np
@@ -21,6 +25,8 @@ from parameterized import parameterized
 
 from tzrec.utils import npz_util
 from tzrec.utils.test_util import make_test_dir, parameterized_name_func
+
+_UNZIP = shutil.which("unzip")
 
 
 class NpzUtilTest(unittest.TestCase):
@@ -104,7 +110,119 @@ class NpzUtilTest(unittest.TestCase):
         path = self._path()
         npz_util.savez_streaming(path, {"a": np.zeros(2, dtype=np.float32)})
         self.assertTrue(os.path.exists(path))
-        self.assertFalse(os.path.exists(f"{path}.part"))
+        self.assertEqual(glob.glob(f"{path}.part.*"), [])
+
+    def test_part_file_removed_on_serialize_failure(self):
+        path = self._path()
+
+        class _Unserializable:
+            def __array__(self, dtype=None, copy=None):
+                raise ValueError("cannot serialize")
+
+        with self.assertRaises(ValueError):
+            npz_util.savez_streaming(path, {"a": _Unserializable()})
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(glob.glob(f"{path}.part.*"), [])
+
+    def test_part_file_removed_on_rename_failure(self):
+        path = self._path()
+        with mock.patch("os.replace", side_effect=OSError("simulated rename failure")):
+            with self.assertRaises(OSError):
+                npz_util.savez_streaming(path, {"a": np.zeros(2, dtype=np.float32)})
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(glob.glob(f"{path}.part.*"), [])
+
+    def _central_directory_read(self, path):
+        """Read every entry locating it through the central directory only.
+
+        Mirrors how libzip / the TorchRecProcessor npz reader consumes the
+        archive: the central directory is the sole source of truth, and the
+        local headers (zeroed crc/sizes for bit-3 streaming entries) are never
+        trusted for entry location or integrity. Returns {name: payload}.
+        """
+        with open(path, "rb") as f:
+            blob = f.read()
+        eocd = blob.rfind(b"PK\x05\x06")
+        self.assertGreaterEqual(eocd, 0)
+        count, cd_size, cd_off = struct.unpack_from("<HII", blob, eocd + 10)
+        if count == 0xFFFF or cd_size == 0xFFFFFFFF or cd_off == 0xFFFFFFFF:
+            loc = eocd - 20
+            self.assertEqual(blob[loc : loc + 4], b"PK\x06\x07")
+            eocd64 = struct.unpack_from("<Q", blob, loc + 8)[0]
+            self.assertEqual(blob[eocd64 : eocd64 + 4], b"PK\x06\x06")
+            count = struct.unpack_from("<Q", blob, eocd64 + 32)[0]
+            cd_size, cd_off = struct.unpack_from("<QQ", blob, eocd64 + 40)
+        entries = {}
+        pos = cd_off
+        for _ in range(count):
+            self.assertEqual(blob[pos : pos + 4], b"PK\x01\x02")
+            crc, csize, usize = struct.unpack_from("<III", blob, pos + 16)
+            nlen, elen, comment_len = struct.unpack_from("<HHH", blob, pos + 28)
+            lho = struct.unpack_from("<I", blob, pos + 42)[0]
+            name = blob[pos + 46 : pos + 46 + nlen].decode()
+            extra = blob[pos + 46 + nlen : pos + 46 + nlen + elen]
+            e = 0
+            while e + 4 <= len(extra):
+                tag, sz = struct.unpack_from("<HH", extra, e)
+                if tag == 0x0001:
+                    # only fields set to 0xFFFFFFFF appear, in fixed order
+                    vals = iter(struct.unpack_from(f"<{sz // 8}Q", extra, e + 4))
+                    if usize == 0xFFFFFFFF:
+                        usize = next(vals)
+                    if csize == 0xFFFFFFFF:
+                        csize = next(vals)
+                    if lho == 0xFFFFFFFF:
+                        lho = next(vals)
+                    break
+                e += 4 + sz
+            self.assertEqual(blob[lho : lho + 4], b"PK\x03\x04")
+            lnlen, lelen = struct.unpack_from("<HH", blob, lho + 26)
+            data = blob[lho + 30 + lnlen + lelen : lho + 30 + lnlen + lelen + csize]
+            self.assertEqual(zlib.crc32(data), crc, name)
+            self.assertEqual(len(data), usize, name)
+            entries[name] = data
+            pos += 46 + nlen + elen + comment_len
+        self.assertEqual(pos, cd_off + cd_size)
+        return entries
+
+    def test_readable_via_central_directory(self):
+        # np.load / libzip locate entries through the central directory and
+        # ignore the (zeroed, bit-3 deferred) local-header crc/sizes; verify
+        # the payload reached that way is intact and matches the input.
+        arrays = {"a": np.arange(12, dtype=np.float32).reshape(3, 4)}
+        path = self._path()
+        npz_util.savez_streaming(path, arrays)
+        entries = self._central_directory_read(path)
+        self.assertEqual(set(entries), {"a.npy"})
+        np.testing.assert_array_equal(
+            np.load(io.BytesIO(entries["a.npy"])), arrays["a"]
+        )
+
+    def test_readable_via_central_directory_zip64(self):
+        arr = np.arange(1000, dtype=np.uint8)
+        path = self._path()
+        with mock.patch("zipfile.ZIP64_LIMIT", 64):
+            npz_util.savez_streaming(path, {"big": arr})
+        entries = self._central_directory_read(path)
+        np.testing.assert_array_equal(np.load(io.BytesIO(entries["big.npy"])), arr)
+
+    @unittest.skipIf(_UNZIP is None, "unzip not installed")
+    def test_external_zip_reader_accepts_streaming_output(self):
+        # Serving reads the npz with libzip, not CPython zipfile. An
+        # independent zip reader validates the same properties libzip relies
+        # on -- that entries carrying bit-3 data descriptors and ZIP64
+        # extension fields are located via the central directory and pass a
+        # full crc32 check.
+        path = self._path()
+        arrays = {
+            "small": np.zeros(2, dtype=np.float32),
+            "big": np.arange(1000, dtype=np.uint8),
+        }
+        with mock.patch("zipfile.ZIP64_LIMIT", 64):
+            npz_util.savez_streaming(path, arrays)
+        result = subprocess.run([_UNZIP, "-t", path], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("No errors detected", result.stdout)
 
     def test_overwrite_existing(self):
         path = self._path()


### PR DESCRIPTION
Distributed embedding export wrote each npz shard with np.savez into a local NamedTemporaryFile then shutil.move'd it onto the OSS-mounted DFS path, because np.savez seeks back to patch every entry's local file header and that seek breaks on OSS. Staging the whole shard on local /tmp overflows local disk for large dynamic embedding tables, which can reach tens of GB per rank.

Add npz_util.savez_streaming, which wraps the destination file in an unseekable adapter so CPython zipfile streams entries with bit-3 data descriptors (crc/sizes after the payload) and appends the central directory at the end -- no seek on the output, no local temp file. The output is readable by np.load and by libzip (the TorchRecProcessor reader), both of which locate entries through the central directory. force_zip64 keeps entries beyond ZIP64_LIMIT from raising, and a .part -> rename publish leaves a crashed partial file invisible to the serving shard-discovery regex.