### PR TITLE
[feat] SID: publish a versioned bundle and append new items onto it

### DIFF
--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -115,11 +115,10 @@ from tzrec.utils.sid.bundle import (
     GROUPS_ARTIFACT,
     MAP_ARTIFACT,
     MAP_ARTIFACTS,
-    ArtifactEntry,
     BundleLayout,
     BundleManifest,
     is_odps_path,
-    resolve_layout,
+    read_manifest,
 )
 from tzrec.utils.sid.collision import (
     CodebookItemGrouping,
@@ -144,6 +143,7 @@ from tzrec.utils.sid.collision import (
 _MAP_WRITE_ROWS = 1_000_000
 _GROUP_WRITE_ITEMS = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
+_NO_ROWS = np.empty(0, dtype=np.int64)
 
 
 def _is_list_column(values: pa.Array) -> bool:
@@ -301,12 +301,12 @@ class ResolveSidCollisionsConfig:
     @cached_property
     def layout(self) -> BundleLayout:
         """Every artifact location this run reads and writes."""
-        return resolve_layout(
-            self.output_path,
-            self.bundle_root,
-            self.partition,
-            self.from_partition,
-            self.reader_type,
+        return BundleLayout(
+            map_root=self.output_path,
+            bundle_root=self.bundle_root,
+            partition=self.partition,
+            from_partition=self.from_partition,
+            reader_type=self.reader_type,
         )
 
     @cached_property
@@ -338,6 +338,7 @@ class CollisionResolutionRunner:
             )
         self._default_writer_type: Optional[str] = None
         self._item_id_type: Optional[pa.DataType] = None
+        self._layout = config.layout
         self._bundle_uuid = uuid.uuid4().hex
         self._written_rows: Dict[str, int] = {}
 
@@ -385,13 +386,11 @@ class CollisionResolutionRunner:
         wanted = [("--input_path", self._config.input_path)]
         if self._config.is_append:
             wanted += [
-                (GROUPS_ARTIFACT, self._config.layout.read_path(GROUPS_ARTIFACT)),
-                ("manifest", self._config.layout.prior_manifest_path()),
+                (GROUPS_ARTIFACT, self._layout.read_path(GROUPS_ARTIFACT)),
+                ("manifest", self._layout.prior_manifest_path()),
             ]
             if self._config.output_path is not None:
-                wanted.append(
-                    (MAP_ARTIFACT, self._config.layout.read_path(MAP_ARTIFACT))
-                )
+                wanted.append((MAP_ARTIFACT, self._layout.read_path(MAP_ARTIFACT)))
         missing = [
             f"{name} -> {path}"
             for name, path in wanted
@@ -410,13 +409,20 @@ class CollisionResolutionRunner:
 
         Its presence is the completion marker, so nothing may be written after it.
         """
-        layout = self._config.layout
-        prior = layout.read_prior_manifest() if self._config.is_append else None
+        layout = self._layout
+        prior = (
+            read_manifest(layout.prior_manifest_path())
+            if self._config.is_append
+            else None
+        )
         observed = result.stats.max_final_bucket_size
         if prior is not None:
             observed = max(observed, prior.max_observed_items_per_sid)
+        map_save_type = "csv" if self._default_writer_type == "CsvWriter" else "parquet"
         artifacts = {
-            name: self._artifact_entry(name, rows)
+            name: layout.entry(
+                name, map_save_type if name in MAP_ARTIFACTS else "parquet", rows
+            )
             for name, rows in self._written_rows.items()
         }
         manifest = BundleManifest(
@@ -430,15 +436,6 @@ class CollisionResolutionRunner:
         )
         path = layout.write_manifest(manifest)
         logger.info("wrote bundle %s manifest to %s", self._bundle_uuid, path)
-
-    def _artifact_entry(self, artifact: str, rows: int) -> ArtifactEntry:
-        """Record where one artifact landed and what it holds."""
-        is_csv_map = (
-            artifact in MAP_ARTIFACTS and self._default_writer_type == "CsvWriter"
-        )
-        return self._config.layout.entry(
-            artifact, "csv" if is_csv_map else "parquet", rows
-        )
 
     def _make_reader(
         self, selected_cols: List[str], input_path: Optional[str] = None
@@ -666,7 +663,7 @@ class CollisionResolutionRunner:
             return PriorOccupancy.empty()
 
         layer_sizes = self._config.layer_sizes
-        groups_path = self._config.layout.read_path(GROUPS_ARTIFACT)
+        groups_path = self._layout.read_path(GROUPS_ARTIFACT)
         prior, published_items = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
@@ -715,7 +712,7 @@ class CollisionResolutionRunner:
 
     def _check_state_item_id_type(self, values: pa.Array, source: str) -> None:
         """Reject an existing artifact whose item ID type differs from the input."""
-        if len(values) == 0 or self._item_id_type is None:
+        if len(values) == 0:
             return
         if values.type != self._item_id_type:
             raise ValueError(
@@ -787,7 +784,7 @@ class CollisionResolutionRunner:
         """Reject a published map whose size disagrees with the groups."""
         if self._config.output_path is None:
             return
-        path = self._config.layout.read_path(MAP_ARTIFACT)
+        path = self._layout.read_path(MAP_ARTIFACT)
         map_rows = 0
         for batch in self._iter_state_batches(
             path, ["index"], "Counting published SID map"
@@ -889,7 +886,7 @@ class CollisionResolutionRunner:
         """Copy every published map row into the merged output unchanged."""
         if not self._config.is_append:
             return 0
-        path = self._config.layout.read_path(MAP_ARTIFACT)
+        path = self._layout.read_path(MAP_ARTIFACT)
         is_csv = isinstance(writer, CsvWriter)
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
@@ -926,7 +923,7 @@ class CollisionResolutionRunner:
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        output_path = self._config.layout.write_path(MAP_ARTIFACT)
+        output_path = self._layout.write_path(MAP_ARTIFACT)
         with closing(self._make_writer(output_path)) as writer:
             progress = ProgressLogger("Writing resolved item map", start_n=0)
             written = self._stream_existing_map_rows(writer)
@@ -937,7 +934,7 @@ class CollisionResolutionRunner:
 
         if not self._config.is_append:
             return
-        delta_path = self._config.layout.write_path(DELTA_MAP_ARTIFACT)
+        delta_path = self._layout.write_path(DELTA_MAP_ARTIFACT)
         self._written_rows[DELTA_MAP_ARTIFACT] = item_ids.shape[0]
         with closing(self._make_writer(delta_path)) as writer:
             self._write_new_map_rows(
@@ -964,31 +961,16 @@ class CollisionResolutionRunner:
             plan: Original SID aggregation and overflow plan.
             result: Completed collision-resolution result.
         """
-        resolved_path = self._config.layout.write_path(GROUPS_ARTIFACT)
         if plan.overflow_rows.size:
             grouping = build_resolved_item_grouping(plan, result)
-            resolved_last_codes = result.resolved_last_codes
         else:
             grouping = build_original_item_grouping(plan)
-            resolved_last_codes = None
-        if self._config.is_append:
-            self._write_merged_sid_groups(
-                resolved_path,
-                self._config.layout.read_path(GROUPS_ARTIFACT),
-                item_ids,
-                origin_codes,
-                grouping,
-                resolved_last_codes,
-            )
-            return
-        self._write_sid_groups(
-            resolved_path,
-            item_ids,
-            origin_codes,
-            grouping,
-            resolved_last_codes=resolved_last_codes,
-            progress_description="Writing resolved SID item groups",
+        write = (
+            self._write_merged_sid_groups
+            if self._config.is_append
+            else self._write_sid_groups
         )
+        write(item_ids, origin_codes, grouping, result.resolved_last_codes)
 
     def _emit_group_rows(
         self,
@@ -999,23 +981,17 @@ class CollisionResolutionRunner:
         rows: Optional[np.ndarray] = None,
     ) -> None:
         """Write one chunk of SID groups, optionally only ``rows`` of it."""
+        itemids = pa.ListArray.from_arrays(pa.array(offsets, type=pa.int32()), values)
         if rows is not None:
             if rows.size == 0:
                 return
-            lengths = np.diff(offsets)[rows]
-            values = values.take(
-                pa.array(concat_ranges(offsets[:-1][rows], lengths), type=pa.int64())
-            )
+            itemids = itemids.take(pa.array(rows, type=pa.int64()))
             codes = codes[rows]
-            offsets = np.zeros(rows.shape[0] + 1, dtype=np.int64)
-            np.cumsum(lengths, out=offsets[1:])
         writer.write(
             {
                 "codebook": self._codes_column(codes, False),
                 "offset_codebook": self._offset_codes_column(codes, False),
-                "itemids": pa.ListArray.from_arrays(
-                    pa.array(offsets, type=pa.int32()), values
-                ),
+                "itemids": itemids,
             }
         )
 
@@ -1024,14 +1000,13 @@ class CollisionResolutionRunner:
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         grouping: CodebookItemGrouping,
-        resolved_last_codes: Optional[np.ndarray],
+        resolved_last_codes: np.ndarray,
     ) -> _AppendGroups:
         """Materialize this run's groups in the shape the merge consumes."""
         offsets = grouping.offsets
         representative_rows = grouping.row_order[offsets[:-1]]
         codes = origin_codes[representative_rows]
-        if resolved_last_codes is not None:
-            codes[:, -1] = resolved_last_codes[representative_rows]
+        codes[:, -1] = resolved_last_codes[representative_rows]
         return _AppendGroups(
             keys=grouping.sid_keys,
             counts=grouping.counts,
@@ -1042,14 +1017,14 @@ class CollisionResolutionRunner:
 
     def _write_merged_sid_groups(
         self,
-        resolved_path: str,
-        existing_path: str,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         grouping: CodebookItemGrouping,
-        resolved_last_codes: Optional[np.ndarray],
+        resolved_last_codes: np.ndarray,
     ) -> None:
         """Merge this run's groups into the published groups and write both."""
+        resolved_path = self._layout.write_path(GROUPS_ARTIFACT)
+        existing_path = self._layout.read_path(GROUPS_ARTIFACT)
         layer_sizes = self._config.layer_sizes
         groups = self._build_append_groups(
             item_ids, origin_codes, grouping, resolved_last_codes
@@ -1063,7 +1038,7 @@ class CollisionResolutionRunner:
             delta_writer = stack.enter_context(
                 closing(
                     self._make_group_writer(
-                        self._config.layout.write_path(DELTA_GROUPS_ARTIFACT)
+                        self._layout.write_path(DELTA_GROUPS_ARTIFACT)
                     )
                 )
             )
@@ -1116,17 +1091,24 @@ class CollisionResolutionRunner:
                 batch_lengths, batch_values = self._decode_grouped_item_ids(
                     batch["itemids"]
                 )
-                emit(
-                    *_merge_group_batch(
-                        batch_keys,
-                        batch_codes,
-                        batch_lengths,
-                        batch_values,
-                        groups,
-                        low,
-                        high,
+                if low == high:
+                    # No new group lands in this batch's key range, so the merge
+                    # would rebuild the batch it was handed.
+                    batch_offsets = np.zeros(batch_keys.shape[0] + 1, dtype=np.int64)
+                    np.cumsum(batch_lengths, out=batch_offsets[1:])
+                    emit(batch_codes, batch_offsets, batch_values, _NO_ROWS)
+                else:
+                    emit(
+                        *_merge_group_batch(
+                            batch_keys,
+                            batch_codes,
+                            batch_lengths,
+                            batch_values,
+                            groups,
+                            low,
+                            high,
+                        )
                     )
-                )
                 cursor = high
             emit_new_only(cursor, group_count)
         self._written_rows[GROUPS_ARTIFACT] = corpus_rows
@@ -1134,27 +1116,24 @@ class CollisionResolutionRunner:
 
     def _write_sid_groups(
         self,
-        output_path: str,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         grouping: CodebookItemGrouping,
-        resolved_last_codes: Optional[np.ndarray],
-        progress_description: str,
+        resolved_last_codes: np.ndarray,
     ) -> None:
         """Write codebook-to-item-ID groups in SID and slot order.
 
         Args:
-            output_path: Destination passed to the selected repository writer.
             item_ids: Input item IDs in original row order.
             origin_codes: Original full SID matrix.
             grouping: Sorted SID groups and their flattened original row order.
-            resolved_last_codes: Final last-layer values, or ``None`` when
-                writing original SIDs.
-            progress_description: Description identifying the group output.
+            resolved_last_codes: Final last-layer value of every input row.
 
         Raises:
             ValueError: If one group exceeds Arrow list offset capacity.
         """
+        output_path = self._layout.write_path(GROUPS_ARTIFACT)
+        progress_description = "Writing resolved SID item groups"
         group_count = grouping.counts.shape[0]
         if np.any(grouping.counts > _ARROW_LIST_OFFSET_MAX):
             raise ValueError("one SID group exceeds Arrow list offset capacity.")
@@ -1175,8 +1154,7 @@ class CollisionResolutionRunner:
                 local_offsets = offsets[group_start : group_end + 1] - child_start
                 representative_rows = grouping.row_order[offsets[group_start:group_end]]
                 code_chunk = origin_codes[representative_rows]
-                if resolved_last_codes is not None:
-                    code_chunk[:, -1] = resolved_last_codes[representative_rows]
+                code_chunk[:, -1] = resolved_last_codes[representative_rows]
                 self._emit_group_rows(
                     writer,
                     code_chunk,

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -69,26 +69,8 @@ the published occupancy instead of restarting at one::
         --delta_map_output_path sid_collision/delta_20260731
 
 Both outputs stay corpus-complete, so generation *n*'s outputs are exactly
-generation *n+1*'s ``--existing_*`` inputs and a full resolve bootstraps the
-chain with no special case. ``--original_sid_groups_output_path`` is the
-exception: it is an audit output keyed by the *predicted* SID, and in append
-mode it covers only this run's items, because published items' original SIDs
-live in the map's ``origin_codebook`` rather than in the groups artifact.
-
-Writers truncate, so every generation needs a fresh output directory.
-``--delta_map_output_path`` emits the new item rows alone and
-``--delta_sid_groups_output_path`` the buckets this run changed, each with its
-complete post-append item list so a serving index can upsert it idempotently.
-
-State paths follow the same rules as ``--input_path``: the reader backend
-comes from the path (``map_v1/*.parquet``, ``odps://…``) or from
-``--reader_type``. Before placing anything, the run
-verifies that no new item ID is already published, and that the two state
-artifacts agree bucket for bucket on count, largest index and index sum -- the
-map stores ``index`` as a value, so unlike the groups artifact it can hold
-holes or duplicates, and appending onto those would reuse a published slot.
-Appends need candidate output more often than a full resolve does, because a
-bucket's free space is ``capacity`` minus its published occupancy.
+generation *n+1*'s ``--existing_*`` inputs; writers truncate, so each
+generation needs a fresh output directory.
 """
 
 from __future__ import annotations
@@ -99,7 +81,7 @@ import os
 from contextlib import ExitStack, closing
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Callable, Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -138,9 +120,6 @@ from tzrec.utils.sid.collision import (
 )
 
 _MAP_WRITE_ROWS = 1_000_000
-# State artifacts are corpus-sized; read them in larger batches than the
-# new-items input so per-batch fixed costs are not multiplied by the corpus.
-_STATE_READ_ROWS = 1_000_000
 _GROUP_WRITE_ITEMS = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
 
@@ -226,7 +205,7 @@ class ResolveSidCollisionsConfig:
     random_num_candidates: int
     rate_only: bool
     odps_data_quota_name: str
-    # Append mode. Defaulted so a full-resolve caller need not mention them.
+    # Append mode; defaulted so full-resolve callers need not pass them.
     existing_sid_map_path: Optional[str] = None
     existing_sid_groups_path: Optional[str] = None
     delta_map_output_path: Optional[str] = None
@@ -257,8 +236,7 @@ class ResolveSidCollisionsConfig:
                 "is set; without it the merged map would hold only the new items."
             )
 
-        # Append-only paths are simply unused outside append mode, so they are
-        # left out of the conflict check rather than rejected.
+        # Append-only paths are ignored, not rejected, outside append mode.
         candidates = [self.output_path, self.resolved_sid_groups_output_path]
         candidates.append(self.original_sid_groups_output_path)
         if self.is_append:
@@ -386,24 +364,20 @@ class CollisionResolutionRunner:
         return result.stats
 
     def _make_reader(
-        self,
-        selected_cols: List[str],
-        input_path: Optional[str] = None,
-        batch_size: Optional[int] = None,
+        self, selected_cols: List[str], input_path: Optional[str] = None
     ) -> BaseReader:
         """Open a repository reader projecting ``selected_cols``.
 
         Args:
             selected_cols: Columns to project.
             input_path: Path to read; defaults to the new-items input.
-            batch_size: Rows per batch; defaults to the configured size.
 
         Returns:
             A reader over the requested path.
         """
         return create_reader(
             input_path=input_path or self._config.input_path,
-            batch_size=batch_size or self._config.batch_size,
+            batch_size=self._config.batch_size,
             selected_cols=selected_cols,
             reader_type=self._config.reader_type,
             quota_name=self._config.odps_data_quota_name,
@@ -414,39 +388,15 @@ class CollisionResolutionRunner:
         path: str,
         fields: List[str],
         description: str,
-        on_open: Optional[Callable[[BaseReader], None]] = None,
     ) -> Iterator[Dict[str, pa.Array]]:
-        """Stream one state artifact, checking columns and logging progress.
-
-        State artifacts are corpus-sized, so they are read with their own batch
-        size rather than the one tuned for the much smaller new-items input --
-        every per-batch fixed cost is otherwise multiplied by the corpus.
-
-        Args:
-            path: State artifact to read.
-            fields: Columns to project and require.
-            description: Progress logger description.
-            on_open: Optional callback invoked once with the opened reader.
-
-        Yields:
-            Each record batch of the artifact.
-
-        Raises:
-            ValueError: If a required column is missing from the artifact.
-        """
-        reader = self._make_reader(
-            fields,
-            input_path=path,
-            batch_size=max(self._config.batch_size, _STATE_READ_ROWS),
-        )
+        """Stream one state artifact, checking columns and logging progress."""
+        reader = self._make_reader(fields, input_path=path)
         missing = [name for name in fields if name not in reader.schema.names]
         if missing:
             raise ValueError(
                 f"columns {missing} are missing from {path!r}; point the flag at "
                 "an output directory written by this tool."
             )
-        if on_open is not None:
-            on_open(reader)
         progress = ProgressLogger(description, start_n=0)
         scanned = 0
         last_progress_count = 0
@@ -635,15 +585,7 @@ class CollisionResolutionRunner:
     ) -> PriorOccupancy:
         """Load and verify published state, or return empty for a full resolve.
 
-        Args:
-            item_ids: Item IDs of the new batch.
-            codes: SID matrix of the new batch.
-
-        Returns:
-            Occupancy restricted to the bands this run can touch.
-
-        Raises:
-            ValueError: If the SID width disagrees with ``--codebook``.
+        The result is restricted to the bands this run can touch.
         """
         if not self._config.is_append:
             logger.info("full-resolve mode: no existing SID state supplied")
@@ -658,7 +600,7 @@ class CollisionResolutionRunner:
                 f"{len(layer_sizes)}."
             )
         groups_path = self._config.existing_sid_groups_path
-        assert groups_path is not None  # is_append means it is set
+        assert groups_path is not None
         prior = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
@@ -677,17 +619,10 @@ class CollisionResolutionRunner:
     def _decode_grouped_item_ids(self, values: pa.Array) -> Tuple[np.ndarray, pa.Array]:
         """Decode a grouped item-ID column into per-group counts and values.
 
-        Inverse of :meth:`_grouped_item_ids_column`. Native list columns expose
-        both halves directly and stay zero-copy; the CSV form is a JSON array
-        string, which has to be parsed -- a plain comma count would be wrong for
-        string IDs that themselves contain commas -- so both halves come out of
-        one parse rather than two.
-
-        Args:
-            values: One batch of the grouped item-ID column.
-
-        Returns:
-            An int64 count per group, and the flattened child values.
+        Inverse of :meth:`_grouped_item_ids_column`. List columns stay
+        zero-copy; the CSV form is a JSON array string that must be parsed --
+        a comma count would be wrong for string IDs containing commas -- so
+        both halves come out of one parse rather than two.
         """
         if _is_list_column(values):
             lengths = (
@@ -706,16 +641,9 @@ class CollisionResolutionRunner:
     def _align_codes_column(self, values: pa.Array, is_csv: bool) -> pa.Array:
         """Return an SID column in the encoding the destination writer needs.
 
-        Passes the Arrow column straight through when the source encoding
-        already matches the writer, and re-encodes through the NumPy form
-        otherwise, so a mixed-format append still produces one valid artifact.
-
-        Args:
-            values: SID column read from an existing artifact.
-            is_csv: Whether the destination writer is a CSV writer.
-
-        Returns:
-            A column matching what :meth:`_codes_column` would emit.
+        Passes the column straight through when the source encoding already
+        matches the writer, and re-encodes otherwise, so a mixed-format append
+        still produces one valid artifact.
         """
         source_is_text = pa.types.is_string(values.type) or pa.types.is_large_string(
             values.type
@@ -725,41 +653,8 @@ class CollisionResolutionRunner:
             return values
         return self._codes_column(self._codes_matrix(values), is_csv)
 
-    def _warn_on_state_format_conversion(self, reader: BaseReader) -> None:
-        """Warn when the merged artifacts will change format.
-
-        The writer follows the new-items input, so a CSV prediction against
-        Parquet state silently rewrites the whole corpus in the other format.
-        That is legal -- each output is self-contained -- but it is never what
-        an operator intends, so make it visible.
-
-        Args:
-            reader: Reader opened over an existing state artifact.
-        """
-        state_writer_type = reader.__class__.__name__.replace("Reader", "Writer")
-        if (
-            self._default_writer_type is not None
-            and state_writer_type != self._default_writer_type
-        ):
-            logger.warning(
-                "existing SID state reads as %s but the output writer is %s; the "
-                "whole corpus will be rewritten in the other format. Set "
-                "--writer_type %s to keep it unchanged.",
-                reader.__class__.__name__,
-                self._default_writer_type,
-                state_writer_type,
-            )
-
     def _check_state_item_id_type(self, values: pa.Array, source: str) -> None:
-        """Reject an existing artifact whose item ID type differs from the input.
-
-        Args:
-            values: Item ID column read from a state artifact.
-            source: Human-readable artifact name for the error message.
-
-        Raises:
-            ValueError: If the type differs from the new-items input.
-        """
+        """Reject an existing artifact whose item ID type differs from the input."""
         if len(values) == 0 or self._item_id_type is None:
             return
         if values.type != self._item_id_type:
@@ -779,17 +674,8 @@ class CollisionResolutionRunner:
         read or written by this run. The same scan probes for item IDs that are
         already published, which is the only place that can be detected.
 
-        Args:
-            path: Previous round's resolved SID groups.
-            band_ids: Band identifier of every new item.
-            item_ids: Item IDs of the new batch.
-
-        Returns:
-            Occupancy restricted to the new batch's bands.
-
-        Raises:
-            ValueError: If the groups stream is not ascending by SID key, or if
-                any new item ID is already published.
+        Raises if the stream is not ascending by SID key, or if any new item
+        ID is already published.
         """
         layer_sizes = self._config.layer_sizes
         wanted_bands = np.unique(band_ids)
@@ -804,7 +690,6 @@ class CollisionResolutionRunner:
             path,
             ["codebook", "itemids"],
             "Reading published SID groups",
-            on_open=self._warn_on_state_format_conversion,
         ):
             keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
             if keys.size:
@@ -819,9 +704,7 @@ class CollisionResolutionRunner:
             lengths, flat_ids = self._decode_grouped_item_ids(batch["itemids"])
             if len(flat_ids):
                 self._check_state_item_id_type(flat_ids, "existing SID groups")
-                # Hash-based set membership: keeps published IDs inside Arrow
-                # rather than materializing
-                # them as Python objects for a comparison-based search.
+                # Hash membership avoids materializing IDs as Python objects.
                 published = pc.is_in(flat_ids, value_set=new_item_ids)
                 batch_overlap = int(pc.sum(published).as_py() or 0)
                 overlap_count += batch_overlap
@@ -856,11 +739,6 @@ class CollisionResolutionRunner:
         structural in the groups artifact (list position is the slot) but not
         in the map, where ``index`` is a stored value.
 
-        Args:
-            prior: Band-restricted occupancy from :meth:`_load_prior_occupancy`.
-
-        Raises:
-            ValueError: If any of the four checks fails.
         """
         path = self._config.existing_sid_map_path
         if path is None or prior.is_empty:
@@ -869,9 +747,8 @@ class CollisionResolutionRunner:
         domain = prior.bucket_keys
         bands = np.unique(bands_of_bucket_keys(domain, layer_sizes[-1]))
         unknown_keys: List[int] = []
-        # Buffer the rows that land in a compared bucket and reduce once at the
-        # end: a per-batch reduction would allocate a domain-sized accumulator
-        # for every batch, which dwarfs the handful of rows each one contributes.
+        # Reduce once at the end: a per-batch reduction would allocate a
+        # domain-sized accumulator for every batch.
         position_chunks: List[np.ndarray] = []
         index_chunks: List[np.ndarray] = []
 
@@ -881,8 +758,7 @@ class CollisionResolutionRunner:
             "Cross-checking published SID map",
         ):
             keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
-            # Only buckets in the new batch's bands are compared; nothing else
-            # can affect this run.
+            # Buckets outside the new batch's bands cannot affect this run.
             rows = np.flatnonzero(in_sorted_bands(keys, bands, layer_sizes[-1]))
             if rows.size == 0:
                 continue
@@ -931,18 +807,7 @@ class CollisionResolutionRunner:
         sum_index: np.ndarray,
         unknown_keys: List[int],
     ) -> None:
-        """Raise on the first failing map/groups consistency check.
-
-        Args:
-            prior: Occupancy derived from the groups artifact.
-            counts: Map rows per bucket.
-            max_index: Largest ``index`` per bucket.
-            sum_index: Sum of ``index`` per bucket.
-            unknown_keys: Map bucket keys absent from the groups artifact.
-
-        Raises:
-            ValueError: If any check fails.
-        """
+        """Raise on the first failing map/groups consistency check."""
         hint = (
             "the two --existing_* artifacts must come from the same generation "
             "of this tool"
@@ -1086,17 +951,7 @@ class CollisionResolutionRunner:
         progress: ProgressLogger,
         written: int,
     ) -> None:
-        """Write this run's own item rows in chunks, without a full code copy.
-
-        Args:
-            writer: Destination writer.
-            is_csv: Whether ``writer`` is a CSV writer.
-            item_ids: Item IDs in original row order.
-            origin_codes: Original full SID matrix.
-            result: Completed collision-resolution result.
-            progress: Shared progress logger.
-            written: Rows already written to ``writer``.
-        """
+        """Write this run's own item rows in chunks, without a full code copy."""
         output_count = item_ids.shape[0]
         last_progress_count = written
         write_chunk = self._map_write_chunk_rows(is_csv, origin_codes.shape[1])
@@ -1125,13 +980,8 @@ class CollisionResolutionRunner:
         Existing rows keep their item ID, both codebooks and their slot index
         verbatim; that copy is the guarantee that no published SID moves.
 
-        Args:
-            writer: Destination writer.
-            is_csv: Whether ``writer`` is a CSV writer.
-
-        Returns:
-            The number of rows copied, or zero outside append mode, where the
-            published-state flags are ignored rather than rejected.
+        Returns zero outside append mode, where the published-state flags are
+        ignored rather than rejected.
         """
         path = self._config.existing_sid_map_path
         if path is None or not self._config.is_append:
@@ -1184,8 +1034,7 @@ class CollisionResolutionRunner:
                 writer, is_csv, item_ids, origin_codes, result, progress, written
             )
 
-        # Delta outputs describe what an append added, so they are ignored
-        # outside append mode rather than duplicating the full map.
+        # Ignored outside append mode; there it would duplicate the full map.
         delta_path = self._config.delta_map_output_path
         if delta_path is None or not self._config.is_append:
             return
@@ -1241,7 +1090,7 @@ class CollisionResolutionRunner:
             resolved_last_codes = None
         if self._config.is_append:
             existing_path = self._config.existing_sid_groups_path
-            assert existing_path is not None  # is_append means it is set
+            assert existing_path is not None
             self._write_merged_sid_groups(
                 resolved_path,
                 existing_path,
@@ -1271,13 +1120,7 @@ class CollisionResolutionRunner:
     ) -> None:
         """Write one chunk of SID groups, optionally only ``rows`` of it.
 
-        Args:
-            writer: Destination writer.
-            is_csv: Whether ``writer`` is a CSV writer.
-            codes: Emitted SID per group.
-            offsets: CSR offsets into ``values``.
-            values: Flattened item IDs.
-            rows: Group rows to keep, or ``None`` for all of them.
+        ``rows`` selects a subset of the groups, or ``None`` for all of them.
         """
         lengths = np.diff(offsets)
         if rows is not None:
@@ -1334,13 +1177,6 @@ class CollisionResolutionRunner:
         optional delta output receives the same rows for the buckets this run
         changed, so a serving index can upsert them idempotently.
 
-        Args:
-            resolved_path: Corpus-complete groups output.
-            existing_path: Previous round's groups artifact.
-            item_ids: Item IDs of the new batch in original row order.
-            origin_codes: Original full SID matrix of the new batch.
-            grouping: This run's resolved grouping.
-            resolved_last_codes: Final last-layer codes, or ``None``.
         """
         layer_sizes = self._config.layer_sizes
         groups = self._build_append_groups(
@@ -1490,14 +1326,7 @@ class CollisionResolutionRunner:
 def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
     """Return how many SID rows one write can encode.
 
-    Args:
-        is_csv: Whether the destination writer is a CSV writer, which encodes
-            codes as text and so has no Arrow list offset ceiling.
-        layer_count: Number of SID layers per row.
-        row_cap: Upper bound the caller already knows.
-
-    Returns:
-        The row count for one write.
+    CSV encodes codes as text and so has no Arrow list offset ceiling.
     """
     if is_csv:
         return row_cap
@@ -1507,20 +1336,10 @@ def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
 def _group_chunk_bounds(
     offsets: np.ndarray, low: int, high: int, max_rows: int
 ) -> Iterator[Tuple[int, int]]:
-    """Split ``[low, high)`` groups into writable chunks.
+    """Split ``[low, high)`` groups into writable ``(start, stop)`` chunks.
 
     A chunk holds at most ``_GROUP_WRITE_ITEMS`` child items and ``max_rows``
-    groups, and always advances by at least one group so a single oversized
-    group still makes progress.
-
-    Args:
-        offsets: CSR offsets of every group.
-        low: First group index.
-        high: One past the last group index.
-        max_rows: Largest number of groups one write may carry.
-
-    Yields:
-        Half-open ``(start, stop)`` group ranges covering ``[low, high)``.
+    groups, and always advances by one group so an oversized group progresses.
     """
     while low < high:
         child_limit = int(offsets[low]) + _GROUP_WRITE_ITEMS
@@ -1572,23 +1391,13 @@ def _merge_group_batch(
     """Merge one batch of published groups with the new groups it overlaps.
 
     Both sides are ascending by SID key, so the output is their sorted union:
-    a bucket present on both sides emits one row whose item list is the
-    published items followed by this run's items. That order is also slot
-    order, because published items hold slots ``1..P`` and new items continue
-    from ``P + 1``.
+    a bucket on both sides emits one row whose item list is the published items
+    followed by this run's. That is also slot order, because published items
+    hold ``1..P`` and new items continue from ``P + 1``.
 
-    Args:
-        batch_keys: Ascending SID keys of the published batch.
-        batch_codes: SID matrix of the published batch.
-        batch_lengths: Item count of every published group.
-        batch_values: Flattened item IDs of the published batch.
-        groups: This run's groups.
-        low: First index of ``groups`` at or after ``batch_keys[0]``.
-        high: One past the last index of ``groups`` at or before the batch end.
-
-    Returns:
-        Emitted codes, CSR offsets, flattened item IDs, and the output rows
-        that this run changed.
+    ``low`` / ``high`` bound the slice of ``groups`` overlapping this batch.
+    Returns emitted codes, CSR offsets, flattened item IDs, and the output rows
+    this run changed.
     """
     batch_rows = batch_keys.shape[0]
     candidate_keys = groups.keys[low:high]
@@ -1633,8 +1442,8 @@ def _merge_group_batch(
     offsets = np.zeros(output_rows + 1, dtype=np.int64)
     np.cumsum(batch_part + new_part, out=offsets[1:])
 
-    # Gather from the published child values followed by only the slice of new
-    # item IDs this batch needs, so the copy stays proportional to the batch.
+    # Take only the slice of new item IDs this batch needs, so the copy stays
+    # proportional to the batch.
     child_low = int(groups.offsets[low])
     child_high = int(groups.offsets[high])
     combined = pa.concat_arrays(
@@ -1726,7 +1535,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=100000,
         help=(
-            "Reader I/O batch size; does not limit the in-memory collision working set."
+            "Reader I/O batch size; does not limit the in-memory collision working "
+            "set. In append mode it also governs the scans of the published map "
+            "and groups, so raise it for a large corpus."
         ),
     )
     parser.add_argument(

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -471,12 +471,12 @@ class CollisionResolutionRunner:
         root = self._config.output_path if is_map else self._config.bundle_root
         assert root is not None and self._config.partition is not None
         is_csv_map = is_map and self._default_writer_type == "CsvWriter"
-        kind = "csv" if is_csv_map else "parquet"
+        save_type = "csv" if is_csv_map else "parquet"
         return artifact_entry(
             root,
             artifact,
             self._config.partition,
-            kind,
+            save_type,
             rows,
             _MAP_SCHEMA if is_map else _GROUPS_SCHEMA,
         )

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -49,8 +49,8 @@ Example::
         --input_path 'sid_predict_output/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map_v1 \
-        --resolved_sid_groups_output_path sid_collision/groups_v1
+        --output_path sid_collision/map \
+        --resolved_sid_groups_output_path sid_collision/resolved_groups
 
 To also write the optional original-SID audit grouping, add
 ``--original_sid_groups_output_path sid_collision/original_groups``.
@@ -67,12 +67,12 @@ the published occupancy instead of restarting at one::
 
     python -m tzrec.tools.sid.resolve_sid_collisions \
         --input_path 'sid_predict_new_20260731/*.parquet' \
-        --existing_sid_map_path    'sid_collision/map_v1/*.parquet' \
-        --existing_sid_groups_path 'sid_collision/groups_v1/*.parquet' \
+        --existing_sid_map_path    'sid_collision/map/*.parquet' \
+        --existing_sid_groups_path 'sid_collision/resolved_groups/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map_v2 \
-        --resolved_sid_groups_output_path sid_collision/groups_v2 \
+        --output_path sid_collision/map_20260731 \
+        --resolved_sid_groups_output_path sid_collision/resolved_groups_20260731 \
         --delta_map_output_path sid_collision/delta_20260731
 
 Both outputs stay corpus-complete, so generation *n*'s outputs are exactly
@@ -174,12 +174,8 @@ class _ItemIdLookup:
 
     def match(self, item_ids: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Return matching source rows and requested-ID positions."""
-        positions = np.searchsorted(self._sorted_ids, item_ids)
-        source_rows = np.flatnonzero(positions < self._sorted_ids.shape[0])
-        if source_rows.size:
-            source_rows = source_rows[
-                self._sorted_ids[positions[source_rows]] == item_ids[source_rows]
-            ]
+        positions, found = lookup_sorted(self._sorted_ids, item_ids)
+        source_rows = np.flatnonzero(found)
         return source_rows, self._sorted_to_requested[positions[source_rows]]
 
     def broadcast_duplicate_targets(self, values: np.ndarray) -> None:
@@ -240,17 +236,18 @@ class ResolveSidCollisionsConfig:
                 "is set; without it the merged map would hold only the new items."
             )
 
-        candidates = [self.output_path, self.resolved_sid_groups_output_path]
-        candidates.append(self.original_sid_groups_output_path)
+        candidates = [
+            self.output_path,
+            self.resolved_sid_groups_output_path,
+            self.original_sid_groups_output_path,
+        ]
         if self.is_append:
-            candidates.extend(
-                (
-                    self.existing_sid_map_path,
-                    self.existing_sid_groups_path,
-                    self.delta_map_output_path,
-                    self.delta_sid_groups_output_path,
-                )
-            )
+            candidates += [
+                self.existing_sid_map_path,
+                self.existing_sid_groups_path,
+                self.delta_map_output_path,
+                self.delta_sid_groups_output_path,
+            ]
         paths = [self.input_path]
         paths.extend(path for path in candidates if path)
         has_conflict, conflict_message = check_path_conflict(paths)
@@ -338,6 +335,11 @@ class CollisionResolutionRunner:
         """Read, resolve collisions, and write the resulting SID map."""
         _require_single_process()
         item_ids, codes = self._load_codes()
+        if codes.shape[1] != len(self._config.layer_sizes):
+            raise ValueError(
+                f"codes have {codes.shape[1]} layers but --codebook has "
+                f"{len(self._config.layer_sizes)}."
+            )
         prior = self._load_prior_state(item_ids, codes)
         plan = prepare_collision_plan(
             item_ids, codes, self._config.resolution_config, prior=prior
@@ -586,20 +588,12 @@ class CollisionResolutionRunner:
     def _load_prior_state(
         self, item_ids: np.ndarray, codes: np.ndarray
     ) -> PriorOccupancy:
-        """Load and verify published state, or return empty for a full resolve.
-
-        The result is restricted to the bands this run can touch.
-        """
+        """Load and verify published state, or return empty for a full resolve."""
         if not self._config.is_append:
             logger.info("full-resolve mode: no existing SID state supplied")
             return PriorOccupancy.empty()
 
         layer_sizes = self._config.layer_sizes
-        if codes.shape[1] != len(layer_sizes):
-            raise ValueError(
-                f"codes have {codes.shape[1]} layers but --codebook has "
-                f"{len(layer_sizes)}."
-            )
         groups_path = self._config.existing_sid_groups_path
         assert groups_path is not None
         prior = self._load_prior_occupancy(
@@ -618,11 +612,7 @@ class CollisionResolutionRunner:
         return prior
 
     def _decode_grouped_item_ids(self, values: pa.Array) -> Tuple[np.ndarray, pa.Array]:
-        """Decode a grouped item-ID column into per-group counts and values.
-
-        Inverse of :meth:`_grouped_item_ids_column`: list columns stay
-        zero-copy, the CSV form splits on the comma it was joined with.
-        """
+        """Decode a grouped item-ID column into per-group counts and values."""
         if _is_list_column(values):
             lists = values
         else:
@@ -644,12 +634,7 @@ class CollisionResolutionRunner:
         )
 
     def _align_codes_column(self, values: pa.Array, is_csv: bool) -> pa.Array:
-        """Return an SID column in the encoding the destination writer needs.
-
-        Passes the column straight through when the source encoding already
-        matches the writer, and re-encodes otherwise, so a mixed-format append
-        still produces one valid artifact.
-        """
+        """Return an SID column in the encoding the destination writer needs."""
         source_is_text = pa.types.is_string(values.type) or pa.types.is_large_string(
             values.type
         )
@@ -672,16 +657,7 @@ class CollisionResolutionRunner:
     def _load_prior_occupancy(
         self, path: str, band_ids: np.ndarray, item_ids: np.ndarray
     ) -> PriorOccupancy:
-        """Read published occupancy from the previous round's resolved groups.
-
-        This is pass 1. Only buckets in a band the new batch touches are kept:
-        relocation never leaves a row's own band, so no other bucket can be
-        read or written by this run. The same scan probes for item IDs that are
-        already published, which is the only place that can be detected.
-
-        Raises if the stream is not ascending by SID key, or if any new item
-        ID is already published.
-        """
+        """Read published occupancy from the previous round's resolved groups."""
         layer_sizes = self._config.layer_sizes
         wanted_bands = np.unique(band_ids)
         new_item_ids = self._item_id_array(item_ids)
@@ -709,7 +685,7 @@ class CollisionResolutionRunner:
             lengths, flat_ids = self._decode_grouped_item_ids(batch["itemids"])
             if len(flat_ids):
                 published = pc.is_in(flat_ids, value_set=new_item_ids)
-                batch_overlap = int(pc.sum(published).as_py() or 0)
+                batch_overlap = published.true_count
                 overlap_count += batch_overlap
                 if batch_overlap and len(overlapping) < 10:
                     overlapping.extend(
@@ -733,16 +709,7 @@ class CollisionResolutionRunner:
         return PriorOccupancy(np.concatenate(key_chunks), np.concatenate(count_chunks))
 
     def _cross_check_existing_map(self, prior: PriorOccupancy) -> None:
-        """Verify the existing map agrees with the published groups.
-
-        This is pass 2. The two state artifacts encode the same occupancy in
-        different shapes, so comparing them catches a mismatched generation
-        pair, a mis-pointed directory and a truncated artifact. It is also the
-        only verification of the map's own ``index`` space: density is
-        structural in the groups artifact (list position is the slot) but not
-        in the map, where ``index`` is a stored value.
-
-        """
+        """Verify the existing map agrees with the published groups."""
         path = self._config.existing_sid_map_path
         if path is None or prior.is_empty:
             return
@@ -750,8 +717,9 @@ class CollisionResolutionRunner:
         domain = prior.bucket_keys
         bands = np.unique(domain // layer_sizes[-1])
         unknown_keys: List[int] = []
-        position_chunks: List[np.ndarray] = []
-        index_chunks: List[np.ndarray] = []
+        counts = np.zeros(domain.shape[0], dtype=np.int64)
+        max_index = np.zeros(domain.shape[0], dtype=np.int64)
+        sum_index = np.zeros(domain.shape[0], dtype=np.int64)
 
         for batch in self._iter_state_batches(
             path,
@@ -760,40 +728,26 @@ class CollisionResolutionRunner:
         ):
             keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
             _, known_band = lookup_sorted(bands, keys // layer_sizes[-1])
-            rows = np.flatnonzero(known_band)
-            if rows.size == 0:
+            if not known_band.any():
                 continue
-            keys = keys[rows]
-            indices = (
-                batch["index"]
-                .take(pa.array(rows, type=pa.int64()))
-                .to_numpy(zero_copy_only=False)
-                .astype(np.int64, copy=False)
-            )
+            keys = keys[known_band]
+            indices = batch["index"].to_numpy(zero_copy_only=False)[known_band]
             positions, known = lookup_sorted(domain, keys)
             if not np.all(known) and len(unknown_keys) < 10:
                 unknown_keys.extend(keys[~known][:10].tolist())
-            if np.any(known):
-                position_chunks.append(positions[known])
-                index_chunks.append(indices[known])
-
-        counts = np.zeros(domain.shape[0], dtype=np.int64)
-        max_index = np.zeros(domain.shape[0], dtype=np.int64)
-        sum_index = np.zeros(domain.shape[0], dtype=np.int64)
-        if position_chunks:
-            positions = np.concatenate(position_chunks)
-            indices = np.concatenate(index_chunks)
-            counts = np.bincount(positions, minlength=domain.shape[0])
-            sum_index = np.bincount(
-                positions, weights=indices, minlength=domain.shape[0]
-            ).astype(np.int64, copy=False)
-            order = np.argsort(positions, kind="stable")
-            sorted_positions = positions[order]
+            if not known.any():
+                continue
+            order = np.argsort(positions[known], kind="stable")
+            batch_positions = positions[known][order]
+            batch_indices = indices[known][order].astype(np.int64, copy=False)
             starts = np.flatnonzero(
-                np.concatenate(([True], sorted_positions[1:] != sorted_positions[:-1]))
+                np.concatenate(([True], batch_positions[1:] != batch_positions[:-1]))
             )
-            max_index[sorted_positions[starts]] = np.maximum.reduceat(
-                indices[order], starts
+            buckets = batch_positions[starts]
+            counts[buckets] += np.diff(np.append(starts, batch_positions.shape[0]))
+            sum_index[buckets] += np.add.reduceat(batch_indices, starts)
+            max_index[buckets] = np.maximum(
+                max_index[buckets], np.maximum.reduceat(batch_indices, starts)
             )
 
         self._report_cross_check(prior, counts, max_index, sum_index, unknown_keys)
@@ -945,26 +899,18 @@ class CollisionResolutionRunner:
                 last_progress_count = written
 
     def _stream_existing_map_rows(self, writer: BaseWriter) -> int:
-        """Copy every published map row into the merged output unchanged.
-
-        Existing rows keep their item ID, both codebooks and their slot index
-        verbatim; that copy is the guarantee that no published SID moves.
-
-        Returns zero outside append mode, where the published-state flags are
-        ignored rather than rejected.
-        """
+        """Copy every published map row into the merged output unchanged."""
         path = self._config.existing_sid_map_path
         if path is None or not self._config.is_append:
             return 0
         is_csv = isinstance(writer, CsvWriter)
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
-        for index, batch in enumerate(
-            self._iter_state_batches(path, fields, "Copying published item map")
+        for batch in self._iter_state_batches(
+            path, fields, "Copying published item map"
         ):
             item_id_column = batch["item_id"]
-            if index == 0:
-                self._check_state_item_id_type(item_id_column, "existing SID map")
+            self._check_state_item_id_type(item_id_column, "existing SID map")
             writer.write(
                 {
                     "item_id": item_id_column,
@@ -1084,16 +1030,12 @@ class CollisionResolutionRunner:
         values: pa.Array,
         rows: Optional[np.ndarray] = None,
     ) -> None:
-        """Write one chunk of SID groups, optionally only ``rows`` of it.
-
-        ``rows`` selects a subset of the groups, or ``None`` for all of them.
-        """
+        """Write one chunk of SID groups, optionally only ``rows`` of it."""
         is_csv = isinstance(writer, CsvWriter)
-        lengths = np.diff(offsets)
         if rows is not None:
             if rows.size == 0:
                 return
-            lengths = lengths[rows]
+            lengths = np.diff(offsets)[rows]
             values = values.take(
                 pa.array(concat_ranges(offsets[:-1][rows], lengths), type=pa.int64())
             )
@@ -1123,7 +1065,9 @@ class CollisionResolutionRunner:
             codes = codes.copy()
             codes[:, -1] = resolved_last_codes[representative_rows]
         return _AppendGroups(
-            grouping=grouping,
+            keys=grouping.sid_keys,
+            counts=grouping.counts,
+            offsets=offsets,
             codes=codes,
             item_ids=self._item_id_array(item_ids[grouping.row_order]),
         )
@@ -1137,15 +1081,7 @@ class CollisionResolutionRunner:
         grouping: CodebookItemGrouping,
         resolved_last_codes: Optional[np.ndarray],
     ) -> None:
-        """Merge this run's groups into the published groups and write both.
-
-        Streams the published groups once and interleaves this run's groups by
-        SID key, so the resolved output is corpus-complete and still ascending
-        -- which is exactly what the next append merge-joins against. The
-        optional delta output receives the same rows for the buckets this run
-        changed, so a serving index can upsert them idempotently.
-
-        """
+        """Merge this run's groups into the published groups and write both."""
         layer_sizes = self._config.layer_sizes
         groups = self._build_append_groups(
             item_ids, origin_codes, grouping, resolved_last_codes
@@ -1189,7 +1125,7 @@ class CollisionResolutionRunner:
                         groups.codes[start:stop],
                         groups.offsets[start : stop + 1] - child_low,
                         groups.item_ids.slice(child_low, child_high - child_low),
-                        np.arange(stop - start),
+                        None,
                     )
 
             cursor = 0
@@ -1264,24 +1200,16 @@ class CollisionResolutionRunner:
                 child_start = int(offsets[group_start])
                 child_end = int(offsets[group_end])
                 rows = grouping.row_order[child_start:child_end]
-                local_offsets = (
-                    offsets[group_start : group_end + 1] - child_start
-                ).astype(np.int32, copy=False)
+                local_offsets = offsets[group_start : group_end + 1] - child_start
                 representative_rows = grouping.row_order[offsets[group_start:group_end]]
                 code_chunk = origin_codes[representative_rows]
                 if resolved_last_codes is not None:
                     code_chunk[:, -1] = resolved_last_codes[representative_rows]
-                flat_item_ids = self._item_id_array(item_ids[rows])
-                writer.write(
-                    {
-                        "codebook": self._codes_column(code_chunk, is_csv),
-                        "offset_codebook": self._offset_codes_column(
-                            code_chunk, is_csv
-                        ),
-                        "itemids": self._grouped_item_ids_column(
-                            flat_item_ids, local_offsets, is_csv
-                        ),
-                    }
+                self._emit_group_rows(
+                    writer,
+                    code_chunk,
+                    local_offsets,
+                    self._item_id_array(item_ids[rows]),
                 )
                 if self._progress_interval_reached(child_end, last_progress_count):
                     progress.log(
@@ -1292,10 +1220,7 @@ class CollisionResolutionRunner:
 
 
 def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
-    """Return how many SID rows one write can encode.
-
-    CSV encodes codes as text and so has no Arrow list offset ceiling.
-    """
+    """Return how many SID rows one write can encode."""
     if is_csv:
         return row_cap
     return min(row_cap, _ARROW_LIST_OFFSET_MAX // layer_count)
@@ -1304,11 +1229,7 @@ def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
 def _group_chunk_bounds(
     offsets: np.ndarray, low: int, high: int, max_rows: int
 ) -> Iterator[Tuple[int, int]]:
-    """Split ``[low, high)`` groups into writable ``(start, stop)`` chunks.
-
-    A chunk holds at most ``_GROUP_WRITE_ITEMS`` child items and ``max_rows``
-    groups, and always advances by one group so an oversized group progresses.
-    """
+    """Split ``[low, high)`` groups into writable ``(start, stop)`` chunks."""
     while low < high:
         child_limit = int(offsets[low]) + _GROUP_WRITE_ITEMS
         stop = int(np.searchsorted(offsets, child_limit, side="right") - 1)
@@ -1319,32 +1240,13 @@ def _group_chunk_bounds(
 
 @dataclass(frozen=True)
 class _AppendGroups:
-    """This run's SID groups, prepared for merging into the published groups.
+    """This run's SID groups, prepared for merging into the published groups."""
 
-    Args:
-        grouping: This run's resolved grouping; owns keys, counts and offsets.
-        codes: Emitted SID of every group, shape ``(len(keys), n_layers)``.
-        item_ids: Item IDs of every group flattened in group and slot order.
-    """
-
-    grouping: CodebookItemGrouping
+    keys: np.ndarray
+    counts: np.ndarray
+    offsets: np.ndarray
     codes: np.ndarray
     item_ids: pa.Array
-
-    @property
-    def keys(self) -> np.ndarray:
-        """Ascending flattened SID key of every group."""
-        return self.grouping.sid_keys
-
-    @property
-    def counts(self) -> np.ndarray:
-        """Item count of every group."""
-        return self.grouping.counts
-
-    @property
-    def offsets(self) -> np.ndarray:
-        """CSR offsets into ``item_ids``."""
-        return self.grouping.offsets
 
 
 def _merge_group_batch(
@@ -1356,22 +1258,10 @@ def _merge_group_batch(
     low: int,
     high: int,
 ) -> Tuple[np.ndarray, np.ndarray, pa.Array, np.ndarray]:
-    """Merge one batch of published groups with the new groups it overlaps.
-
-    Both sides are ascending by SID key, so the output is their sorted union:
-    a bucket on both sides emits one row whose item list is the published items
-    followed by this run's. That is also slot order, because published items
-    hold ``1..P`` and new items continue from ``P + 1``.
-
-    ``low`` / ``high`` bound the slice of ``groups`` overlapping this batch.
-    Returns emitted codes, CSR offsets, flattened item IDs, and the output rows
-    this run changed.
-    """
+    """Merge one batch of published groups with the new groups it overlaps."""
     batch_rows = batch_keys.shape[0]
     candidate_keys = groups.keys[low:high]
-    positions = np.searchsorted(candidate_keys, batch_keys)
-    matched = positions < candidate_keys.shape[0]
-    matched[matched] = candidate_keys[positions[matched]] == batch_keys[matched]
+    positions, matched = lookup_sorted(candidate_keys, batch_keys)
 
     new_for_batch = np.full(batch_rows, -1, dtype=np.int64)
     new_for_batch[matched] = low + positions[matched]
@@ -1400,8 +1290,7 @@ def _merge_group_batch(
 
     codes = np.empty((output_rows, batch_codes.shape[1]), dtype=np.int64)
     codes[batch_slots] = batch_codes
-    if unmatched.size:
-        codes[unmatched_slots] = groups.codes[unmatched]
+    codes[unmatched_slots] = groups.codes[unmatched]
 
     batch_part = np.where(has_batch, batch_lengths[batch_index], 0)
     new_part = np.where(has_new, groups.counts[new_index], 0)
@@ -1410,7 +1299,7 @@ def _merge_group_batch(
 
     child_low = int(groups.offsets[low])
     child_high = int(groups.offsets[high])
-    combined = pa.concat_arrays(
+    combined = pa.chunked_array(
         [batch_values, groups.item_ids.slice(child_low, child_high - child_low)]
     )
     batch_child_starts = np.zeros(batch_rows + 1, dtype=np.int64)
@@ -1422,7 +1311,7 @@ def _merge_group_batch(
     gather[concat_ranges(offsets[:-1] + batch_part, new_part)] = concat_ranges(
         len(batch_values) + groups.offsets[new_index] - child_low, new_part
     )
-    values = combined.take(pa.array(gather, type=pa.int64()))
+    values = combined.take(pa.array(gather, type=pa.int64())).combine_chunks()
     return codes, offsets, values, np.flatnonzero(has_new)
 
 

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -113,18 +113,13 @@ from tzrec.utils.sid.bundle import (
     DELTA_GROUPS_ARTIFACT,
     DELTA_MAP_ARTIFACT,
     GROUPS_ARTIFACT,
-    GROUPS_ARTIFACTS,
     MAP_ARTIFACT,
     MAP_ARTIFACTS,
     ArtifactEntry,
+    BundleLayout,
     BundleManifest,
-    artifact_entry,
-    artifact_location,
-    artifact_read_pattern,
     is_odps_path,
-    manifest_path,
-    read_manifest,
-    write_manifest,
+    resolve_layout,
 )
 from tzrec.utils.sid.collision import (
     CodebookItemGrouping,
@@ -149,19 +144,6 @@ from tzrec.utils.sid.collision import (
 _MAP_WRITE_ROWS = 1_000_000
 _GROUP_WRITE_ITEMS = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
-
-_MAP_SCHEMA = {
-    "item_id": "item id type of the input",
-    "origin_codebook": "list<int64>",
-    "codebook": "list<int64>",
-    "offset_codebook": "list<int64>",
-    "index": "int64",
-}
-_GROUPS_SCHEMA = {
-    "codebook": "list<int64>",
-    "offset_codebook": "list<int64>",
-    "itemids": "list<item id type of the input>",
-}
 
 
 def _is_list_column(values: pa.Array) -> bool:
@@ -316,20 +298,16 @@ class ResolveSidCollisionsConfig:
             odps_data_quota_name=args.odps_data_quota_name,
         )
 
-    def artifact_write_path(self, artifact: str) -> str:
-        """Return where one artifact of this run's partition is written."""
-        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.output_path
-        assert root is not None and self.partition is not None
-        return artifact_location(root, artifact, self.partition)
-
-    def artifact_read_path(self, artifact: str) -> str:
-        """Return where one artifact of the appended-onto partition is read."""
-        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.output_path
-        assert root is not None and self.from_partition is not None
-        suffix = "parquet"
-        if artifact in MAP_ARTIFACTS and self.reader_type == "CsvReader":
-            suffix = "csv"
-        return artifact_read_pattern(root, artifact, self.from_partition, suffix)
+    @cached_property
+    def layout(self) -> BundleLayout:
+        """Every artifact location this run reads and writes."""
+        return resolve_layout(
+            self.output_path,
+            self.bundle_root,
+            self.partition,
+            self.from_partition,
+            self.reader_type,
+        )
 
     @cached_property
     def resolution_config(self) -> CollisionResolutionConfig:
@@ -407,12 +385,12 @@ class CollisionResolutionRunner:
         wanted = [("--input_path", self._config.input_path)]
         if self._config.is_append:
             wanted += [
-                (GROUPS_ARTIFACT, self._config.artifact_read_path(GROUPS_ARTIFACT)),
-                ("manifest", self._prior_manifest_path()),
+                (GROUPS_ARTIFACT, self._config.layout.read_path(GROUPS_ARTIFACT)),
+                ("manifest", self._config.layout.prior_manifest_path()),
             ]
             if self._config.output_path is not None:
                 wanted.append(
-                    (MAP_ARTIFACT, self._config.artifact_read_path(MAP_ARTIFACT))
+                    (MAP_ARTIFACT, self._config.layout.read_path(MAP_ARTIFACT))
                 )
         missing = [
             f"{name} -> {path}"
@@ -427,24 +405,13 @@ class CollisionResolutionRunner:
                 "missing, because the readers cannot tell the two apart."
             )
 
-    def _prior_manifest_path(self) -> str:
-        """Return the manifest of the generation being appended onto."""
-        assert self._config.bundle_root is not None
-        assert self._config.from_partition is not None
-        return manifest_path(self._config.bundle_root, self._config.from_partition)
-
     def _write_manifest(self, result: CollisionResolutionResult) -> None:
         """Describe every artifact this run published, written last.
 
         Its presence is the completion marker, so nothing may be written after it.
         """
-        assert self._config.bundle_root is not None
-        assert self._config.partition is not None
-        prior = (
-            read_manifest(self._prior_manifest_path())
-            if self._config.is_append
-            else None
-        )
+        layout = self._config.layout
+        prior = layout.read_prior_manifest() if self._config.is_append else None
         observed = result.stats.max_final_bucket_size
         if prior is not None:
             observed = max(observed, prior.max_observed_items_per_sid)
@@ -461,24 +428,16 @@ class CollisionResolutionRunner:
             item_id_type=str(self._item_id_type) if self._item_id_type else None,
             artifacts=artifacts,
         )
-        path = manifest_path(self._config.bundle_root, self._config.partition)
-        write_manifest(path, manifest)
+        path = layout.write_manifest(manifest)
         logger.info("wrote bundle %s manifest to %s", self._bundle_uuid, path)
 
     def _artifact_entry(self, artifact: str, rows: int) -> ArtifactEntry:
         """Record where one artifact landed and what it holds."""
-        is_map = artifact in MAP_ARTIFACTS
-        root = self._config.output_path if is_map else self._config.bundle_root
-        assert root is not None and self._config.partition is not None
-        is_csv_map = is_map and self._default_writer_type == "CsvWriter"
-        save_type = "csv" if is_csv_map else "parquet"
-        return artifact_entry(
-            root,
-            artifact,
-            self._config.partition,
-            save_type,
-            rows,
-            _MAP_SCHEMA if is_map else _GROUPS_SCHEMA,
+        is_csv_map = (
+            artifact in MAP_ARTIFACTS and self._default_writer_type == "CsvWriter"
+        )
+        return self._config.layout.entry(
+            artifact, "csv" if is_csv_map else "parquet", rows
         )
 
     def _make_reader(
@@ -707,7 +666,7 @@ class CollisionResolutionRunner:
             return PriorOccupancy.empty()
 
         layer_sizes = self._config.layer_sizes
-        groups_path = self._config.artifact_read_path(GROUPS_ARTIFACT)
+        groups_path = self._config.layout.read_path(GROUPS_ARTIFACT)
         prior, published_items = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
@@ -828,7 +787,7 @@ class CollisionResolutionRunner:
         """Reject a published map whose size disagrees with the groups."""
         if self._config.output_path is None:
             return
-        path = self._config.artifact_read_path(MAP_ARTIFACT)
+        path = self._config.layout.read_path(MAP_ARTIFACT)
         map_rows = 0
         for batch in self._iter_state_batches(
             path, ["index"], "Counting published SID map"
@@ -930,7 +889,7 @@ class CollisionResolutionRunner:
         """Copy every published map row into the merged output unchanged."""
         if not self._config.is_append:
             return 0
-        path = self._config.artifact_read_path(MAP_ARTIFACT)
+        path = self._config.layout.read_path(MAP_ARTIFACT)
         is_csv = isinstance(writer, CsvWriter)
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
@@ -967,7 +926,7 @@ class CollisionResolutionRunner:
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        output_path = self._config.artifact_write_path(MAP_ARTIFACT)
+        output_path = self._config.layout.write_path(MAP_ARTIFACT)
         with closing(self._make_writer(output_path)) as writer:
             progress = ProgressLogger("Writing resolved item map", start_n=0)
             written = self._stream_existing_map_rows(writer)
@@ -978,7 +937,7 @@ class CollisionResolutionRunner:
 
         if not self._config.is_append:
             return
-        delta_path = self._config.artifact_write_path(DELTA_MAP_ARTIFACT)
+        delta_path = self._config.layout.write_path(DELTA_MAP_ARTIFACT)
         self._written_rows[DELTA_MAP_ARTIFACT] = item_ids.shape[0]
         with closing(self._make_writer(delta_path)) as writer:
             self._write_new_map_rows(
@@ -1005,7 +964,7 @@ class CollisionResolutionRunner:
             plan: Original SID aggregation and overflow plan.
             result: Completed collision-resolution result.
         """
-        resolved_path = self._config.artifact_write_path(GROUPS_ARTIFACT)
+        resolved_path = self._config.layout.write_path(GROUPS_ARTIFACT)
         if plan.overflow_rows.size:
             grouping = build_resolved_item_grouping(plan, result)
             resolved_last_codes = result.resolved_last_codes
@@ -1015,7 +974,7 @@ class CollisionResolutionRunner:
         if self._config.is_append:
             self._write_merged_sid_groups(
                 resolved_path,
-                self._config.artifact_read_path(GROUPS_ARTIFACT),
+                self._config.layout.read_path(GROUPS_ARTIFACT),
                 item_ids,
                 origin_codes,
                 grouping,
@@ -1104,7 +1063,7 @@ class CollisionResolutionRunner:
             delta_writer = stack.enter_context(
                 closing(
                     self._make_group_writer(
-                        self._config.artifact_write_path(DELTA_GROUPS_ARTIFACT)
+                        self._config.layout.write_path(DELTA_GROUPS_ARTIFACT)
                     )
                 )
             )

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -22,10 +22,10 @@ The runner retains the first capacity items in each SID bucket, attempts to
 relocate overflow items using fixed-width last-layer candidates, delegates
 placement to the pure NumPy core, and writes item-level and grouped SID results
 through TorchEasyRec readers and writers. CSV encodes each SID/candidate column
-and each item-ID group as comma-separated values because Arrow's CSV writer
-cannot serialize list columns, so an item ID containing a comma is rejected at
-write time; ``candidate_codes`` is a flat ``topk * n_layers`` run split by the
-``--codebook`` length.
+as comma-separated codes because Arrow's CSV writer cannot serialize list
+columns; ``candidate_codes`` is a flat ``topk * n_layers`` run split by the
+``--codebook`` length. The SID groups are always parquet, so they keep native
+list columns whatever ``--writer_type`` says.
 
 The random strategy intentionally preserves the legacy deterministic baseline:
 it draws with replacement from the full last-layer space. Placement skips an
@@ -118,6 +118,7 @@ from tzrec.utils.sid.bundle import (
     MAP_ARTIFACTS,
     ArtifactEntry,
     BundleManifest,
+    artifact_entry,
     artifact_location,
     artifact_read_pattern,
     is_odps_path,
@@ -241,7 +242,6 @@ class ResolveSidCollisionsConfig:
     rate_only: bool
     odps_data_quota_name: str
     from_partition: Optional[str] = None
-    source_model: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.batch_size < 1:
@@ -301,7 +301,6 @@ class ResolveSidCollisionsConfig:
             bundle_root=args.bundle_root,
             partition=args.partition,
             from_partition=args.from_partition,
-            source_model=args.source_model,
             reader_type=args.reader_type,
             writer_type=args.writer_type,
             batch_size=args.batch_size,
@@ -459,7 +458,6 @@ class CollisionResolutionRunner:
             codebook=list(self._config.layer_sizes),
             capacity=self._config.max_items_per_codebook,
             max_observed_items_per_sid=observed,
-            source_model=self._config.source_model,
             item_id_type=str(self._item_id_type) if self._item_id_type else None,
             artifacts=artifacts,
         )
@@ -469,21 +467,19 @@ class CollisionResolutionRunner:
 
     def _artifact_entry(self, artifact: str, rows: int) -> ArtifactEntry:
         """Record where one artifact landed and what it holds."""
-        location = self._config.artifact_write_path(artifact)
-        schema = _MAP_SCHEMA if artifact in MAP_ARTIFACTS else _GROUPS_SCHEMA
-        if artifact in MAP_ARTIFACTS and is_odps_path(location):
-            table, _, partition = location.rpartition("/tables/")[2].partition("/")
-            return ArtifactEntry(
-                type="odps",
-                rows=rows,
-                schema=schema,
-                table=table,
-                partition=partition,
-            )
-        kind = "parquet"
-        if artifact in MAP_ARTIFACTS and self._default_writer_type == "CsvWriter":
-            kind = "csv"
-        return ArtifactEntry(type=kind, rows=rows, schema=schema, path=location)
+        is_map = artifact in MAP_ARTIFACTS
+        root = self._config.output_path if is_map else self._config.bundle_root
+        assert root is not None and self._config.partition is not None
+        is_csv_map = is_map and self._default_writer_type == "CsvWriter"
+        kind = "csv" if is_csv_map else "parquet"
+        return artifact_entry(
+            root,
+            artifact,
+            self._config.partition,
+            kind,
+            rows,
+            _MAP_SCHEMA if is_map else _GROUPS_SCHEMA,
+        )
 
     def _make_reader(
         self, selected_cols: List[str], input_path: Optional[str] = None
@@ -869,24 +865,6 @@ class CollisionResolutionRunner:
         return pa.array(values, type=self._item_id_type)
 
     @staticmethod
-    def _grouped_item_ids_column(
-        values: pa.Array, offsets: np.ndarray, is_csv: bool
-    ) -> pa.Array:
-        """Encode flat item IDs and offsets as one grouped output column."""
-        arrow_offsets = pa.array(offsets, type=pa.int32())
-        if not is_csv:
-            return pa.ListArray.from_arrays(arrow_offsets, values)
-
-        encoded_values = pc.cast(values, pa.string())
-        if pc.any(pc.match_substring(encoded_values, ",")).as_py():
-            raise ValueError(
-                "CSV SID group output joins item IDs with commas, so an item ID "
-                "cannot itself contain one; use parquet or ODPS for such IDs."
-            )
-        encoded_lists = pa.ListArray.from_arrays(arrow_offsets, encoded_values)
-        return pc.binary_join(encoded_lists, ",")
-
-    @staticmethod
     def _codes_column(codes: np.ndarray, is_csv: bool) -> pa.Array:
         """Encode an SID matrix for the actual output writer."""
         row_count, layer_count = codes.shape
@@ -1062,7 +1040,6 @@ class CollisionResolutionRunner:
         rows: Optional[np.ndarray] = None,
     ) -> None:
         """Write one chunk of SID groups, optionally only ``rows`` of it."""
-        is_csv = isinstance(writer, CsvWriter)
         if rows is not None:
             if rows.size == 0:
                 return
@@ -1075,9 +1052,11 @@ class CollisionResolutionRunner:
             np.cumsum(lengths, out=offsets[1:])
         writer.write(
             {
-                "codebook": self._codes_column(codes, is_csv),
-                "offset_codebook": self._offset_codes_column(codes, is_csv),
-                "itemids": self._grouped_item_ids_column(values, offsets, is_csv),
+                "codebook": self._codes_column(codes, False),
+                "offset_codebook": self._offset_codes_column(codes, False),
+                "itemids": pa.ListArray.from_arrays(
+                    pa.array(offsets, type=pa.int32()), values
+                ),
             }
         )
 
@@ -1093,7 +1072,6 @@ class CollisionResolutionRunner:
         representative_rows = grouping.row_order[offsets[:-1]]
         codes = origin_codes[representative_rows]
         if resolved_last_codes is not None:
-            codes = codes.copy()
             codes[:, -1] = resolved_last_codes[representative_rows]
         return _AppendGroups(
             keys=grouping.sid_keys,
@@ -1123,8 +1101,6 @@ class CollisionResolutionRunner:
             writer = stack.enter_context(
                 closing(self._make_group_writer(resolved_path))
             )
-            is_csv = isinstance(writer, CsvWriter)
-            delta_writer: Optional[BaseWriter] = None
             delta_writer = stack.enter_context(
                 closing(
                     self._make_group_writer(
@@ -1148,7 +1124,7 @@ class CollisionResolutionRunner:
 
             corpus_rows = 0
             delta_rows = 0
-            max_rows = _max_code_rows(is_csv, groups.codes.shape[1], group_count)
+            max_rows = _max_code_rows(False, groups.codes.shape[1], group_count)
 
             def emit_new_only(low: int, high: int) -> None:
                 """Write groups this run created in buckets nobody occupied."""
@@ -1226,11 +1202,10 @@ class CollisionResolutionRunner:
 
         offsets = grouping.offsets
         with closing(self._make_group_writer(output_path)) as writer:
-            is_csv = False
             progress = ProgressLogger(progress_description, start_n=0)
             last_progress_count = 0
             max_codebook_rows = _max_code_rows(
-                is_csv, origin_codes.shape[1], group_count
+                False, origin_codes.shape[1], group_count
             )
             for group_start, group_end in _group_chunk_bounds(
                 offsets, 0, group_count, max_codebook_rows
@@ -1392,11 +1367,6 @@ def build_parser() -> argparse.ArgumentParser:
             "Generation to append onto. Supplying it selects append mode: the new "
             "items in --input_path are placed without moving any published SID."
         ),
-    )
-    parser.add_argument(
-        "--source_model",
-        default=None,
-        help="Optional manifest field naming the quantizer that produced the SIDs.",
     )
     parser.add_argument(
         "--reader_type",

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -30,6 +30,13 @@ The random strategy intentionally preserves the legacy deterministic baseline:
 it draws with replacement from the full last-layer space. Placement skips an
 item's origin, so an origin draw or a duplicate draw is not replaced.
 
+Both the item map and the SID groups carry an ``offset_codebook`` column
+alongside ``codebook``: the same SID with each layer shifted into one
+contiguous vocabulary, so layer ``i`` is offset by ``sum(codebook[:i])``. With
+``--codebook 64,64,64`` the SID ``[1, 2, 3]`` is written as ``[1, 66, 131]``.
+It is derived from the emitted SID, so a relocated item's offset SID follows
+where it landed, not what the model predicted.
+
 It is a single-process tool -- launch it with ``python -m`` (no torchrun /
 process group). The input is a Semantic-ID table from ``tzrec.predict`` (an
 ``item_id`` column, a ``codes`` ``list<int>`` column, and -- for the default
@@ -114,6 +121,7 @@ from tzrec.utils.sid.collision import (
     prepare_collision_plan,
     sid_band_ids,
     sid_bucket_keys,
+    sid_offset_codes,
 )
 
 _MAP_WRITE_ROWS = 1_000_000
@@ -629,6 +637,12 @@ class CollisionResolutionRunner:
             flat = pc.cast(flat, self._item_id_type)
         return lengths, flat
 
+    def _offset_codes_column(self, codes: np.ndarray, is_csv: bool) -> pa.Array:
+        """Encode an SID matrix shifted into one contiguous vocabulary."""
+        return self._codes_column(
+            sid_offset_codes(codes, self._config.layer_sizes), is_csv
+        )
+
     def _align_codes_column(self, values: pa.Array, is_csv: bool) -> pa.Array:
         """Return an SID column in the encoding the destination writer needs.
 
@@ -921,6 +935,7 @@ class CollisionResolutionRunner:
                     "item_id": self._item_id_array(item_ids[selection]),
                     "origin_codebook": self._codes_column(origin_chunk, is_csv),
                     "codebook": self._codes_column(final_chunk, is_csv),
+                    "offset_codebook": self._offset_codes_column(final_chunk, is_csv),
                     "index": pa.array(result.slot_indices[selection], type=pa.int64()),
                 }
             )
@@ -957,6 +972,9 @@ class CollisionResolutionRunner:
                         batch["origin_codebook"], is_csv
                     ),
                     "codebook": self._align_codes_column(batch["codebook"], is_csv),
+                    "offset_codebook": self._offset_codes_column(
+                        self._codes_matrix(batch["codebook"]), is_csv
+                    ),
                     "index": pc.cast(batch["index"], pa.int64()),
                 }
             )
@@ -1085,6 +1103,7 @@ class CollisionResolutionRunner:
         writer.write(
             {
                 "codebook": self._codes_column(codes, is_csv),
+                "offset_codebook": self._offset_codes_column(codes, is_csv),
                 "itemids": self._grouped_item_ids_column(values, offsets, is_csv),
             }
         )
@@ -1256,6 +1275,9 @@ class CollisionResolutionRunner:
                 writer.write(
                     {
                         "codebook": self._codes_column(code_chunk, is_csv),
+                        "offset_codebook": self._offset_codes_column(
+                            code_chunk, is_csv
+                        ),
                         "itemids": self._grouped_item_ids_column(
                             flat_item_ids, local_offsets, is_csv
                         ),

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -20,18 +20,18 @@ ID. Duplicate data should still be fixed upstream.
 
 The runner retains the first capacity items in each SID bucket, attempts to
 relocate overflow items using fixed-width last-layer candidates, delegates
-placement to the pure NumPy core, and writes item-level and grouped SID results
-through TorchEasyRec readers and writers. CSV encodes each SID/candidate column
-as comma-separated codes because Arrow's CSV writer cannot serialize list
-columns; ``candidate_codes`` is a flat ``topk * n_layers`` run split by the
-``--codebook`` length. The SID groups are always parquet, so they keep native
-list columns whatever ``--writer_type`` says.
+placement to the pure NumPy core, and writes the ``item_to_sid`` and
+``sid_to_items`` artifacts through TorchEasyRec readers and writers. CSV encodes
+each SID/candidate column as comma-separated codes because Arrow's CSV writer
+cannot serialize list columns; ``candidate_codes`` is a flat ``topk * n_layers``
+run split by the ``--codebook`` length. ``sid_to_items`` is always parquet, so
+it keeps native list columns whatever ``--item_to_sid_writer_type`` says.
 
 The random strategy intentionally preserves the legacy deterministic baseline:
 it draws with replacement from the full last-layer space. Placement skips an
 item's origin, so an origin draw or a duplicate draw is not replaced.
 
-Both the item map and the SID groups carry an ``offset_codebook`` column
+Both item_to_sid and sid_to_items carry an ``offset_codebook`` column
 alongside ``codebook``: the same SID with each layer shifted into one
 contiguous vocabulary, so layer ``i`` is offset by ``sum(codebook[:i])``. With
 ``--codebook 64,64,64`` the SID ``[1, 2, 3]`` is written as ``[1, 66, 131]``.
@@ -50,18 +50,19 @@ Example::
         --input_path 'sid_predict_output/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map \
-        --bundle_root sid_collision/bundle \
-        --partition v1
+        --output_path sid_collision \
+        --generation v1
 
-Artifacts land at ``<root>/<artifact>/<partition>``: the item map under
-``--output_path``, the SID groups and the manifest under ``--bundle_root``. The
-manifest is written last, so its presence marks the generation complete.
+Artifacts land at ``<root>/<generation>/<artifact>``, so one generation is one
+self-contained directory. Everything sits under ``--output_path`` unless
+``--item_to_sid_root`` moves the item-to-SID family to its own storage, such as
+an ODPS table. The manifest is written last, so its presence marks the
+generation complete.
 
 Append mode
 -----------
 
-Supplying ``--from_partition`` switches the tool to appending new items onto an
+Supplying ``--from_generation`` switches the tool to appending new items onto an
 already-published generation: ``--input_path`` then holds only the new items,
 and **no published SID is ever moved**. Published items are never rows in the
 plan, so they cannot be re-ranked; they are read only to be copied into the
@@ -72,14 +73,13 @@ published occupancy instead of restarting at one::
         --input_path 'sid_predict_new_20260731/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map \
-        --bundle_root sid_collision/bundle \
-        --partition v2 --from_partition v1
+        --output_path sid_collision \
+        --generation v2 --from_generation v1
 
-An append also writes ``delta_item_to_sid_map`` and
-``delta_sid_to_item_groups``, holding this run's rows and every bucket it
-touched. Both corpus outputs stay complete, so generation *n* is exactly what
-generation *n+1* reads at ``--from_partition``.
+An append also writes ``delta_item_to_sid`` and ``delta_sid_to_items``, holding
+this run's rows and every bucket it touched. Both corpus outputs stay complete,
+so generation *n* is exactly what generation *n+1* reads at
+``--from_generation``.
 
 """
 
@@ -126,8 +126,8 @@ from tzrec.utils.sid.collision import (
     sid_offset_codes,
 )
 
-_MAP_WRITE_ROWS = 1_000_000
-_GROUP_WRITE_ITEMS = 1_000_000
+_ITEM_TO_SID_WRITE_ROWS = 1_000_000
+_SID_TO_ITEMS_WRITE_SIZE = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
 _NO_ROWS = np.empty(0, dtype=np.int64)
 
@@ -142,7 +142,7 @@ def _is_list_column(values: pa.Array) -> bool:
 
 
 def _require_single_process() -> None:
-    """Reject multi-process launches; the tool writes one complete map itself."""
+    """Reject multi-process launches; the tool writes one complete corpus itself."""
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
     rank = int(os.environ.get("RANK", "0"))
     if world_size != 1 or rank != 0:
@@ -194,10 +194,10 @@ class ResolveSidCollisionsConfig:
 
     input_path: str
     output_path: Optional[str]
-    bundle_root: Optional[str]
-    partition: Optional[str]
+    item_to_sid_root: Optional[str]
+    generation: Optional[str]
     reader_type: Optional[str]
-    writer_type: Optional[str]
+    item_to_sid_writer_type: Optional[str]
     batch_size: int
     progress_interval: int
     item_id_field: str
@@ -209,7 +209,7 @@ class ResolveSidCollisionsConfig:
     random_num_candidates: int
     rate_only: bool
     odps_data_quota_name: str
-    from_partition: Optional[str] = None
+    from_generation: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.batch_size < 1:
@@ -224,30 +224,66 @@ class ResolveSidCollisionsConfig:
             )
         if self.strategy not in {"candidate", "random"}:
             raise ValueError(f"unsupported strategy: {self.strategy!r}.")
-        for name in ("output_path", "bundle_root", "partition"):
-            if not self.rate_only and not getattr(self, name):
-                raise ValueError(f"{name} is required unless rate_only is set.")
-        if self.from_partition is not None and self.from_partition == self.partition:
+        if not self.rate_only and not self.generation:
+            raise ValueError("generation is required unless rate_only is set.")
+        if not self.output_path and (not self.rate_only or self.is_append):
             raise ValueError(
-                f"from_partition and partition are both {self.partition!r}; writing "
-                "over the artifacts being read destroys them mid-run."
+                "output_path is required unless rate_only is set without "
+                "from_generation; an append reads the published sid_to_items and "
+                "manifest from it."
+            )
+        if self.from_generation is not None and self.from_generation == self.generation:
+            raise ValueError(
+                f"from_generation and generation are both {self.generation!r}; "
+                "writing over the artifacts being read destroys them mid-run."
             )
 
+        # Eagerly build both so their validation fails here rather than lazily
+        # inside run(), and before output_path is treated as a local path below.
+        _ = self.resolution_config
+        _ = self.layout
+
         paths = [self.input_path]
-        paths.extend(path for path in (self.output_path, self.bundle_root) if path)
+        if self.output_path:
+            paths.append(self.output_path)
+            paths.extend(self._checkable_item_to_sid_root(self.output_path))
         has_conflict, conflict_message = check_path_conflict(paths)
         if has_conflict:
             raise ValueError(conflict_message)
 
-        # Eagerly build both so their validation fails here rather than lazily
-        # inside run().
-        _ = self.resolution_config
-        _ = self.layout
+    def _checkable_item_to_sid_root(self, output_path: str) -> List[str]:
+        """Return ``item_to_sid_root`` for conflict checking, if it is doing work.
+
+        Pointing it at ``output_path`` makes the flag a no-op, and feeding both
+        to the conflict check would reject the run for colliding with itself.
+        ``output_path`` is always local, because the layout refuses an ODPS one.
+        """
+        root = self.item_to_sid_root
+        if not root:
+            return []
+        if is_odps_path(root):
+            return [root]
+        inner, outer = os.path.realpath(root), os.path.realpath(output_path)
+        if inner == outer:
+            logger.warning(
+                "--item_to_sid_root %s is the same location as --output_path, so "
+                "the flag has no effect and is ignored",
+                root,
+            )
+            return []
+        if os.path.commonpath([inner, outer]) == outer:
+            logger.warning(
+                "--item_to_sid_root %s sits inside --output_path %s, where the "
+                "generation directories live; writing there anyway",
+                root,
+                output_path,
+            )
+        return [root]
 
     @property
     def is_append(self) -> bool:
         """Whether this run appends onto an already-published generation."""
-        return self.from_partition is not None
+        return self.from_generation is not None
 
     @classmethod
     def from_namespace(cls, args: argparse.Namespace) -> "ResolveSidCollisionsConfig":
@@ -262,11 +298,11 @@ class ResolveSidCollisionsConfig:
         return cls(
             input_path=args.input_path,
             output_path=args.output_path,
-            bundle_root=args.bundle_root,
-            partition=args.partition,
-            from_partition=args.from_partition,
+            item_to_sid_root=args.item_to_sid_root,
+            generation=args.generation,
+            from_generation=args.from_generation,
             reader_type=args.reader_type,
-            writer_type=args.writer_type,
+            item_to_sid_writer_type=args.item_to_sid_writer_type,
             batch_size=args.batch_size,
             progress_interval=args.progress_interval,
             item_id_field=args.item_id_field,
@@ -284,11 +320,10 @@ class ResolveSidCollisionsConfig:
     def layout(self) -> BundleLayout:
         """Every artifact location this run reads and writes."""
         return BundleLayout(
-            map_root=self.output_path,
-            bundle_root=self.bundle_root,
-            partition=self.partition,
-            from_partition=self.from_partition,
-            reader_type=self.reader_type,
+            output_path=self.output_path,
+            item_to_sid_root=self.item_to_sid_root or self.output_path,
+            generation=self.generation,
+            from_generation=self.from_generation,
         )
 
     @cached_property
@@ -323,9 +358,12 @@ class CollisionResolutionRunner:
         self._bundle = Bundle(config.layout)
 
     def run(self) -> CollisionResolutionStats:
-        """Read, resolve collisions, and write the resulting SID map."""
+        """Read, resolve collisions, and publish the resulting generation."""
         _require_single_process()
         self._check_input_locations()
+        self._bundle.check_prior_compatible(
+            list(self._config.layer_sizes), self._config.max_items_per_codebook
+        )
         item_ids, codes = self._load_codes()
         if codes.shape[1] != len(self._config.layer_sizes):
             raise ValueError(
@@ -350,12 +388,12 @@ class CollisionResolutionRunner:
         del candidate_last_codes
 
         if self._config.rate_only:
-            logger.info("rate_only: skipping map and SID group writes")
+            logger.info("rate_only: skipping item_to_sid and sid_to_items writes")
             del plan
         else:
-            self._write_group_outputs(item_ids, codes, plan, result)
+            self._write_sid_to_items_outputs(item_ids, codes, plan, result)
             del plan
-            self._write_map(item_ids, codes, result)
+            self._write_item_to_sid(item_ids, codes, result)
             self._write_manifest(result)
 
         logger.info("SID collision resolution finished: %s", result.stats)
@@ -496,7 +534,7 @@ class CollisionResolutionRunner:
         reader = self._make_reader(
             [self._config.item_id_field, self._config.code_field]
         )
-        self._resolved_writer_type = self._config.writer_type or (
+        self._resolved_writer_type = self._config.item_to_sid_writer_type or (
             reader.__class__.__name__.replace("Reader", "Writer")
         )
         progress = ProgressLogger("Reading SID input", start_n=0)
@@ -597,7 +635,7 @@ class CollisionResolutionRunner:
 
         if candidates is None:
             raise ValueError(
-                "map has overflow items but candidate_codes yielded no candidates."
+                "the plan has overflow items but candidate_codes yielded no candidates."
             )
         item_id_lookup.broadcast_duplicate_targets(candidates)
         item_id_lookup.broadcast_duplicate_targets(seen)
@@ -620,16 +658,18 @@ class CollisionResolutionRunner:
 
         layer_sizes = self._config.layer_sizes
         prior, published_items = self._load_prior_occupancy(
-            self._bundle.prior_groups_path, sid_band_ids(codes, layer_sizes), item_ids
+            self._bundle.prior_sid_to_items_path,
+            sid_band_ids(codes, layer_sizes),
+            item_ids,
         )
-        self._check_existing_map_size(published_items)
+        self._check_existing_item_to_sid_size(published_items)
         logger.info(
             "append mode: %d new items onto %d published items in %d touched "
-            "buckets, from partition %s",
+            "buckets, from generation %s",
             item_ids.shape[0],
             published_items,
             prior.bucket_keys.shape[0],
-            self._config.from_partition,
+            self._config.from_generation,
         )
         return prior
 
@@ -672,7 +712,7 @@ class CollisionResolutionRunner:
         if values.type != self._item_id_type:
             raise ValueError(
                 f"{source} item ID type {values.type} differs from the new-items "
-                f"input type {self._item_id_type}; the merged map cannot mix "
+                f"input type {self._item_id_type}; the merged item_to_sid cannot mix "
                 "them. Re-export the state or the prediction with one type."
             )
 
@@ -693,13 +733,22 @@ class CollisionResolutionRunner:
         for batch in self._iter_state_batches(
             path,
             ["codebook", "itemids"],
-            "Reading published SID groups",
+            "Reading published sid_to_items",
         ):
-            keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
+            codes = self._codes_matrix(batch["codebook"])
+            if codes.shape[1] != len(layer_sizes):
+                raise ValueError(
+                    f"generation {self._config.from_generation!r} holds "
+                    f"{codes.shape[1]}-layer SIDs but --codebook has "
+                    f"{len(layer_sizes)}; its manifest disagrees with its own "
+                    "artifacts, so every published SID would be re-keyed under "
+                    "the wrong radix."
+                )
+            keys = sid_bucket_keys(codes, layer_sizes)
             if keys.size:
                 if int(keys[0]) <= previous_max_key or np.any(keys[1:] <= keys[:-1]):
                     raise ValueError(
-                        "existing SID groups must be ascending by SID key with one "
+                        "existing sid_to_items must be ascending by SID key with one "
                         "row per bucket; the merge would otherwise emit duplicate "
                         "buckets."
                     )
@@ -735,18 +784,19 @@ class CollisionResolutionRunner:
             published_items,
         )
 
-    def _check_existing_map_size(self, published_items: int) -> None:
+    def _check_existing_item_to_sid_size(self, published_items: int) -> None:
         """Reject a published map whose size disagrees with the groups."""
-        if self._config.output_path is None:
-            return
-        map_rows = 0
+        item_to_sid_rows = 0
         for batch in self._iter_state_batches(
-            self._bundle.prior_map_path, ["index"], "Counting published SID map"
+            self._bundle.prior_item_to_sid_path,
+            ["index"],
+            "Counting published item_to_sid",
         ):
-            map_rows += len(batch["index"])
-        if map_rows != published_items:
+            item_to_sid_rows += len(batch["index"])
+        if item_to_sid_rows != published_items:
             raise ValueError(
-                f"existing map holds {map_rows} rows but the existing groups hold "
+                f"existing item_to_sid holds {item_to_sid_rows} rows but the existing "
+                f"sid_to_items hold "
                 f"{published_items} item IDs; one of the two artifacts is "
                 "incomplete or they come from different generations of this tool. "
                 "Appending onto them would drop published items or reuse their "
@@ -801,7 +851,7 @@ class CollisionResolutionRunner:
         )
         return pa.ListArray.from_arrays(offsets, values)
 
-    def _write_new_map_rows(
+    def _write_new_item_to_sid_rows(
         self,
         writer: BaseWriter,
         item_ids: np.ndarray,
@@ -818,7 +868,9 @@ class CollisionResolutionRunner:
         is_csv = self._resolved_writer_type == "CsvWriter"
         output_count = item_ids.shape[0]
         last_progress_count = written
-        write_chunk = _max_code_rows(is_csv, origin_codes.shape[1], _MAP_WRITE_ROWS)
+        write_chunk = _max_code_rows(
+            is_csv, origin_codes.shape[1], _ITEM_TO_SID_WRITE_ROWS
+        )
         for start in range(0, output_count, write_chunk):
             end = min(start + write_chunk, output_count)
             selection = slice(start, end)
@@ -840,19 +892,19 @@ class CollisionResolutionRunner:
                 last_progress_count = written
         return output_count
 
-    def _stream_existing_map_rows(self, writer: BaseWriter) -> int:
-        """Copy every published map row into the merged output unchanged."""
+    def _stream_existing_item_to_sid_rows(self, writer: BaseWriter) -> int:
+        """Copy every published item_to_sid row into the merged output unchanged."""
         if not self._config.is_append:
             return 0
-        path = self._bundle.prior_map_path
+        path = self._bundle.prior_item_to_sid_path
         is_csv = self._resolved_writer_type == "CsvWriter"
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
         for batch in self._iter_state_batches(
-            path, fields, "Copying published item map"
+            path, fields, "Copying published item_to_sid"
         ):
             item_id_column = batch["item_id"]
-            self._check_state_item_id_type(item_id_column, "existing SID map")
+            self._check_state_item_id_type(item_id_column, "existing item_to_sid")
             writer.write(
                 {
                     "item_id": item_id_column,
@@ -869,41 +921,41 @@ class CollisionResolutionRunner:
             written += len(item_id_column)
         return written
 
-    def _write_map(
+    def _write_item_to_sid(
         self,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         result: CollisionResolutionResult,
     ) -> None:
-        """Write the corpus-complete item map.
+        """Write the corpus-complete item_to_sid.
 
         In append mode the published rows are streamed through first and this
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        with closing(self._make_writer(self._bundle.map_path)) as writer:
-            progress = ProgressLogger("Writing resolved item map", start_n=0)
-            written = self._stream_existing_map_rows(writer)
-            written += self._write_new_map_rows(
+        with closing(self._make_writer(self._bundle.item_to_sid_path)) as writer:
+            progress = ProgressLogger("Writing resolved item_to_sid", start_n=0)
+            written = self._stream_existing_item_to_sid_rows(writer)
+            written += self._write_new_item_to_sid_rows(
                 writer, item_ids, origin_codes, result, progress, written
             )
-            self._bundle.record_map(written)
+            self._bundle.record_item_to_sid(written)
 
         if not self._config.is_append:
             return
-        with closing(self._make_writer(self._bundle.delta_map_path)) as writer:
-            self._bundle.record_delta_map(
-                self._write_new_map_rows(
+        with closing(self._make_writer(self._bundle.delta_item_to_sid_path)) as writer:
+            self._bundle.record_delta_item_to_sid(
+                self._write_new_item_to_sid_rows(
                     writer,
                     item_ids,
                     origin_codes,
                     result,
-                    ProgressLogger("Writing delta item map", start_n=0),
+                    ProgressLogger("Writing delta item_to_sid", start_n=0),
                     0,
                 )
             )
 
-    def _write_group_outputs(
+    def _write_sid_to_items_outputs(
         self,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
@@ -916,13 +968,13 @@ class CollisionResolutionRunner:
         else:
             grouping = build_original_item_grouping(plan)
         write = (
-            self._write_merged_sid_groups
+            self._write_merged_sid_to_items
             if self._config.is_append
-            else self._write_sid_groups
+            else self._write_sid_to_items
         )
         write(item_ids, origin_codes, grouping, result.resolved_last_codes)
 
-    def _emit_group_rows(
+    def _emit_sid_to_items_rows(
         self,
         writer: BaseWriter,
         codes: np.ndarray,
@@ -930,10 +982,10 @@ class CollisionResolutionRunner:
         values: pa.Array,
         rows: Optional[np.ndarray] = None,
     ) -> int:
-        """Write one chunk of SID groups, optionally only ``rows`` of it.
+        """Write one chunk of sid_to_items, optionally only ``rows`` of it.
 
         Returns:
-            How many group rows were written.
+            How many rows were written.
         """
         itemids = pa.ListArray.from_arrays(pa.array(offsets, type=pa.int32()), values)
         if rows is not None:
@@ -970,16 +1022,16 @@ class CollisionResolutionRunner:
             item_ids=self._item_id_array(item_ids[grouping.row_order]),
         )
 
-    def _write_merged_sid_groups(
+    def _write_merged_sid_to_items(
         self,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         grouping: CodebookItemGrouping,
         resolved_last_codes: np.ndarray,
     ) -> None:
-        """Merge this run's groups into the published groups and write both."""
-        resolved_path = self._bundle.groups_path
-        existing_path = self._bundle.prior_groups_path
+        """Merge this run's buckets into the published sid_to_items, writing both."""
+        resolved_path = self._bundle.sid_to_items_path
+        existing_path = self._bundle.prior_sid_to_items_path
         layer_sizes = self._config.layer_sizes
         groups = self._build_append_groups(
             item_ids, origin_codes, grouping, resolved_last_codes
@@ -994,7 +1046,9 @@ class CollisionResolutionRunner:
             )
             delta_writer = stack.enter_context(
                 closing(
-                    self._make_writer(self._bundle.delta_groups_path, "ParquetWriter")
+                    self._make_writer(
+                        self._bundle.delta_sid_to_items_path, "ParquetWriter"
+                    )
                 )
             )
 
@@ -1006,15 +1060,17 @@ class CollisionResolutionRunner:
             ) -> None:
                 """Write one chunk to the corpus output and the delta output."""
                 nonlocal corpus_rows, delta_rows
-                corpus_rows += self._emit_group_rows(writer, codes, offsets, values)
-                delta_rows += self._emit_group_rows(
+                corpus_rows += self._emit_sid_to_items_rows(
+                    writer, codes, offsets, values
+                )
+                delta_rows += self._emit_sid_to_items_rows(
                     delta_writer, codes, offsets, values, rows
                 )
 
             max_rows = _max_code_rows(False, groups.codes.shape[1], group_count)
 
             def emit_new_only(low: int, high: int) -> None:
-                """Write groups this run created in buckets nobody occupied."""
+                """Write rows this run created in buckets nobody occupied."""
                 for start, stop in _group_chunk_bounds(
                     groups.offsets, low, high, max_rows
                 ):
@@ -1031,7 +1087,7 @@ class CollisionResolutionRunner:
             for batch in self._iter_state_batches(
                 existing_path,
                 ["codebook", "itemids"],
-                "Writing merged SID item groups",
+                "Writing merged sid_to_items",
             ):
                 batch_codes = self._codes_matrix(batch["codebook"])
                 batch_keys = sid_bucket_keys(batch_codes, layer_sizes)
@@ -1045,8 +1101,8 @@ class CollisionResolutionRunner:
                     batch["itemids"]
                 )
                 if low == high:
-                    # No new group lands in this batch's key range, so the merge
-                    # would rebuild the batch it was handed.
+                    # No new bucket lands in this batch's key range, so the
+                    # merge would rebuild the batch it was handed.
                     batch_offsets = np.zeros(batch_keys.shape[0] + 1, dtype=np.int64)
                     np.cumsum(batch_lengths, out=batch_offsets[1:])
                     emit(batch_codes, batch_offsets, batch_values, _NO_ROWS)
@@ -1064,17 +1120,17 @@ class CollisionResolutionRunner:
                     )
                 cursor = high
             emit_new_only(cursor, group_count)
-        self._bundle.record_groups(corpus_rows)
-        self._bundle.record_delta_groups(delta_rows)
+        self._bundle.record_sid_to_items(corpus_rows)
+        self._bundle.record_delta_sid_to_items(delta_rows)
 
-    def _write_sid_groups(
+    def _write_sid_to_items(
         self,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         grouping: CodebookItemGrouping,
         resolved_last_codes: np.ndarray,
     ) -> None:
-        """Write codebook-to-item-ID groups in SID and slot order.
+        """Write sid_to_items in SID and slot order.
 
         Args:
             item_ids: Input item IDs in original row order.
@@ -1083,14 +1139,14 @@ class CollisionResolutionRunner:
             resolved_last_codes: Final last-layer value of every input row.
 
         Raises:
-            ValueError: If one group exceeds Arrow list offset capacity.
+            ValueError: If one bucket exceeds Arrow list offset capacity.
         """
-        output_path = self._bundle.groups_path
-        progress_description = "Writing resolved SID item groups"
+        output_path = self._bundle.sid_to_items_path
+        progress_description = "Writing resolved sid_to_items"
         group_count = grouping.counts.shape[0]
         written = 0
         if np.any(grouping.counts > _ARROW_LIST_OFFSET_MAX):
-            raise ValueError("one SID group exceeds Arrow list offset capacity.")
+            raise ValueError("one SID bucket exceeds Arrow list offset capacity.")
 
         offsets = grouping.offsets
         with closing(self._make_writer(output_path, "ParquetWriter")) as writer:
@@ -1109,7 +1165,7 @@ class CollisionResolutionRunner:
                 representative_rows = grouping.row_order[offsets[group_start:group_end]]
                 code_chunk = origin_codes[representative_rows]
                 code_chunk[:, -1] = resolved_last_codes[representative_rows]
-                written += self._emit_group_rows(
+                written += self._emit_sid_to_items_rows(
                     writer,
                     code_chunk,
                     local_offsets,
@@ -1121,7 +1177,7 @@ class CollisionResolutionRunner:
                         suffix=f"{child_end} samples processed",
                     )
                     last_progress_count = child_end
-        self._bundle.record_groups(written)
+        self._bundle.record_sid_to_items(written)
 
 
 def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
@@ -1136,7 +1192,7 @@ def _group_chunk_bounds(
 ) -> Iterator[Tuple[int, int]]:
     """Split ``[low, high)`` groups into writable ``(start, stop)`` chunks."""
     while low < high:
-        child_limit = int(offsets[low]) + _GROUP_WRITE_ITEMS
+        child_limit = int(offsets[low]) + _SID_TO_ITEMS_WRITE_SIZE
         stop = int(np.searchsorted(offsets, child_limit, side="right") - 1)
         stop = min(max(stop, low + 1), low + max_rows, high)
         yield low, stop
@@ -1233,26 +1289,30 @@ def build_parser() -> argparse.ArgumentParser:
         "--output_path",
         default=None,
         help=(
-            "Root of the item-map family. May be an odps:// table or a file/OSS "
-            "path; artifacts land at <root>/<artifact>/<partition>. Required "
-            "unless --rate_only is set."
+            "Bundle root. Artifacts land at <root>/<generation>/<artifact>, so "
+            "one generation is one self-contained directory. Holds the SID "
+            "sid_to_items and the manifest, which are always files, so it can be a "
+            "file or OSS path but never an odps:// table. Required unless "
+            "--rate_only is set without --from_generation, since an append "
+            "reads the published groups and manifest from it."
         ),
     )
     parser.add_argument(
-        "--bundle_root",
+        "--item_to_sid_root",
         default=None,
         help=(
-            "Root of the serving set -- SID groups and the manifest. Always a "
-            "file or OSS path. Required unless --rate_only is set."
+            "Root for the item_to_sid family only, when it needs storage of its "
+            "own -- an odps:// table, say. Defaults to --output_path; pointing "
+            "it at the same place is ignored with a warning."
         ),
     )
     parser.add_argument(
-        "--partition",
+        "--generation",
         default=None,
         help="Generation being written, e.g. 'v2'. Required unless --rate_only.",
     )
     parser.add_argument(
-        "--from_partition",
+        "--from_generation",
         default=None,
         help=(
             "Generation to append onto. Supplying it selects append mode: the new "
@@ -1263,12 +1323,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--reader_type",
         choices=["CsvReader", "ParquetReader", "OdpsReader"],
         default=None,
+        help=(
+            "Format of --input_path, used only when the path carries no .csv / "
+            ".parquet / odps:// marker. The published artifacts an append reads "
+            "are opened in the format their own manifest records."
+        ),
     )
     parser.add_argument(
-        "--writer_type",
+        "--item_to_sid_writer_type",
         choices=["CsvWriter", "ParquetWriter", "OdpsWriter"],
         default=None,
-        help="Output writer; defaults to matching the input reader.",
+        help=(
+            "Writer for the item_to_sid family only; defaults to matching the "
+            "input reader. The SID groups and the manifest are always parquet "
+            "and JSON."
+        ),
     )
     parser.add_argument(
         "--batch_size",

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -753,20 +753,19 @@ class CollisionResolutionRunner:
                 "slots."
             )
 
-    def _make_writer(self, output_path: str) -> BaseWriter:
-        """Create a repository writer for one independently resolved output."""
-        if self._resolved_writer_type is None:
+    def _make_writer(
+        self, output_path: str, writer_type: Optional[str] = None
+    ) -> BaseWriter:
+        """Create a repository writer, defaulting to the resolved writer type."""
+        writer_type = writer_type or self._resolved_writer_type
+        if writer_type is None:
             raise RuntimeError("writer type is unavailable before reading input.")
         return create_writer(
             output_path,
-            writer_type=self._resolved_writer_type,
+            writer_type=writer_type,
             quota_name=self._config.odps_data_quota_name,
             world_size=1,
         )
-
-    def _make_group_writer(self, output_path: str) -> BaseWriter:
-        """Create the writer for a serving-set artifact, which is always parquet."""
-        return create_writer(output_path, writer_type="ParquetWriter", world_size=1)
 
     def _item_id_array(self, values: np.ndarray) -> pa.Array:
         """Encode item IDs with the input Arrow type preserved."""
@@ -991,10 +990,12 @@ class CollisionResolutionRunner:
         delta_rows = 0
         with ExitStack() as stack:
             writer = stack.enter_context(
-                closing(self._make_group_writer(resolved_path))
+                closing(self._make_writer(resolved_path, "ParquetWriter"))
             )
             delta_writer = stack.enter_context(
-                closing(self._make_group_writer(self._bundle.delta_groups_path))
+                closing(
+                    self._make_writer(self._bundle.delta_groups_path, "ParquetWriter")
+                )
             )
 
             def emit(
@@ -1092,7 +1093,7 @@ class CollisionResolutionRunner:
             raise ValueError("one SID group exceeds Arrow list offset capacity.")
 
         offsets = grouping.offsets
-        with closing(self._make_group_writer(output_path)) as writer:
+        with closing(self._make_writer(output_path, "ParquetWriter")) as writer:
             progress = ProgressLogger(progress_description, start_n=0)
             last_progress_count = 0
             max_codebook_rows = _max_code_rows(

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -238,8 +238,8 @@ class ResolveSidCollisionsConfig:
                 "writing over the artifacts being read destroys them mid-run."
             )
 
-        # Eagerly build both so their validation fails here rather than lazily
-        # inside run(), and before output_path is treated as a local path below.
+        # Validate here, not lazily in run(), and before output_path is
+        # treated as a local path below.
         _ = self.resolution_config
         _ = self.layout
 
@@ -263,21 +263,13 @@ class ResolveSidCollisionsConfig:
             return []
         if is_odps_path(root):
             return [root]
-        inner, outer = os.path.realpath(root), os.path.realpath(output_path)
-        if inner == outer:
+        if os.path.realpath(root) == os.path.realpath(output_path):
             logger.warning(
                 "--item_to_sid_root %s is the same location as --output_path, so "
                 "the flag has no effect and is ignored",
                 root,
             )
             return []
-        if os.path.commonpath([inner, outer]) == outer:
-            logger.warning(
-                "--item_to_sid_root %s sits inside --output_path %s, where the "
-                "generation directories live; writing there anyway",
-                root,
-                output_path,
-            )
         return [root]
 
     @property
@@ -735,16 +727,7 @@ class CollisionResolutionRunner:
             ["codebook", "itemids"],
             "Reading published sid_to_items",
         ):
-            codes = self._codes_matrix(batch["codebook"])
-            if codes.shape[1] != len(layer_sizes):
-                raise ValueError(
-                    f"generation {self._config.from_generation!r} holds "
-                    f"{codes.shape[1]}-layer SIDs but --codebook has "
-                    f"{len(layer_sizes)}; its manifest disagrees with its own "
-                    "artifacts, so every published SID would be re-keyed under "
-                    "the wrong radix."
-                )
-            keys = sid_bucket_keys(codes, layer_sizes)
+            keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
             if keys.size:
                 if int(keys[0]) <= previous_max_key or np.any(keys[1:] <= keys[:-1]):
                     raise ValueError(
@@ -1101,8 +1084,7 @@ class CollisionResolutionRunner:
                     batch["itemids"]
                 )
                 if low == high:
-                    # No new bucket lands in this batch's key range, so the
-                    # merge would rebuild the batch it was handed.
+                    # No new bucket in range: the merge would rebuild the batch.
                     batch_offsets = np.zeros(batch_keys.shape[0] + 1, dtype=np.int64)
                     np.cumsum(batch_lengths, out=batch_offsets[1:])
                     emit(batch_codes, batch_offsets, batch_values, _NO_ROWS)

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -51,40 +51,44 @@ Example::
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
         --output_path sid_collision/map \
-        --resolved_sid_groups_output_path sid_collision/resolved_groups
+        --bundle_root sid_collision/bundle \
+        --partition v1
 
-To also write the optional original-SID audit grouping, add
-``--original_sid_groups_output_path sid_collision/original_groups``.
+Artifacts land at ``<root>/<artifact>/<partition>``: the item map under
+``--output_path``, the SID groups and the manifest under ``--bundle_root``. The
+manifest is written last, so its presence marks the generation complete.
 
 Append mode
 -----------
 
-Supplying ``--existing_sid_groups_path`` switches the tool to appending new
-items onto an already-published corpus: ``--input_path`` then holds only the
-new items, and **no published SID is ever moved**. Published items are never
-rows in the plan, so they cannot be re-ranked; they are read only to be copied
-into the merged outputs. A new item continues its bucket's slot numbering from
-the published occupancy instead of restarting at one::
+Supplying ``--from_partition`` switches the tool to appending new items onto an
+already-published generation: ``--input_path`` then holds only the new items,
+and **no published SID is ever moved**. Published items are never rows in the
+plan, so they cannot be re-ranked; they are read only to be copied into the
+merged outputs. A new item continues its bucket's slot numbering from the
+published occupancy instead of restarting at one::
 
     python -m tzrec.tools.sid.resolve_sid_collisions \
         --input_path 'sid_predict_new_20260731/*.parquet' \
-        --existing_sid_map_path    'sid_collision/map/*.parquet' \
-        --existing_sid_groups_path 'sid_collision/resolved_groups/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map_20260731 \
-        --resolved_sid_groups_output_path sid_collision/resolved_groups_20260731 \
-        --delta_map_output_path sid_collision/delta_20260731
+        --output_path sid_collision/map \
+        --bundle_root sid_collision/bundle \
+        --partition v2 --from_partition v1
 
-Both outputs stay corpus-complete, so generation *n*'s outputs are exactly
-generation *n+1*'s ``--existing_*`` inputs; writers truncate, so each
-generation needs a fresh output directory.
+An append also writes ``delta_item_to_sid_map`` and
+``delta_sid_to_item_groups``, holding this run's rows and every bucket it
+touched. Both corpus outputs stay complete, so generation *n* is exactly what
+generation *n+1* reads at ``--from_partition``.
+
 """
 
 from __future__ import annotations
 
 import argparse
+import glob
 import os
+import uuid
 from contextlib import ExitStack, closing
 from dataclasses import dataclass
 from functools import cached_property
@@ -105,6 +109,22 @@ from tzrec.datasets.dataset import (
 )
 from tzrec.utils.logging_util import ProgressLogger, logger
 from tzrec.utils.path_util import check_path_conflict
+from tzrec.utils.sid.bundle import (
+    DELTA_GROUPS_ARTIFACT,
+    DELTA_MAP_ARTIFACT,
+    GROUPS_ARTIFACT,
+    GROUPS_ARTIFACTS,
+    MAP_ARTIFACT,
+    MAP_ARTIFACTS,
+    ArtifactEntry,
+    BundleManifest,
+    artifact_location,
+    artifact_read_pattern,
+    is_odps_path,
+    manifest_path,
+    read_manifest,
+    write_manifest,
+)
 from tzrec.utils.sid.collision import (
     CodebookItemGrouping,
     CollisionPlan,
@@ -128,6 +148,19 @@ from tzrec.utils.sid.collision import (
 _MAP_WRITE_ROWS = 1_000_000
 _GROUP_WRITE_ITEMS = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
+
+_MAP_SCHEMA = {
+    "item_id": "item id type of the input",
+    "origin_codebook": "list<int64>",
+    "codebook": "list<int64>",
+    "offset_codebook": "list<int64>",
+    "index": "int64",
+}
+_GROUPS_SCHEMA = {
+    "codebook": "list<int64>",
+    "offset_codebook": "list<int64>",
+    "itemids": "list<item id type of the input>",
+}
 
 
 def _is_list_column(values: pa.Array) -> bool:
@@ -192,8 +225,8 @@ class ResolveSidCollisionsConfig:
 
     input_path: str
     output_path: Optional[str]
-    original_sid_groups_output_path: Optional[str]
-    resolved_sid_groups_output_path: Optional[str]
+    bundle_root: Optional[str]
+    partition: Optional[str]
     reader_type: Optional[str]
     writer_type: Optional[str]
     batch_size: int
@@ -207,10 +240,8 @@ class ResolveSidCollisionsConfig:
     random_num_candidates: int
     rate_only: bool
     odps_data_quota_name: str
-    existing_sid_map_path: Optional[str] = None
-    existing_sid_groups_path: Optional[str] = None
-    delta_map_output_path: Optional[str] = None
-    delta_sid_groups_output_path: Optional[str] = None
+    from_partition: Optional[str] = None
+    source_model: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.batch_size < 1:
@@ -225,32 +256,22 @@ class ResolveSidCollisionsConfig:
             )
         if self.strategy not in {"candidate", "random"}:
             raise ValueError(f"unsupported strategy: {self.strategy!r}.")
-        if not self.rate_only and not self.output_path:
-            raise ValueError("output_path is required unless rate_only is set.")
-        if not self.rate_only and not self.resolved_sid_groups_output_path:
+        for name in ("output_path", "bundle_root", "partition"):
+            if not self.rate_only and not getattr(self, name):
+                raise ValueError(f"{name} is required unless rate_only is set.")
+        if self.bundle_root and is_odps_path(self.bundle_root):
             raise ValueError(
-                "resolved_sid_groups_output_path is required unless rate_only is set."
+                "bundle_root holds the SID groups and the manifest, which are "
+                f"always files; got {self.bundle_root!r}."
             )
-        if self.is_append and not self.rate_only and not self.existing_sid_map_path:
+        if self.from_partition is not None and self.from_partition == self.partition:
             raise ValueError(
-                "existing_sid_map_path is required in append mode unless rate_only "
-                "is set; without it the merged map would hold only the new items."
+                f"from_partition and partition are both {self.partition!r}; writing "
+                "over the artifacts being read destroys them mid-run."
             )
 
-        candidates = [
-            self.output_path,
-            self.resolved_sid_groups_output_path,
-            self.original_sid_groups_output_path,
-        ]
-        if self.is_append:
-            candidates += [
-                self.existing_sid_map_path,
-                self.existing_sid_groups_path,
-                self.delta_map_output_path,
-                self.delta_sid_groups_output_path,
-            ]
         paths = [self.input_path]
-        paths.extend(path for path in candidates if path)
+        paths.extend(path for path in (self.output_path, self.bundle_root) if path)
         has_conflict, conflict_message = check_path_conflict(paths)
         if has_conflict:
             raise ValueError(conflict_message)
@@ -261,12 +282,8 @@ class ResolveSidCollisionsConfig:
 
     @property
     def is_append(self) -> bool:
-        """Whether this run appends onto an already-published corpus.
-
-        The previous round's resolved groups is the occupancy authority and is
-        required by every append, so its presence selects the mode.
-        """
-        return self.existing_sid_groups_path is not None
+        """Whether this run appends onto an already-published generation."""
+        return self.from_partition is not None
 
     @classmethod
     def from_namespace(cls, args: argparse.Namespace) -> "ResolveSidCollisionsConfig":
@@ -281,12 +298,10 @@ class ResolveSidCollisionsConfig:
         return cls(
             input_path=args.input_path,
             output_path=args.output_path,
-            original_sid_groups_output_path=args.original_sid_groups_output_path,
-            resolved_sid_groups_output_path=args.resolved_sid_groups_output_path,
-            existing_sid_map_path=args.existing_sid_map_path,
-            existing_sid_groups_path=args.existing_sid_groups_path,
-            delta_map_output_path=args.delta_map_output_path,
-            delta_sid_groups_output_path=args.delta_sid_groups_output_path,
+            bundle_root=args.bundle_root,
+            partition=args.partition,
+            from_partition=args.from_partition,
+            source_model=args.source_model,
             reader_type=args.reader_type,
             writer_type=args.writer_type,
             batch_size=args.batch_size,
@@ -301,6 +316,21 @@ class ResolveSidCollisionsConfig:
             rate_only=args.rate_only,
             odps_data_quota_name=args.odps_data_quota_name,
         )
+
+    def artifact_write_path(self, artifact: str) -> str:
+        """Return where one artifact of this run's partition is written."""
+        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.output_path
+        assert root is not None and self.partition is not None
+        return artifact_location(root, artifact, self.partition)
+
+    def artifact_read_path(self, artifact: str) -> str:
+        """Return where one artifact of the appended-onto partition is read."""
+        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.output_path
+        assert root is not None and self.from_partition is not None
+        suffix = "parquet"
+        if artifact in MAP_ARTIFACTS and self.reader_type == "CsvReader":
+            suffix = "csv"
+        return artifact_read_pattern(root, artifact, self.from_partition, suffix)
 
     @cached_property
     def resolution_config(self) -> CollisionResolutionConfig:
@@ -331,10 +361,13 @@ class CollisionResolutionRunner:
             )
         self._default_writer_type: Optional[str] = None
         self._item_id_type: Optional[pa.DataType] = None
+        self._bundle_uuid = uuid.uuid4().hex
+        self._written_rows: Dict[str, int] = {}
 
     def run(self) -> CollisionResolutionStats:
         """Read, resolve collisions, and write the resulting SID map."""
         _require_single_process()
+        self._check_input_locations()
         item_ids, codes = self._load_codes()
         if codes.shape[1] != len(self._config.layer_sizes):
             raise ValueError(
@@ -365,9 +398,92 @@ class CollisionResolutionRunner:
             self._write_group_outputs(item_ids, codes, plan, result)
             del plan
             self._write_map(item_ids, codes, result)
+            self._write_manifest(result)
 
         logger.info("SID collision resolution finished: %s", result.stats)
         return result.stats
+
+    def _check_input_locations(self) -> None:
+        """Reject a run whose inputs are not all present, before any pass runs."""
+        wanted = [("--input_path", self._config.input_path)]
+        if self._config.is_append:
+            wanted += [
+                (GROUPS_ARTIFACT, self._config.artifact_read_path(GROUPS_ARTIFACT)),
+                ("manifest", self._prior_manifest_path()),
+            ]
+            if self._config.output_path is not None:
+                wanted.append(
+                    (MAP_ARTIFACT, self._config.artifact_read_path(MAP_ARTIFACT))
+                )
+        missing = [
+            f"{name} -> {path}"
+            for name, path in wanted
+            if not is_odps_path(path) and not glob.glob(path)
+        ]
+        if missing:
+            raise ValueError(
+                "these input locations hold no files:\n  "
+                + "\n  ".join(missing)
+                + "\nA directory that exists but holds no part files counts as "
+                "missing, because the readers cannot tell the two apart."
+            )
+
+    def _prior_manifest_path(self) -> str:
+        """Return the manifest of the generation being appended onto."""
+        assert self._config.bundle_root is not None
+        assert self._config.from_partition is not None
+        return manifest_path(self._config.bundle_root, self._config.from_partition)
+
+    def _write_manifest(self, result: CollisionResolutionResult) -> None:
+        """Describe every artifact this run published, written last.
+
+        Its presence is the completion marker, so nothing may be written after it.
+        """
+        assert self._config.bundle_root is not None
+        assert self._config.partition is not None
+        prior = (
+            read_manifest(self._prior_manifest_path())
+            if self._config.is_append
+            else None
+        )
+        observed = result.stats.max_final_bucket_size
+        if prior is not None:
+            observed = max(observed, prior.max_observed_items_per_sid)
+        artifacts = {
+            name: self._artifact_entry(name, rows)
+            for name, rows in self._written_rows.items()
+        }
+        manifest = BundleManifest(
+            bundle_uuid=self._bundle_uuid,
+            since_bundle_uuid=prior.bundle_uuid if prior is not None else None,
+            codebook=list(self._config.layer_sizes),
+            capacity=self._config.max_items_per_codebook,
+            max_observed_items_per_sid=observed,
+            source_model=self._config.source_model,
+            item_id_type=str(self._item_id_type) if self._item_id_type else None,
+            artifacts=artifacts,
+        )
+        path = manifest_path(self._config.bundle_root, self._config.partition)
+        write_manifest(path, manifest)
+        logger.info("wrote bundle %s manifest to %s", self._bundle_uuid, path)
+
+    def _artifact_entry(self, artifact: str, rows: int) -> ArtifactEntry:
+        """Record where one artifact landed and what it holds."""
+        location = self._config.artifact_write_path(artifact)
+        schema = _MAP_SCHEMA if artifact in MAP_ARTIFACTS else _GROUPS_SCHEMA
+        if artifact in MAP_ARTIFACTS and is_odps_path(location):
+            table, _, partition = location.rpartition("/tables/")[2].partition("/")
+            return ArtifactEntry(
+                type="odps",
+                rows=rows,
+                schema=schema,
+                table=table,
+                partition=partition,
+            )
+        kind = "parquet"
+        if artifact in MAP_ARTIFACTS and self._default_writer_type == "CsvWriter":
+            kind = "csv"
+        return ArtifactEntry(type=kind, rows=rows, schema=schema, path=location)
 
     def _make_reader(
         self, selected_cols: List[str], input_path: Optional[str] = None
@@ -595,20 +711,18 @@ class CollisionResolutionRunner:
             return PriorOccupancy.empty()
 
         layer_sizes = self._config.layer_sizes
-        groups_path = self._config.existing_sid_groups_path
-        assert groups_path is not None
+        groups_path = self._config.artifact_read_path(GROUPS_ARTIFACT)
         prior, published_items = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
         self._check_existing_map_size(published_items)
         logger.info(
             "append mode: %d new items onto %d published items in %d touched "
-            "buckets (groups=%s, map=%s)",
+            "buckets, from partition %s",
             item_ids.shape[0],
             published_items,
             prior.bucket_keys.shape[0],
-            self._config.existing_sid_groups_path,
-            self._config.existing_sid_map_path,
+            self._config.from_partition,
         )
         return prior
 
@@ -716,9 +830,9 @@ class CollisionResolutionRunner:
 
     def _check_existing_map_size(self, published_items: int) -> None:
         """Reject a published map whose size disagrees with the groups."""
-        path = self._config.existing_sid_map_path
-        if path is None:
+        if self._config.output_path is None:
             return
+        path = self._config.artifact_read_path(MAP_ARTIFACT)
         map_rows = 0
         for batch in self._iter_state_batches(
             path, ["index"], "Counting published SID map"
@@ -743,6 +857,10 @@ class CollisionResolutionRunner:
             quota_name=self._config.odps_data_quota_name,
             world_size=1,
         )
+
+    def _make_group_writer(self, output_path: str) -> BaseWriter:
+        """Create the writer for a serving-set artifact, which is always parquet."""
+        return create_writer(output_path, writer_type="ParquetWriter", world_size=1)
 
     def _item_id_array(self, values: np.ndarray) -> pa.Array:
         """Encode item IDs with the input Arrow type preserved."""
@@ -832,9 +950,9 @@ class CollisionResolutionRunner:
 
     def _stream_existing_map_rows(self, writer: BaseWriter) -> int:
         """Copy every published map row into the merged output unchanged."""
-        path = self._config.existing_sid_map_path
-        if path is None or not self._config.is_append:
+        if not self._config.is_append:
             return 0
+        path = self._config.artifact_read_path(MAP_ARTIFACT)
         is_csv = isinstance(writer, CsvWriter)
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
@@ -871,19 +989,19 @@ class CollisionResolutionRunner:
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        output_path = self._config.output_path
-        if output_path is None:
-            raise RuntimeError("map output path was not validated.")
+        output_path = self._config.artifact_write_path(MAP_ARTIFACT)
         with closing(self._make_writer(output_path)) as writer:
             progress = ProgressLogger("Writing resolved item map", start_n=0)
             written = self._stream_existing_map_rows(writer)
             self._write_new_map_rows(
                 writer, item_ids, origin_codes, result, progress, written
             )
+            self._written_rows[MAP_ARTIFACT] = written + item_ids.shape[0]
 
-        delta_path = self._config.delta_map_output_path
-        if delta_path is None or not self._config.is_append:
+        if not self._config.is_append:
             return
+        delta_path = self._config.artifact_write_path(DELTA_MAP_ARTIFACT)
+        self._written_rows[DELTA_MAP_ARTIFACT] = item_ids.shape[0]
         with closing(self._make_writer(delta_path)) as writer:
             self._write_new_map_rows(
                 writer,
@@ -909,36 +1027,17 @@ class CollisionResolutionRunner:
             plan: Original SID aggregation and overflow plan.
             result: Completed collision-resolution result.
         """
-        original_path = self._config.original_sid_groups_output_path
-        resolved_path = self._config.resolved_sid_groups_output_path
-        if resolved_path is None:
-            raise RuntimeError("resolved SID group output path was not validated.")
-
-        original_grouping: Optional[CodebookItemGrouping] = None
-        if original_path is not None:
-            original_grouping = build_original_item_grouping(plan)
-            self._write_sid_groups(
-                original_path,
-                item_ids,
-                origin_codes,
-                original_grouping,
-                resolved_last_codes=None,
-                progress_description="Writing original SID item groups",
-            )
-
+        resolved_path = self._config.artifact_write_path(GROUPS_ARTIFACT)
         if plan.overflow_rows.size:
-            del original_grouping
             grouping = build_resolved_item_grouping(plan, result)
             resolved_last_codes = result.resolved_last_codes
         else:
-            grouping = original_grouping or build_original_item_grouping(plan)
+            grouping = build_original_item_grouping(plan)
             resolved_last_codes = None
         if self._config.is_append:
-            existing_path = self._config.existing_sid_groups_path
-            assert existing_path is not None
             self._write_merged_sid_groups(
                 resolved_path,
-                existing_path,
+                self._config.artifact_read_path(GROUPS_ARTIFACT),
                 item_ids,
                 origin_codes,
                 grouping,
@@ -1021,29 +1120,34 @@ class CollisionResolutionRunner:
         group_count = groups.keys.shape[0]
 
         with ExitStack() as stack:
-            writer = stack.enter_context(closing(self._make_writer(resolved_path)))
+            writer = stack.enter_context(
+                closing(self._make_group_writer(resolved_path))
+            )
             is_csv = isinstance(writer, CsvWriter)
             delta_writer: Optional[BaseWriter] = None
-            if self._config.delta_sid_groups_output_path is not None:
-                delta_writer = stack.enter_context(
-                    closing(
-                        self._make_writer(self._config.delta_sid_groups_output_path)
+            delta_writer = stack.enter_context(
+                closing(
+                    self._make_group_writer(
+                        self._config.artifact_write_path(DELTA_GROUPS_ARTIFACT)
                     )
                 )
+            )
 
             def emit(
                 codes: np.ndarray,
                 offsets: np.ndarray,
                 values: pa.Array,
-                delta_rows: Optional[np.ndarray],
+                rows: Optional[np.ndarray],
             ) -> None:
                 """Write one chunk to the corpus output and the delta output."""
+                nonlocal corpus_rows, delta_rows
                 self._emit_group_rows(writer, codes, offsets, values)
-                if delta_writer is not None:
-                    self._emit_group_rows(
-                        delta_writer, codes, offsets, values, delta_rows
-                    )
+                corpus_rows += codes.shape[0]
+                delta_rows += codes.shape[0] if rows is None else int(rows.shape[0])
+                self._emit_group_rows(delta_writer, codes, offsets, values, rows)
 
+            corpus_rows = 0
+            delta_rows = 0
             max_rows = _max_code_rows(is_csv, groups.codes.shape[1], group_count)
 
             def emit_new_only(low: int, high: int) -> None:
@@ -1090,6 +1194,8 @@ class CollisionResolutionRunner:
                 )
                 cursor = high
             emit_new_only(cursor, group_count)
+        self._written_rows[GROUPS_ARTIFACT] = corpus_rows
+        self._written_rows[DELTA_GROUPS_ARTIFACT] = delta_rows
 
     def _write_sid_groups(
         self,
@@ -1119,8 +1225,8 @@ class CollisionResolutionRunner:
             raise ValueError("one SID group exceeds Arrow list offset capacity.")
 
         offsets = grouping.offsets
-        with closing(self._make_writer(output_path)) as writer:
-            is_csv = isinstance(writer, CsvWriter)
+        with closing(self._make_group_writer(output_path)) as writer:
+            is_csv = False
             progress = ProgressLogger(progress_description, start_n=0)
             last_progress_count = 0
             max_codebook_rows = _max_code_rows(
@@ -1149,6 +1255,7 @@ class CollisionResolutionRunner:
                         suffix=f"{child_end} samples processed",
                     )
                     last_progress_count = child_end
+        self._written_rows[GROUPS_ARTIFACT] = group_count
 
 
 def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
@@ -1259,50 +1366,37 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output_path",
         default=None,
-        help="Resolved item map output; required unless --rate_only is set.",
-    )
-    parser.add_argument(
-        "--original_sid_groups_output_path",
-        default=None,
-        help=("Optional audit output grouping item IDs by their original SID."),
-    )
-    parser.add_argument(
-        "--resolved_sid_groups_output_path",
-        default=None,
         help=(
-            "Output grouped item IDs keyed by their resolved SID; required "
+            "Root of the item-map family. May be an odps:// table or a file/OSS "
+            "path; artifacts land at <root>/<artifact>/<partition>. Required "
             "unless --rate_only is set."
         ),
     )
     parser.add_argument(
-        "--existing_sid_groups_path",
+        "--bundle_root",
         default=None,
         help=(
-            "Previous round's --resolved_sid_groups_output_path. Supplying it "
-            "selects append mode: the new items in --input_path are placed "
-            "without moving any already-published SID."
+            "Root of the serving set -- SID groups and the manifest. Always a "
+            "file or OSS path. Required unless --rate_only is set."
         ),
     )
     parser.add_argument(
-        "--existing_sid_map_path",
+        "--partition",
+        default=None,
+        help="Generation being written, e.g. 'v2'. Required unless --rate_only.",
+    )
+    parser.add_argument(
+        "--from_partition",
         default=None,
         help=(
-            "Previous round's --output_path. Required in append mode unless "
-            "--rate_only, because only the map carries origin_codebook."
+            "Generation to append onto. Supplying it selects append mode: the new "
+            "items in --input_path are placed without moving any published SID."
         ),
     )
     parser.add_argument(
-        "--delta_map_output_path",
+        "--source_model",
         default=None,
-        help="Append mode only: map rows for the new items alone.",
-    )
-    parser.add_argument(
-        "--delta_sid_groups_output_path",
-        default=None,
-        help=(
-            "Append mode only: buckets this run changed, each with its complete "
-            "post-append item list, for an idempotent index upsert."
-        ),
+        help="Optional manifest field naming the quantizer that produced the SIDs.",
     )
     parser.add_argument(
         "--reader_type",

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -600,7 +600,7 @@ class CollisionResolutionRunner:
         prior, published_items = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
-        self._cross_check_existing_map(prior, published_items)
+        self._check_existing_map_size(published_items)
         logger.info(
             "append mode: %d new items onto %d published items in %d touched "
             "buckets (groups=%s, map=%s)",
@@ -714,121 +714,23 @@ class CollisionResolutionRunner:
             published_items,
         )
 
-    def _cross_check_existing_map(
-        self, prior: PriorOccupancy, published_items: int
-    ) -> None:
-        """Verify the existing map agrees with the published groups."""
+    def _check_existing_map_size(self, published_items: int) -> None:
+        """Reject a published map whose size disagrees with the groups."""
         path = self._config.existing_sid_map_path
         if path is None:
             return
-        layer_sizes = self._config.layer_sizes
-        domain = prior.bucket_keys
-        bands = np.unique(domain // layer_sizes[-1])
-        unknown_keys: List[int] = []
-        counts = np.zeros(domain.shape[0], dtype=np.int64)
-        max_index = np.zeros(domain.shape[0], dtype=np.int64)
-        sum_index = np.zeros(domain.shape[0], dtype=np.int64)
-        sum_square_index = np.zeros(domain.shape[0], dtype=np.int64)
         map_rows = 0
-
         for batch in self._iter_state_batches(
-            path,
-            ["codebook", "index"],
-            "Cross-checking published SID map",
+            path, ["index"], "Counting published SID map"
         ):
-            keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
-            map_rows += keys.shape[0]
-            _, known_band = lookup_sorted(bands, keys // layer_sizes[-1])
-            if not known_band.any():
-                continue
-            keys = keys[known_band]
-            indices = batch["index"].to_numpy(zero_copy_only=False)[known_band]
-            positions, known = lookup_sorted(domain, keys)
-            if not np.all(known) and len(unknown_keys) < 10:
-                unknown_keys.extend(keys[~known][:10].tolist())
-            if not known.any():
-                continue
-            order = np.argsort(positions[known], kind="stable")
-            batch_positions = positions[known][order]
-            batch_indices = indices[known][order].astype(np.int64, copy=False)
-            starts = np.flatnonzero(
-                np.concatenate(([True], batch_positions[1:] != batch_positions[:-1]))
-            )
-            buckets = batch_positions[starts]
-            counts[buckets] += np.diff(np.append(starts, batch_positions.shape[0]))
-            sum_index[buckets] += np.add.reduceat(batch_indices, starts)
-            sum_square_index[buckets] += np.add.reduceat(
-                batch_indices * batch_indices, starts
-            )
-            max_index[buckets] = np.maximum(
-                max_index[buckets], np.maximum.reduceat(batch_indices, starts)
-            )
-
-        self._report_cross_check(
-            prior, counts, max_index, sum_index, sum_square_index, unknown_keys
-        )
+            map_rows += len(batch["index"])
         if map_rows != published_items:
             raise ValueError(
                 f"existing map holds {map_rows} rows but the existing groups hold "
                 f"{published_items} item IDs; one of the two artifacts is "
-                "incomplete, and appending onto it would drop published items or "
-                "reuse their slots. The per-bucket checks only cover bands the new "
-                "items touch, so a truncated shard elsewhere shows up only here."
-            )
-
-    @staticmethod
-    def _report_cross_check(
-        prior: PriorOccupancy,
-        counts: np.ndarray,
-        max_index: np.ndarray,
-        sum_index: np.ndarray,
-        sum_square_index: np.ndarray,
-        unknown_keys: List[int],
-    ) -> None:
-        """Raise on the first failing map/groups consistency check."""
-        hint = (
-            "the two --existing_* artifacts must come from the same generation "
-            "of this tool"
-        )
-        if unknown_keys:
-            preview = ",".join(str(value) for value in unknown_keys[:10])
-            raise ValueError(
-                f"existing map holds SID buckets absent from the existing groups; "
-                f"{hint}. First offending bucket keys: {preview}."
-            )
-        mismatched = np.flatnonzero(counts != prior.bucket_counts)
-        if mismatched.size:
-            first = int(mismatched[0])
-            raise ValueError(
-                f"existing map and groups disagree on {mismatched.size} buckets; "
-                f"{hint}. Bucket key {int(prior.bucket_keys[first])} has "
-                f"{int(counts[first])} map rows but {int(prior.bucket_counts[first])} "
-                "grouped item IDs."
-            )
-        holed = np.flatnonzero(max_index != counts)
-        if holed.size:
-            first = int(holed[0])
-            raise ValueError(
-                f"existing map index space has holes in {holed.size} buckets. "
-                f"Bucket key {int(prior.bucket_keys[first])} holds "
-                f"{int(counts[first])} items but its largest index is "
-                f"{int(max_index[first])}; appending would reuse a published slot. "
-                "Item deletion is not supported -- tombstone instead."
-            )
-        expected_sum = counts * (counts + 1) // 2
-        expected_square_sum = counts * (counts + 1) * (2 * counts + 1) // 6
-        duplicated = np.flatnonzero(
-            (sum_index != expected_sum) | (sum_square_index != expected_square_sum)
-        )
-        if duplicated.size:
-            first = int(duplicated[0])
-            raise ValueError(
-                f"existing map index space is not dense in {duplicated.size} "
-                f"buckets. Bucket key {int(prior.bucket_keys[first])} has index sum "
-                f"{int(sum_index[first])} and square sum "
-                f"{int(sum_square_index[first])}, expected "
-                f"{int(expected_sum[first])} and {int(expected_square_sum[first])} "
-                f"for {int(counts[first])} items."
+                "incomplete or they come from different generations of this tool. "
+                "Appending onto them would drop published items or reuse their "
+                "slots."
             )
 
     def _make_writer(self, output_path: str) -> BaseWriter:

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -42,11 +42,53 @@ Example::
         --input_path 'sid_predict_output/*.parquet' \
         --codebook 256,256,256 --max_items_per_codebook 5 \
         --strategy candidate \
-        --output_path sid_collision/map \
-        --resolved_sid_groups_output_path sid_collision/resolved_groups
+        --output_path sid_collision/map_v1 \
+        --resolved_sid_groups_output_path sid_collision/groups_v1
 
 To also write the optional original-SID audit grouping, add
 ``--original_sid_groups_output_path sid_collision/original_groups``.
+
+Append mode
+-----------
+
+Supplying ``--existing_sid_groups_path`` switches the tool to appending new
+items onto an already-published corpus: ``--input_path`` then holds only the
+new items, and **no published SID is ever moved**. Published items are never
+rows in the plan, so they cannot be re-ranked; they are read only to be copied
+into the merged outputs. A new item continues its bucket's slot numbering from
+the published occupancy instead of restarting at one::
+
+    python -m tzrec.tools.sid.resolve_sid_collisions \
+        --input_path 'sid_predict_new_20260731/*.parquet' \
+        --existing_sid_map_path    'sid_collision/map_v1/*.parquet' \
+        --existing_sid_groups_path 'sid_collision/groups_v1/*.parquet' \
+        --codebook 256,256,256 --max_items_per_codebook 5 \
+        --strategy candidate \
+        --output_path sid_collision/map_v2 \
+        --resolved_sid_groups_output_path sid_collision/groups_v2 \
+        --delta_map_output_path sid_collision/delta_20260731
+
+Both outputs stay corpus-complete, so generation *n*'s outputs are exactly
+generation *n+1*'s ``--existing_*`` inputs and a full resolve bootstraps the
+chain with no special case. ``--original_sid_groups_output_path`` is the
+exception: it is an audit output keyed by the *predicted* SID, and in append
+mode it covers only this run's items, because published items' original SIDs
+live in the map's ``origin_codebook`` rather than in the groups artifact.
+
+Writers truncate, so every generation needs a fresh output directory.
+``--delta_map_output_path`` emits the new item rows alone and
+``--delta_sid_groups_output_path`` the buckets this run changed, each with its
+complete post-append item list so a serving index can upsert it idempotently.
+
+State paths follow the same rules as ``--input_path``: the reader backend
+comes from the path (``map_v1/*.parquet``, ``odps://…``) or from
+``--reader_type``. Before placing anything, the run
+verifies that no new item ID is already published, and that the two state
+artifacts agree bucket for bucket on count, largest index and index sum -- the
+map stores ``index`` as a value, so unlike the groups artifact it can hold
+holes or duplicates, and appending onto those would reuse a published slot.
+Appends need candidate output more often than a full resolve does, because a
+bucket's free space is ``capacity`` minus its published occupancy.
 """
 
 from __future__ import annotations
@@ -54,10 +96,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from contextlib import closing
+from contextlib import ExitStack, closing
 from dataclasses import dataclass
 from functools import cached_property
-from typing import List, Optional, Tuple
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -82,15 +124,34 @@ from tzrec.utils.sid.collision import (
     CollisionResolutionStats,
     CollisionResolver,
     KnnCollisionResolver,
+    PriorOccupancy,
     RandomCollisionResolver,
+    bands_of_bucket_keys,
     build_original_item_grouping,
     build_resolved_item_grouping,
+    concat_ranges,
+    in_sorted_bands,
+    lookup_sorted,
     prepare_collision_plan,
+    sid_band_ids,
+    sid_bucket_keys,
 )
 
 _MAP_WRITE_ROWS = 1_000_000
+# State artifacts are corpus-sized; read them in larger batches than the
+# new-items input so per-batch fixed costs are not multiplied by the corpus.
+_STATE_READ_ROWS = 1_000_000
 _GROUP_WRITE_ITEMS = 1_000_000
 _ARROW_LIST_OFFSET_MAX = int(np.iinfo(np.int32).max)
+
+
+def _is_list_column(values: pa.Array) -> bool:
+    """Whether an Arrow column is one of the native list types."""
+    return (
+        pa.types.is_list(values.type)
+        or pa.types.is_large_list(values.type)
+        or pa.types.is_fixed_size_list(values.type)
+    )
 
 
 def _require_single_process() -> None:
@@ -165,6 +226,11 @@ class ResolveSidCollisionsConfig:
     random_num_candidates: int
     rate_only: bool
     odps_data_quota_name: str
+    # Append mode. Defaulted so a full-resolve caller need not mention them.
+    existing_sid_map_path: Optional[str] = None
+    existing_sid_groups_path: Optional[str] = None
+    delta_map_output_path: Optional[str] = None
+    delta_sid_groups_output_path: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.batch_size < 1:
@@ -185,17 +251,27 @@ class ResolveSidCollisionsConfig:
             raise ValueError(
                 "resolved_sid_groups_output_path is required unless rate_only is set."
             )
-
-        paths = [self.input_path]
-        paths.extend(
-            path
-            for path in (
-                self.output_path,
-                self.original_sid_groups_output_path,
-                self.resolved_sid_groups_output_path,
+        if self.is_append and not self.rate_only and not self.existing_sid_map_path:
+            raise ValueError(
+                "existing_sid_map_path is required in append mode unless rate_only "
+                "is set; without it the merged map would hold only the new items."
             )
-            if path
-        )
+
+        # Append-only paths are simply unused outside append mode, so they are
+        # left out of the conflict check rather than rejected.
+        candidates = [self.output_path, self.resolved_sid_groups_output_path]
+        candidates.append(self.original_sid_groups_output_path)
+        if self.is_append:
+            candidates.extend(
+                (
+                    self.existing_sid_map_path,
+                    self.existing_sid_groups_path,
+                    self.delta_map_output_path,
+                    self.delta_sid_groups_output_path,
+                )
+            )
+        paths = [self.input_path]
+        paths.extend(path for path in candidates if path)
         has_conflict, conflict_message = check_path_conflict(paths)
         if has_conflict:
             raise ValueError(conflict_message)
@@ -203,6 +279,15 @@ class ResolveSidCollisionsConfig:
         # Eagerly build the resolution config so its validation (layer_sizes,
         # capacity) fails fast here rather than lazily inside run().
         _ = self.resolution_config
+
+    @property
+    def is_append(self) -> bool:
+        """Whether this run appends onto an already-published corpus.
+
+        The previous round's resolved groups is the occupancy authority and is
+        required by every append, so its presence selects the mode.
+        """
+        return self.existing_sid_groups_path is not None
 
     @classmethod
     def from_namespace(cls, args: argparse.Namespace) -> "ResolveSidCollisionsConfig":
@@ -219,6 +304,10 @@ class ResolveSidCollisionsConfig:
             output_path=args.output_path,
             original_sid_groups_output_path=args.original_sid_groups_output_path,
             resolved_sid_groups_output_path=args.resolved_sid_groups_output_path,
+            existing_sid_map_path=args.existing_sid_map_path,
+            existing_sid_groups_path=args.existing_sid_groups_path,
+            delta_map_output_path=args.delta_map_output_path,
+            delta_sid_groups_output_path=args.delta_sid_groups_output_path,
             reader_type=args.reader_type,
             writer_type=args.writer_type,
             batch_size=args.batch_size,
@@ -268,10 +357,9 @@ class CollisionResolutionRunner:
         """Read, resolve collisions, and write the resulting SID map."""
         _require_single_process()
         item_ids, codes = self._load_codes()
+        prior = self._load_prior_state(item_ids, codes)
         plan = prepare_collision_plan(
-            item_ids,
-            codes,
-            self._config.resolution_config,
+            item_ids, codes, self._config.resolution_config, prior=prior
         )
         collect_grouping = not self._config.rate_only and bool(plan.overflow_rows.size)
         candidate_last_codes = None
@@ -297,15 +385,77 @@ class CollisionResolutionRunner:
         logger.info("SID collision resolution finished: %s", result.stats)
         return result.stats
 
-    def _make_reader(self, selected_cols: List[str]) -> BaseReader:
-        """Open a repository reader projecting ``selected_cols``."""
+    def _make_reader(
+        self,
+        selected_cols: List[str],
+        input_path: Optional[str] = None,
+        batch_size: Optional[int] = None,
+    ) -> BaseReader:
+        """Open a repository reader projecting ``selected_cols``.
+
+        Args:
+            selected_cols: Columns to project.
+            input_path: Path to read; defaults to the new-items input.
+            batch_size: Rows per batch; defaults to the configured size.
+
+        Returns:
+            A reader over the requested path.
+        """
         return create_reader(
-            input_path=self._config.input_path,
-            batch_size=self._config.batch_size,
+            input_path=input_path or self._config.input_path,
+            batch_size=batch_size or self._config.batch_size,
             selected_cols=selected_cols,
             reader_type=self._config.reader_type,
             quota_name=self._config.odps_data_quota_name,
         )
+
+    def _iter_state_batches(
+        self,
+        path: str,
+        fields: List[str],
+        description: str,
+        on_open: Optional[Callable[[BaseReader], None]] = None,
+    ) -> Iterator[Dict[str, pa.Array]]:
+        """Stream one state artifact, checking columns and logging progress.
+
+        State artifacts are corpus-sized, so they are read with their own batch
+        size rather than the one tuned for the much smaller new-items input --
+        every per-batch fixed cost is otherwise multiplied by the corpus.
+
+        Args:
+            path: State artifact to read.
+            fields: Columns to project and require.
+            description: Progress logger description.
+            on_open: Optional callback invoked once with the opened reader.
+
+        Yields:
+            Each record batch of the artifact.
+
+        Raises:
+            ValueError: If a required column is missing from the artifact.
+        """
+        reader = self._make_reader(
+            fields,
+            input_path=path,
+            batch_size=max(self._config.batch_size, _STATE_READ_ROWS),
+        )
+        missing = [name for name in fields if name not in reader.schema.names]
+        if missing:
+            raise ValueError(
+                f"columns {missing} are missing from {path!r}; point the flag at "
+                "an output directory written by this tool."
+            )
+        if on_open is not None:
+            on_open(reader)
+        progress = ProgressLogger(description, start_n=0)
+        scanned = 0
+        last_progress_count = 0
+        for batch in reader.to_batches():
+            yield batch
+            scanned += len(batch[fields[0]])
+            if self._progress_interval_reached(scanned, last_progress_count):
+                progress.log(scanned, suffix=f"{scanned} samples processed")
+                last_progress_count = scanned
 
     def _progress_interval_reached(
         self, processed: int, last_progress_count: int
@@ -316,11 +466,7 @@ class CollisionResolutionRunner:
     @staticmethod
     def _codes_matrix(values: pa.Array) -> np.ndarray:
         """Decode an SID column into an ``(N, n_layers)`` int64 matrix."""
-        if (
-            pa.types.is_list(values.type)
-            or pa.types.is_large_list(values.type)
-            or pa.types.is_fixed_size_list(values.type)
-        ):
+        if _is_list_column(values):
             row_count = len(values)
             flat = (
                 values.flatten()
@@ -484,6 +630,359 @@ class CollisionResolutionRunner:
             )
         return candidates
 
+    def _load_prior_state(
+        self, item_ids: np.ndarray, codes: np.ndarray
+    ) -> PriorOccupancy:
+        """Load and verify published state, or return empty for a full resolve.
+
+        Args:
+            item_ids: Item IDs of the new batch.
+            codes: SID matrix of the new batch.
+
+        Returns:
+            Occupancy restricted to the bands this run can touch.
+
+        Raises:
+            ValueError: If the SID width disagrees with ``--codebook``.
+        """
+        if not self._config.is_append:
+            logger.info("full-resolve mode: no existing SID state supplied")
+            return PriorOccupancy.empty()
+
+        layer_sizes = self._config.layer_sizes
+        if codes.shape[1] != len(layer_sizes):
+            # prepare_collision_plan raises the same way, but only after these
+            # two corpus-sized passes would already have run.
+            raise ValueError(
+                f"codes have {codes.shape[1]} layers but --codebook has "
+                f"{len(layer_sizes)}."
+            )
+        groups_path = self._config.existing_sid_groups_path
+        assert groups_path is not None  # is_append means it is set
+        prior = self._load_prior_occupancy(
+            groups_path, sid_band_ids(codes, layer_sizes), item_ids
+        )
+        self._cross_check_existing_map(prior)
+        logger.info(
+            "append mode: %d new items onto %d published items in %d touched "
+            "buckets (groups=%s, map=%s)",
+            item_ids.shape[0],
+            prior.total_items,
+            prior.bucket_keys.shape[0],
+            self._config.existing_sid_groups_path,
+            self._config.existing_sid_map_path,
+        )
+        return prior
+
+    def _decode_grouped_item_ids(self, values: pa.Array) -> Tuple[np.ndarray, pa.Array]:
+        """Decode a grouped item-ID column into per-group counts and values.
+
+        Inverse of :meth:`_grouped_item_ids_column`. Native list columns expose
+        both halves directly and stay zero-copy; the CSV form is a JSON array
+        string, which has to be parsed -- a plain comma count would be wrong for
+        string IDs that themselves contain commas -- so both halves come out of
+        one parse rather than two.
+
+        Args:
+            values: One batch of the grouped item-ID column.
+
+        Returns:
+            An int64 count per group, and the flattened child values.
+        """
+        if _is_list_column(values):
+            lengths = (
+                pc.list_value_length(values)
+                .to_numpy(zero_copy_only=False)
+                .astype(np.int64, copy=False)
+            )
+            return lengths, values.flatten()
+        groups = [json.loads(text) for text in values.to_pylist()]
+        lengths = np.fromiter(
+            (len(group) for group in groups), dtype=np.int64, count=len(groups)
+        )
+        flat = [item_id for group in groups for item_id in group]
+        return lengths, pa.array(flat, type=self._item_id_type)
+
+    def _align_codes_column(self, values: pa.Array, is_csv: bool) -> pa.Array:
+        """Return an SID column in the encoding the destination writer needs.
+
+        Passes the Arrow column straight through when the source encoding
+        already matches the writer, and re-encodes through the NumPy form
+        otherwise, so a mixed-format append still produces one valid artifact.
+
+        Args:
+            values: SID column read from an existing artifact.
+            is_csv: Whether the destination writer is a CSV writer.
+
+        Returns:
+            A column matching what :meth:`_codes_column` would emit.
+        """
+        source_is_text = pa.types.is_string(values.type) or pa.types.is_large_string(
+            values.type
+        )
+        matches_writer = source_is_text if is_csv else _is_list_column(values)
+        if matches_writer:
+            return values
+        return self._codes_column(self._codes_matrix(values), is_csv)
+
+    def _warn_on_state_format_conversion(self, reader: BaseReader) -> None:
+        """Warn when the merged artifacts will change format.
+
+        The writer follows the new-items input, so a CSV prediction against
+        Parquet state silently rewrites the whole corpus in the other format.
+        That is legal -- each output is self-contained -- but it is never what
+        an operator intends, so make it visible.
+
+        Args:
+            reader: Reader opened over an existing state artifact.
+        """
+        state_writer_type = reader.__class__.__name__.replace("Reader", "Writer")
+        if (
+            self._default_writer_type is not None
+            and state_writer_type != self._default_writer_type
+        ):
+            logger.warning(
+                "existing SID state reads as %s but the output writer is %s; the "
+                "whole corpus will be rewritten in the other format. Set "
+                "--writer_type %s to keep it unchanged.",
+                reader.__class__.__name__,
+                self._default_writer_type,
+                state_writer_type,
+            )
+
+    def _check_state_item_id_type(self, values: pa.Array, source: str) -> None:
+        """Reject an existing artifact whose item ID type differs from the input.
+
+        Args:
+            values: Item ID column read from a state artifact.
+            source: Human-readable artifact name for the error message.
+
+        Raises:
+            ValueError: If the type differs from the new-items input.
+        """
+        if len(values) == 0 or self._item_id_type is None:
+            return
+        if values.type != self._item_id_type:
+            raise ValueError(
+                f"{source} item ID type {values.type} differs from the new-items "
+                f"input type {self._item_id_type}; the merged map cannot mix "
+                "them. Re-export the state or the prediction with one type."
+            )
+
+    def _load_prior_occupancy(
+        self, path: str, band_ids: np.ndarray, item_ids: np.ndarray
+    ) -> PriorOccupancy:
+        """Read published occupancy from the previous round's resolved groups.
+
+        This is pass 1. Only buckets in a band the new batch touches are kept:
+        relocation never leaves a row's own band, so no other bucket can be
+        read or written by this run. The same scan probes for item IDs that are
+        already published, which is the only place that can be detected.
+
+        Args:
+            path: Previous round's resolved SID groups.
+            band_ids: Band identifier of every new item.
+            item_ids: Item IDs of the new batch.
+
+        Returns:
+            Occupancy restricted to the new batch's bands.
+
+        Raises:
+            ValueError: If the groups stream is not ascending by SID key, or if
+                any new item ID is already published.
+        """
+        layer_sizes = self._config.layer_sizes
+        wanted_bands = np.unique(band_ids)
+        new_item_ids = self._item_id_array(item_ids)
+
+        key_chunks: List[np.ndarray] = []
+        count_chunks: List[np.ndarray] = []
+        overlapping: List[object] = []
+        overlap_count = 0
+        previous_max_key = -1
+        for batch in self._iter_state_batches(
+            path,
+            ["codebook", "itemids"],
+            "Reading published SID groups",
+            on_open=self._warn_on_state_format_conversion,
+        ):
+            keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
+            if keys.size:
+                if int(keys[0]) <= previous_max_key or np.any(keys[1:] <= keys[:-1]):
+                    raise ValueError(
+                        "existing SID groups must be ascending by SID key with one "
+                        "row per bucket; the merge would otherwise emit duplicate "
+                        "buckets."
+                    )
+                previous_max_key = int(keys[-1])
+
+            lengths, flat_ids = self._decode_grouped_item_ids(batch["itemids"])
+            if len(flat_ids):
+                self._check_state_item_id_type(flat_ids, "existing SID groups")
+                # Hash-based set membership: keeps published IDs inside Arrow
+                # rather than materializing
+                # them as Python objects for a comparison-based search.
+                published = pc.is_in(flat_ids, value_set=new_item_ids)
+                batch_overlap = int(pc.sum(published).as_py() or 0)
+                overlap_count += batch_overlap
+                if batch_overlap and len(overlapping) < 10:
+                    overlapping.extend(
+                        flat_ids.filter(published).slice(0, 10).to_pylist()
+                    )
+
+            keep = in_sorted_bands(keys, wanted_bands, layer_sizes[-1])
+            if np.any(keep):
+                key_chunks.append(keys[keep])
+                count_chunks.append(lengths[keep])
+
+        if overlap_count:
+            preview = ",".join(str(value) for value in overlapping[:10])
+            raise ValueError(
+                f"{overlap_count} new item IDs are already published; an item "
+                "cannot hold two SIDs. Remove them from the append batch. First "
+                f"offending IDs: {preview}."
+            )
+        if not key_chunks:
+            return PriorOccupancy.empty()
+        return PriorOccupancy(np.concatenate(key_chunks), np.concatenate(count_chunks))
+
+    def _cross_check_existing_map(self, prior: PriorOccupancy) -> None:
+        """Verify the existing map agrees with the published groups.
+
+        This is pass 2. The two state artifacts encode the same occupancy in
+        different shapes, so comparing them catches a mismatched generation
+        pair, a mis-pointed directory and a truncated artifact. It is also the
+        only verification of the map's own ``index`` space: density is
+        structural in the groups artifact (list position is the slot) but not
+        in the map, where ``index`` is a stored value.
+
+        Args:
+            prior: Band-restricted occupancy from :meth:`_load_prior_occupancy`.
+
+        Raises:
+            ValueError: If any of the four checks fails.
+        """
+        path = self._config.existing_sid_map_path
+        if path is None or prior.is_empty:
+            return
+        layer_sizes = self._config.layer_sizes
+        domain = prior.bucket_keys
+        bands = np.unique(bands_of_bucket_keys(domain, layer_sizes[-1]))
+        unknown_keys: List[int] = []
+        # Buffer the rows that land in a compared bucket and reduce once at the
+        # end: a per-batch reduction would allocate a domain-sized accumulator
+        # for every batch, which dwarfs the handful of rows each one contributes.
+        position_chunks: List[np.ndarray] = []
+        index_chunks: List[np.ndarray] = []
+
+        for batch in self._iter_state_batches(
+            path,
+            ["codebook", "index"],
+            "Cross-checking published SID map",
+        ):
+            keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
+            # Only buckets in the new batch's bands are compared; nothing else
+            # can affect this run.
+            rows = np.flatnonzero(in_sorted_bands(keys, bands, layer_sizes[-1]))
+            if rows.size == 0:
+                continue
+            keys = keys[rows]
+            indices = (
+                batch["index"]
+                .take(pa.array(rows, type=pa.int64()))
+                .to_numpy(zero_copy_only=False)
+                .astype(np.int64, copy=False)
+            )
+            positions, known = lookup_sorted(domain, keys)
+            if not np.all(known) and len(unknown_keys) < 10:
+                unknown_keys.extend(keys[~known][:10].tolist())
+            if np.any(known):
+                position_chunks.append(positions[known])
+                index_chunks.append(indices[known])
+
+        counts = np.zeros(domain.shape[0], dtype=np.int64)
+        max_index = np.zeros(domain.shape[0], dtype=np.int64)
+        sum_index = np.zeros(domain.shape[0], dtype=np.int64)
+        if position_chunks:
+            positions = np.concatenate(position_chunks)
+            indices = np.concatenate(index_chunks)
+            counts = np.bincount(positions, minlength=domain.shape[0])
+            sum_index = np.bincount(
+                positions, weights=indices, minlength=domain.shape[0]
+            ).astype(np.int64, copy=False)
+            # Segment maximum via one stable sort plus reduceat; np.maximum.at
+            # is unbuffered and far slower at corpus scale.
+            order = np.argsort(positions, kind="stable")
+            sorted_positions = positions[order]
+            starts = np.flatnonzero(
+                np.concatenate(([True], sorted_positions[1:] != sorted_positions[:-1]))
+            )
+            max_index[sorted_positions[starts]] = np.maximum.reduceat(
+                indices[order], starts
+            )
+
+        self._report_cross_check(prior, counts, max_index, sum_index, unknown_keys)
+
+    @staticmethod
+    def _report_cross_check(
+        prior: PriorOccupancy,
+        counts: np.ndarray,
+        max_index: np.ndarray,
+        sum_index: np.ndarray,
+        unknown_keys: List[int],
+    ) -> None:
+        """Raise on the first failing map/groups consistency check.
+
+        Args:
+            prior: Occupancy derived from the groups artifact.
+            counts: Map rows per bucket.
+            max_index: Largest ``index`` per bucket.
+            sum_index: Sum of ``index`` per bucket.
+            unknown_keys: Map bucket keys absent from the groups artifact.
+
+        Raises:
+            ValueError: If any check fails.
+        """
+        hint = (
+            "the two --existing_* artifacts must come from the same generation "
+            "of this tool"
+        )
+        if unknown_keys:
+            preview = ",".join(str(value) for value in unknown_keys[:10])
+            raise ValueError(
+                f"existing map holds SID buckets absent from the existing groups; "
+                f"{hint}. First offending bucket keys: {preview}."
+            )
+        mismatched = np.flatnonzero(counts != prior.bucket_counts)
+        if mismatched.size:
+            first = int(mismatched[0])
+            raise ValueError(
+                f"existing map and groups disagree on {mismatched.size} buckets; "
+                f"{hint}. Bucket key {int(prior.bucket_keys[first])} has "
+                f"{int(counts[first])} map rows but {int(prior.bucket_counts[first])} "
+                "grouped item IDs."
+            )
+        holed = np.flatnonzero(max_index != counts)
+        if holed.size:
+            first = int(holed[0])
+            raise ValueError(
+                f"existing map index space has holes in {holed.size} buckets. "
+                f"Bucket key {int(prior.bucket_keys[first])} holds "
+                f"{int(counts[first])} items but its largest index is "
+                f"{int(max_index[first])}; appending would reuse a published slot. "
+                "Item deletion is not supported -- tombstone instead."
+            )
+        expected_sum = counts * (counts + 1) // 2
+        duplicated = np.flatnonzero(sum_index != expected_sum)
+        if duplicated.size:
+            first = int(duplicated[0])
+            raise ValueError(
+                f"existing map index space is not dense in {duplicated.size} "
+                f"buckets. Bucket key {int(prior.bucket_keys[first])} has index sum "
+                f"{int(sum_index[first])}, expected {int(expected_sum[first])} for "
+                f"{int(counts[first])} items."
+            )
+
     def _make_writer(self, output_path: str) -> BaseWriter:
         """Create a repository writer for one independently resolved output."""
         if self._default_writer_type is None:
@@ -562,48 +1061,144 @@ class CollisionResolutionRunner:
         )
         return pa.ListArray.from_arrays(offsets, values)
 
+    def _map_write_chunk_rows(self, is_csv: bool, layer_count: int) -> int:
+        """Return the largest map row count one write can encode.
+
+        Args:
+            is_csv: Whether the destination writer is a CSV writer.
+            layer_count: Number of SID layers per row.
+
+        Returns:
+            The chunk size in rows.
+
+        Raises:
+            ValueError: If a single row exceeds Arrow list offset capacity.
+        """
+        return _max_code_rows(is_csv, layer_count, _MAP_WRITE_ROWS)
+
+    def _write_new_map_rows(
+        self,
+        writer: BaseWriter,
+        is_csv: bool,
+        item_ids: np.ndarray,
+        origin_codes: np.ndarray,
+        result: CollisionResolutionResult,
+        progress: ProgressLogger,
+        written: int,
+    ) -> None:
+        """Write this run's own item rows in chunks, without a full code copy.
+
+        Args:
+            writer: Destination writer.
+            is_csv: Whether ``writer`` is a CSV writer.
+            item_ids: Item IDs in original row order.
+            origin_codes: Original full SID matrix.
+            result: Completed collision-resolution result.
+            progress: Shared progress logger.
+            written: Rows already written to ``writer``.
+        """
+        output_count = item_ids.shape[0]
+        last_progress_count = written
+        write_chunk = self._map_write_chunk_rows(is_csv, origin_codes.shape[1])
+        for start in range(0, output_count, write_chunk):
+            end = min(start + write_chunk, output_count)
+            selection = slice(start, end)
+            origin_chunk = origin_codes[selection]
+            final_chunk = origin_chunk.copy()
+            final_chunk[:, -1] = result.resolved_last_codes[selection]
+            writer.write(
+                {
+                    "item_id": self._item_id_array(item_ids[selection]),
+                    "origin_codebook": self._codes_column(origin_chunk, is_csv),
+                    "codebook": self._codes_column(final_chunk, is_csv),
+                    "index": pa.array(result.slot_indices[selection], type=pa.int64()),
+                }
+            )
+            written += end - start
+            if self._progress_interval_reached(written, last_progress_count):
+                progress.log(written, suffix=f"{written} samples processed")
+                last_progress_count = written
+
+    def _stream_existing_map_rows(self, writer: BaseWriter, is_csv: bool) -> int:
+        """Copy every published map row into the merged output unchanged.
+
+        Existing rows keep their item ID, both codebooks and their slot index
+        verbatim; that copy is the guarantee that no published SID moves.
+
+        Args:
+            writer: Destination writer.
+            is_csv: Whether ``writer`` is a CSV writer.
+
+        Returns:
+            The number of rows copied, or zero outside append mode, where the
+            published-state flags are ignored rather than rejected.
+        """
+        path = self._config.existing_sid_map_path
+        if path is None or not self._config.is_append:
+            return 0
+        fields = [
+            "item_id",
+            "origin_codebook",
+            "codebook",
+            "index",
+        ]
+        written = 0
+        for batch in self._iter_state_batches(
+            path, fields, "Copying published item map"
+        ):
+            item_id_column = batch["item_id"]
+            self._check_state_item_id_type(item_id_column, "existing SID map")
+            writer.write(
+                {
+                    "item_id": item_id_column,
+                    "origin_codebook": self._align_codes_column(
+                        batch["origin_codebook"], is_csv
+                    ),
+                    "codebook": self._align_codes_column(batch["codebook"], is_csv),
+                    "index": pc.cast(batch["index"], pa.int64()),
+                }
+            )
+            written += len(item_id_column)
+        return written
+
     def _write_map(
         self,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         result: CollisionResolutionResult,
     ) -> None:
-        """Write the resolved map in chunks without a full final-code copy."""
+        """Write the corpus-complete item map.
+
+        In append mode the published rows are streamed through first and this
+        run's rows are appended, so the artifact stands alone and is exactly
+        what the next append consumes.
+        """
         output_path = self._config.output_path
         if output_path is None:
             raise RuntimeError("map output path was not validated.")
         with closing(self._make_writer(output_path)) as writer:
             is_csv = isinstance(writer, CsvWriter)
-            output_count = item_ids.shape[0]
             progress = ProgressLogger("Writing resolved item map", start_n=0)
-            last_progress_count = 0
-            write_chunk = _MAP_WRITE_ROWS
-            if not is_csv:
-                write_chunk = min(
-                    write_chunk,
-                    _ARROW_LIST_OFFSET_MAX // origin_codes.shape[1],
-                )
-                if write_chunk < 1:
-                    raise ValueError("one SID row exceeds Arrow list offset capacity.")
-            for start in range(0, output_count, write_chunk):
-                end = min(start + write_chunk, output_count)
-                selection = slice(start, end)
-                origin_chunk = origin_codes[selection]
-                final_chunk = origin_chunk.copy()
-                final_chunk[:, -1] = result.resolved_last_codes[selection]
-                writer.write(
-                    {
-                        "item_id": self._item_id_array(item_ids[selection]),
-                        "origin_codebook": self._codes_column(origin_chunk, is_csv),
-                        "codebook": self._codes_column(final_chunk, is_csv),
-                        "index": pa.array(
-                            result.slot_indices[selection], type=pa.int64()
-                        ),
-                    }
-                )
-                if self._progress_interval_reached(end, last_progress_count):
-                    progress.log(end, suffix=f"{end} samples processed")
-                    last_progress_count = end
+            written = self._stream_existing_map_rows(writer, is_csv)
+            self._write_new_map_rows(
+                writer, is_csv, item_ids, origin_codes, result, progress, written
+            )
+
+        # Delta outputs describe what an append added, so they are ignored
+        # outside append mode rather than duplicating the full map.
+        delta_path = self._config.delta_map_output_path
+        if delta_path is None or not self._config.is_append:
+            return
+        with closing(self._make_writer(delta_path)) as writer:
+            self._write_new_map_rows(
+                writer,
+                isinstance(writer, CsvWriter),
+                item_ids,
+                origin_codes,
+                result,
+                ProgressLogger("Writing delta item map", start_n=0),
+                0,
+            )
 
     def _write_group_outputs(
         self,
@@ -644,6 +1239,18 @@ class CollisionResolutionRunner:
         else:
             grouping = original_grouping or build_original_item_grouping(plan)
             resolved_last_codes = None
+        if self._config.is_append:
+            existing_path = self._config.existing_sid_groups_path
+            assert existing_path is not None  # is_append means it is set
+            self._write_merged_sid_groups(
+                resolved_path,
+                existing_path,
+                item_ids,
+                origin_codes,
+                grouping,
+                resolved_last_codes,
+            )
+            return
         self._write_sid_groups(
             resolved_path,
             item_ids,
@@ -652,6 +1259,168 @@ class CollisionResolutionRunner:
             resolved_last_codes=resolved_last_codes,
             progress_description="Writing resolved SID item groups",
         )
+
+    def _emit_group_rows(
+        self,
+        writer: BaseWriter,
+        is_csv: bool,
+        codes: np.ndarray,
+        offsets: np.ndarray,
+        values: pa.Array,
+        rows: Optional[np.ndarray] = None,
+    ) -> None:
+        """Write one chunk of SID groups, optionally only ``rows`` of it.
+
+        Args:
+            writer: Destination writer.
+            is_csv: Whether ``writer`` is a CSV writer.
+            codes: Emitted SID per group.
+            offsets: CSR offsets into ``values``.
+            values: Flattened item IDs.
+            rows: Group rows to keep, or ``None`` for all of them.
+        """
+        lengths = np.diff(offsets)
+        if rows is not None:
+            if rows.size == 0:
+                return
+            lengths = lengths[rows]
+            values = values.take(
+                pa.array(concat_ranges(offsets[:-1][rows], lengths), type=pa.int64())
+            )
+            codes = codes[rows]
+            offsets = np.zeros(rows.shape[0] + 1, dtype=np.int64)
+            np.cumsum(lengths, out=offsets[1:])
+        writer.write(
+            {
+                "codebook": self._codes_column(codes, is_csv),
+                "itemids": self._grouped_item_ids_column(values, offsets, is_csv),
+            }
+        )
+
+    def _build_append_groups(
+        self,
+        item_ids: np.ndarray,
+        origin_codes: np.ndarray,
+        grouping: CodebookItemGrouping,
+        resolved_last_codes: Optional[np.ndarray],
+    ) -> _AppendGroups:
+        """Materialize this run's groups in the shape the merge consumes."""
+        offsets = grouping.offsets
+        representative_rows = grouping.row_order[offsets[:-1]]
+        codes = origin_codes[representative_rows]
+        if resolved_last_codes is not None:
+            codes = codes.copy()
+            codes[:, -1] = resolved_last_codes[representative_rows]
+        return _AppendGroups(
+            grouping=grouping,
+            codes=codes,
+            item_ids=self._item_id_array(item_ids[grouping.row_order]),
+        )
+
+    def _write_merged_sid_groups(
+        self,
+        resolved_path: str,
+        existing_path: str,
+        item_ids: np.ndarray,
+        origin_codes: np.ndarray,
+        grouping: CodebookItemGrouping,
+        resolved_last_codes: Optional[np.ndarray],
+    ) -> None:
+        """Merge this run's groups into the published groups and write both.
+
+        Streams the published groups once and interleaves this run's groups by
+        SID key, so the resolved output is corpus-complete and still ascending
+        -- which is exactly what the next append merge-joins against. The
+        optional delta output receives the same rows for the buckets this run
+        changed, so a serving index can upsert them idempotently.
+
+        Args:
+            resolved_path: Corpus-complete groups output.
+            existing_path: Previous round's groups artifact.
+            item_ids: Item IDs of the new batch in original row order.
+            origin_codes: Original full SID matrix of the new batch.
+            grouping: This run's resolved grouping.
+            resolved_last_codes: Final last-layer codes, or ``None``.
+        """
+        layer_sizes = self._config.layer_sizes
+        groups = self._build_append_groups(
+            item_ids, origin_codes, grouping, resolved_last_codes
+        )
+        group_count = groups.keys.shape[0]
+
+        with ExitStack() as stack:
+            writer = stack.enter_context(closing(self._make_writer(resolved_path)))
+            is_csv = isinstance(writer, CsvWriter)
+            delta_writer: Optional[BaseWriter] = None
+            delta_is_csv = False
+            if self._config.delta_sid_groups_output_path is not None:
+                delta_writer = stack.enter_context(
+                    closing(
+                        self._make_writer(self._config.delta_sid_groups_output_path)
+                    )
+                )
+                delta_is_csv = isinstance(delta_writer, CsvWriter)
+
+            def emit(
+                codes: np.ndarray,
+                offsets: np.ndarray,
+                values: pa.Array,
+                delta_rows: Optional[np.ndarray],
+            ) -> None:
+                """Write one chunk to the corpus output and the delta output."""
+                self._emit_group_rows(writer, is_csv, codes, offsets, values)
+                if delta_writer is not None:
+                    self._emit_group_rows(
+                        delta_writer, delta_is_csv, codes, offsets, values, delta_rows
+                    )
+
+            max_rows = _max_code_rows(is_csv, groups.codes.shape[1], group_count)
+
+            def emit_new_only(low: int, high: int) -> None:
+                """Write groups this run created in buckets nobody occupied."""
+                for start, stop in _group_chunk_bounds(
+                    groups.offsets, low, high, max_rows
+                ):
+                    child_low = int(groups.offsets[start])
+                    child_high = int(groups.offsets[stop])
+                    emit(
+                        groups.codes[start:stop],
+                        groups.offsets[start : stop + 1] - child_low,
+                        groups.item_ids.slice(child_low, child_high - child_low),
+                        np.arange(stop - start),
+                    )
+
+            cursor = 0
+            for batch in self._iter_state_batches(
+                existing_path,
+                ["codebook", "itemids"],
+                "Writing merged SID item groups",
+            ):
+                batch_codes = self._codes_matrix(batch["codebook"])
+                batch_keys = sid_bucket_keys(batch_codes, layer_sizes)
+                if batch_keys.size == 0:
+                    continue
+                low = int(np.searchsorted(groups.keys, batch_keys[0], side="left"))
+                if cursor < low:
+                    emit_new_only(cursor, low)
+                high = int(np.searchsorted(groups.keys, batch_keys[-1], side="right"))
+                batch_lengths, batch_values = self._decode_grouped_item_ids(
+                    batch["itemids"]
+                )
+                self._check_state_item_id_type(batch_values, "existing SID groups")
+                emit(
+                    *_merge_group_batch(
+                        batch_keys,
+                        batch_codes,
+                        batch_lengths,
+                        batch_values,
+                        groups,
+                        low,
+                        high,
+                    )
+                )
+                cursor = high
+            emit_new_only(cursor, group_count)
 
     def _write_sid_groups(
         self,
@@ -685,20 +1454,12 @@ class CollisionResolutionRunner:
             is_csv = isinstance(writer, CsvWriter)
             progress = ProgressLogger(progress_description, start_n=0)
             last_progress_count = 0
-            max_codebook_rows = (
-                group_count
-                if is_csv
-                else _ARROW_LIST_OFFSET_MAX // origin_codes.shape[1]
+            max_codebook_rows = _max_code_rows(
+                is_csv, origin_codes.shape[1], group_count
             )
-            if not is_csv and max_codebook_rows < 1:
-                raise ValueError("one SID row exceeds Arrow list offset capacity.")
-            group_start = 0
-            while group_start < group_count:
-                child_limit = int(offsets[group_start]) + _GROUP_WRITE_ITEMS
-                group_end = int(np.searchsorted(offsets, child_limit, side="right") - 1)
-                group_end = max(group_end, group_start + 1)
-                group_end = min(group_end, group_start + max_codebook_rows)
-
+            for group_start, group_end in _group_chunk_bounds(
+                offsets, 0, group_count, max_codebook_rows
+            ):
                 child_start = int(offsets[group_start])
                 child_end = int(offsets[group_end])
                 rows = grouping.row_order[child_start:child_end]
@@ -718,13 +1479,178 @@ class CollisionResolutionRunner:
                         ),
                     }
                 )
-                group_start = group_end
                 if self._progress_interval_reached(child_end, last_progress_count):
                     progress.log(
                         child_end,
                         suffix=f"{child_end} samples processed",
                     )
                     last_progress_count = child_end
+
+
+def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
+    """Return how many SID rows one write can encode.
+
+    Args:
+        is_csv: Whether the destination writer is a CSV writer, which encodes
+            codes as text and so has no Arrow list offset ceiling.
+        layer_count: Number of SID layers per row.
+        row_cap: Upper bound the caller already knows.
+
+    Returns:
+        The row count for one write.
+    """
+    if is_csv:
+        return row_cap
+    return min(row_cap, _ARROW_LIST_OFFSET_MAX // layer_count)
+
+
+def _group_chunk_bounds(
+    offsets: np.ndarray, low: int, high: int, max_rows: int
+) -> Iterator[Tuple[int, int]]:
+    """Split ``[low, high)`` groups into writable chunks.
+
+    A chunk holds at most ``_GROUP_WRITE_ITEMS`` child items and ``max_rows``
+    groups, and always advances by at least one group so a single oversized
+    group still makes progress.
+
+    Args:
+        offsets: CSR offsets of every group.
+        low: First group index.
+        high: One past the last group index.
+        max_rows: Largest number of groups one write may carry.
+
+    Yields:
+        Half-open ``(start, stop)`` group ranges covering ``[low, high)``.
+    """
+    while low < high:
+        child_limit = int(offsets[low]) + _GROUP_WRITE_ITEMS
+        stop = int(np.searchsorted(offsets, child_limit, side="right") - 1)
+        stop = min(max(stop, low + 1), low + max_rows, high)
+        yield low, stop
+        low = stop
+
+
+@dataclass(frozen=True)
+class _AppendGroups:
+    """This run's SID groups, prepared for merging into the published groups.
+
+    Args:
+        grouping: This run's resolved grouping; owns keys, counts and offsets.
+        codes: Emitted SID of every group, shape ``(len(keys), n_layers)``.
+        item_ids: Item IDs of every group flattened in group and slot order.
+    """
+
+    grouping: CodebookItemGrouping
+    codes: np.ndarray
+    item_ids: pa.Array
+
+    @property
+    def keys(self) -> np.ndarray:
+        """Ascending flattened SID key of every group."""
+        return self.grouping.sid_keys
+
+    @property
+    def counts(self) -> np.ndarray:
+        """Item count of every group."""
+        return self.grouping.counts
+
+    @property
+    def offsets(self) -> np.ndarray:
+        """CSR offsets into ``item_ids``."""
+        return self.grouping.offsets
+
+
+def _merge_group_batch(
+    batch_keys: np.ndarray,
+    batch_codes: np.ndarray,
+    batch_lengths: np.ndarray,
+    batch_values: pa.Array,
+    groups: _AppendGroups,
+    low: int,
+    high: int,
+) -> Tuple[np.ndarray, np.ndarray, pa.Array, np.ndarray]:
+    """Merge one batch of published groups with the new groups it overlaps.
+
+    Both sides are ascending by SID key, so the output is their sorted union:
+    a bucket present on both sides emits one row whose item list is the
+    published items followed by this run's items. That order is also slot
+    order, because published items hold slots ``1..P`` and new items continue
+    from ``P + 1``.
+
+    Args:
+        batch_keys: Ascending SID keys of the published batch.
+        batch_codes: SID matrix of the published batch.
+        batch_lengths: Item count of every published group.
+        batch_values: Flattened item IDs of the published batch.
+        groups: This run's groups.
+        low: First index of ``groups`` at or after ``batch_keys[0]``.
+        high: One past the last index of ``groups`` at or before the batch end.
+
+    Returns:
+        Emitted codes, CSR offsets, flattened item IDs, and the output rows
+        that this run changed.
+    """
+    batch_rows = batch_keys.shape[0]
+    candidate_keys = groups.keys[low:high]
+    positions = np.searchsorted(candidate_keys, batch_keys)
+    matched = positions < candidate_keys.shape[0]
+    matched[matched] = candidate_keys[positions[matched]] == batch_keys[matched]
+
+    new_for_batch = np.full(batch_rows, -1, dtype=np.int64)
+    new_for_batch[matched] = low + positions[matched]
+    consumed = np.zeros(candidate_keys.shape[0], dtype=bool)
+    consumed[positions[matched]] = True
+    unmatched = low + np.flatnonzero(~consumed)
+
+    # Interleave by key: every key is unique across the union because matched
+    # pairs collapse into a single row.
+    output_rows = batch_rows + unmatched.shape[0]
+    batch_slots = np.arange(batch_rows) + np.searchsorted(
+        groups.keys[unmatched], batch_keys, side="left"
+    )
+    unmatched_slots = np.arange(unmatched.shape[0]) + np.searchsorted(
+        batch_keys, groups.keys[unmatched], side="left"
+    )
+
+    batch_of_output = np.full(output_rows, -1, dtype=np.int64)
+    batch_of_output[batch_slots] = np.arange(batch_rows)
+    new_of_output = np.full(output_rows, -1, dtype=np.int64)
+    new_of_output[batch_slots] = new_for_batch
+    new_of_output[unmatched_slots] = unmatched
+
+    has_batch = batch_of_output >= 0
+    has_new = new_of_output >= 0
+    batch_index = np.maximum(batch_of_output, 0)
+    new_index = np.maximum(new_of_output, 0)
+
+    codes = np.empty((output_rows, batch_codes.shape[1]), dtype=np.int64)
+    codes[batch_slots] = batch_codes
+    if unmatched.size:
+        codes[unmatched_slots] = groups.codes[unmatched]
+
+    batch_part = np.where(has_batch, batch_lengths[batch_index], 0)
+    new_part = np.where(has_new, groups.counts[new_index], 0)
+    offsets = np.zeros(output_rows + 1, dtype=np.int64)
+    np.cumsum(batch_part + new_part, out=offsets[1:])
+
+    # Gather from the published child values followed by only the slice of new
+    # item IDs this batch needs, so the copy stays proportional to the batch.
+    child_low = int(groups.offsets[low])
+    child_high = int(groups.offsets[high])
+    combined = pa.concat_arrays(
+        [batch_values, groups.item_ids.slice(child_low, child_high - child_low)]
+    )
+    batch_child_starts = np.zeros(batch_rows + 1, dtype=np.int64)
+    np.cumsum(batch_lengths, out=batch_child_starts[1:])
+    gather = np.empty(int(offsets[-1]), dtype=np.int64)
+    gather[concat_ranges(offsets[:-1], batch_part)] = concat_ranges(
+        batch_child_starts[batch_index], batch_part
+    )
+    gather[concat_ranges(offsets[:-1] + batch_part, new_part)] = concat_ranges(
+        len(batch_values) + groups.offsets[new_index] - child_low, new_part
+    )
+    values = combined.take(pa.array(gather, type=pa.int64()))
+    return codes, offsets, values, np.flatnonzero(has_new)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -752,6 +1678,36 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Output grouped item IDs keyed by their resolved SID; required "
             "unless --rate_only is set."
+        ),
+    )
+    parser.add_argument(
+        "--existing_sid_groups_path",
+        default=None,
+        help=(
+            "Previous round's --resolved_sid_groups_output_path. Supplying it "
+            "selects append mode: the new items in --input_path are placed "
+            "without moving any already-published SID."
+        ),
+    )
+    parser.add_argument(
+        "--existing_sid_map_path",
+        default=None,
+        help=(
+            "Previous round's --output_path. Required in append mode unless "
+            "--rate_only, because only the map carries origin_codebook."
+        ),
+    )
+    parser.add_argument(
+        "--delta_map_output_path",
+        default=None,
+        help="Append mode only: map rows for the new items alone.",
+    )
+    parser.add_argument(
+        "--delta_sid_groups_output_path",
+        default=None,
+        help=(
+            "Append mode only: buckets this run changed, each with its complete "
+            "post-append item list, for an idempotent index upsert."
         ),
     )
     parser.add_argument(

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -76,7 +76,6 @@ generation needs a fresh output directory.
 from __future__ import annotations
 
 import argparse
-import json
 import os
 from contextlib import ExitStack, closing
 from dataclasses import dataclass
@@ -108,11 +107,9 @@ from tzrec.utils.sid.collision import (
     KnnCollisionResolver,
     PriorOccupancy,
     RandomCollisionResolver,
-    bands_of_bucket_keys,
     build_original_item_grouping,
     build_resolved_item_grouping,
     concat_ranges,
-    in_sorted_bands,
     lookup_sorted,
     prepare_collision_plan,
     sid_band_ids,
@@ -205,7 +202,6 @@ class ResolveSidCollisionsConfig:
     random_num_candidates: int
     rate_only: bool
     odps_data_quota_name: str
-    # Append mode; defaulted so full-resolve callers need not pass them.
     existing_sid_map_path: Optional[str] = None
     existing_sid_groups_path: Optional[str] = None
     delta_map_output_path: Optional[str] = None
@@ -236,7 +232,6 @@ class ResolveSidCollisionsConfig:
                 "is set; without it the merged map would hold only the new items."
             )
 
-        # Append-only paths are ignored, not rejected, outside append mode.
         candidates = [self.output_path, self.resolved_sid_groups_output_path]
         candidates.append(self.original_sid_groups_output_path)
         if self.is_append:
@@ -593,8 +588,6 @@ class CollisionResolutionRunner:
 
         layer_sizes = self._config.layer_sizes
         if codes.shape[1] != len(layer_sizes):
-            # prepare_collision_plan raises the same way, but only after these
-            # two corpus-sized passes would already have run.
             raise ValueError(
                 f"codes have {codes.shape[1]} layers but --codebook has "
                 f"{len(layer_sizes)}."
@@ -619,24 +612,22 @@ class CollisionResolutionRunner:
     def _decode_grouped_item_ids(self, values: pa.Array) -> Tuple[np.ndarray, pa.Array]:
         """Decode a grouped item-ID column into per-group counts and values.
 
-        Inverse of :meth:`_grouped_item_ids_column`. List columns stay
-        zero-copy; the CSV form is a JSON array string that must be parsed --
-        a comma count would be wrong for string IDs containing commas -- so
-        both halves come out of one parse rather than two.
+        Inverse of :meth:`_grouped_item_ids_column`: list columns stay
+        zero-copy, the CSV form splits on the comma it was joined with.
         """
         if _is_list_column(values):
-            lengths = (
-                pc.list_value_length(values)
-                .to_numpy(zero_copy_only=False)
-                .astype(np.int64, copy=False)
-            )
-            return lengths, values.flatten()
-        groups = [json.loads(text) for text in values.to_pylist()]
-        lengths = np.fromiter(
-            (len(group) for group in groups), dtype=np.int64, count=len(groups)
+            lists = values
+        else:
+            lists = pc.split_pattern(pc.cast(values, pa.string()), ",")
+        lengths = (
+            pc.list_value_length(lists)
+            .to_numpy(zero_copy_only=False)
+            .astype(np.int64, copy=False)
         )
-        flat = [item_id for group in groups for item_id in group]
-        return lengths, pa.array(flat, type=self._item_id_type)
+        flat = lists.flatten()
+        if self._item_id_type is not None and flat.type != self._item_id_type:
+            flat = pc.cast(flat, self._item_id_type)
+        return lengths, flat
 
     def _align_codes_column(self, values: pa.Array, is_csv: bool) -> pa.Array:
         """Return an SID column in the encoding the destination writer needs.
@@ -703,8 +694,6 @@ class CollisionResolutionRunner:
 
             lengths, flat_ids = self._decode_grouped_item_ids(batch["itemids"])
             if len(flat_ids):
-                self._check_state_item_id_type(flat_ids, "existing SID groups")
-                # Hash membership avoids materializing IDs as Python objects.
                 published = pc.is_in(flat_ids, value_set=new_item_ids)
                 batch_overlap = int(pc.sum(published).as_py() or 0)
                 overlap_count += batch_overlap
@@ -713,7 +702,7 @@ class CollisionResolutionRunner:
                         flat_ids.filter(published).slice(0, 10).to_pylist()
                     )
 
-            keep = in_sorted_bands(keys, wanted_bands, layer_sizes[-1])
+            _, keep = lookup_sorted(wanted_bands, keys // layer_sizes[-1])
             if np.any(keep):
                 key_chunks.append(keys[keep])
                 count_chunks.append(lengths[keep])
@@ -745,10 +734,8 @@ class CollisionResolutionRunner:
             return
         layer_sizes = self._config.layer_sizes
         domain = prior.bucket_keys
-        bands = np.unique(bands_of_bucket_keys(domain, layer_sizes[-1]))
+        bands = np.unique(domain // layer_sizes[-1])
         unknown_keys: List[int] = []
-        # Reduce once at the end: a per-batch reduction would allocate a
-        # domain-sized accumulator for every batch.
         position_chunks: List[np.ndarray] = []
         index_chunks: List[np.ndarray] = []
 
@@ -758,8 +745,8 @@ class CollisionResolutionRunner:
             "Cross-checking published SID map",
         ):
             keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
-            # Buckets outside the new batch's bands cannot affect this run.
-            rows = np.flatnonzero(in_sorted_bands(keys, bands, layer_sizes[-1]))
+            _, known_band = lookup_sorted(bands, keys // layer_sizes[-1])
+            rows = np.flatnonzero(known_band)
             if rows.size == 0:
                 continue
             keys = keys[rows]
@@ -786,8 +773,6 @@ class CollisionResolutionRunner:
             sum_index = np.bincount(
                 positions, weights=indices, minlength=domain.shape[0]
             ).astype(np.int64, copy=False)
-            # Segment maximum via one stable sort plus reduceat; np.maximum.at
-            # is unbuffered and far slower at corpus scale.
             order = np.argsort(positions, kind="stable")
             sorted_positions = positions[order]
             starts = np.flatnonzero(
@@ -874,29 +859,14 @@ class CollisionResolutionRunner:
         if not is_csv:
             return pa.ListArray.from_arrays(arrow_offsets, values)
 
-        if pa.types.is_integer(values.type):
-            encoded_values = pc.cast(values, pa.string())
-        else:
-            try:
-                encoded_values = pa.array(
-                    [
-                        json.dumps(
-                            value,
-                            ensure_ascii=False,
-                            separators=(",", ":"),
-                        )
-                        for value in values.to_pylist()
-                    ],
-                    type=pa.string(),
-                )
-            except (TypeError, ValueError) as error:
-                raise ValueError(
-                    "CSV SID group output cannot JSON-encode item ID type "
-                    f"{values.type}."
-                ) from error
+        encoded_values = pc.cast(values, pa.string())
+        if pc.any(pc.match_substring(encoded_values, ",")).as_py():
+            raise ValueError(
+                "CSV SID group output joins item IDs with commas, so an item ID "
+                "cannot itself contain one; use parquet or ODPS for such IDs."
+            )
         encoded_lists = pa.ListArray.from_arrays(arrow_offsets, encoded_values)
-        joined_values = pc.binary_join(encoded_lists, ",")
-        return pc.binary_join_element_wise("[", joined_values, "]", "")
+        return pc.binary_join(encoded_lists, ",")
 
     @staticmethod
     def _codes_column(codes: np.ndarray, is_csv: bool) -> pa.Array:
@@ -926,25 +896,9 @@ class CollisionResolutionRunner:
         )
         return pa.ListArray.from_arrays(offsets, values)
 
-    def _map_write_chunk_rows(self, is_csv: bool, layer_count: int) -> int:
-        """Return the largest map row count one write can encode.
-
-        Args:
-            is_csv: Whether the destination writer is a CSV writer.
-            layer_count: Number of SID layers per row.
-
-        Returns:
-            The chunk size in rows.
-
-        Raises:
-            ValueError: If a single row exceeds Arrow list offset capacity.
-        """
-        return _max_code_rows(is_csv, layer_count, _MAP_WRITE_ROWS)
-
     def _write_new_map_rows(
         self,
         writer: BaseWriter,
-        is_csv: bool,
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         result: CollisionResolutionResult,
@@ -952,9 +906,10 @@ class CollisionResolutionRunner:
         written: int,
     ) -> None:
         """Write this run's own item rows in chunks, without a full code copy."""
+        is_csv = isinstance(writer, CsvWriter)
         output_count = item_ids.shape[0]
         last_progress_count = written
-        write_chunk = self._map_write_chunk_rows(is_csv, origin_codes.shape[1])
+        write_chunk = _max_code_rows(is_csv, origin_codes.shape[1], _MAP_WRITE_ROWS)
         for start in range(0, output_count, write_chunk):
             end = min(start + write_chunk, output_count)
             selection = slice(start, end)
@@ -974,7 +929,7 @@ class CollisionResolutionRunner:
                 progress.log(written, suffix=f"{written} samples processed")
                 last_progress_count = written
 
-    def _stream_existing_map_rows(self, writer: BaseWriter, is_csv: bool) -> int:
+    def _stream_existing_map_rows(self, writer: BaseWriter) -> int:
         """Copy every published map row into the merged output unchanged.
 
         Existing rows keep their item ID, both codebooks and their slot index
@@ -986,18 +941,15 @@ class CollisionResolutionRunner:
         path = self._config.existing_sid_map_path
         if path is None or not self._config.is_append:
             return 0
-        fields = [
-            "item_id",
-            "origin_codebook",
-            "codebook",
-            "index",
-        ]
+        is_csv = isinstance(writer, CsvWriter)
+        fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
-        for batch in self._iter_state_batches(
-            path, fields, "Copying published item map"
+        for index, batch in enumerate(
+            self._iter_state_batches(path, fields, "Copying published item map")
         ):
             item_id_column = batch["item_id"]
-            self._check_state_item_id_type(item_id_column, "existing SID map")
+            if index == 0:
+                self._check_state_item_id_type(item_id_column, "existing SID map")
             writer.write(
                 {
                     "item_id": item_id_column,
@@ -1027,21 +979,18 @@ class CollisionResolutionRunner:
         if output_path is None:
             raise RuntimeError("map output path was not validated.")
         with closing(self._make_writer(output_path)) as writer:
-            is_csv = isinstance(writer, CsvWriter)
             progress = ProgressLogger("Writing resolved item map", start_n=0)
-            written = self._stream_existing_map_rows(writer, is_csv)
+            written = self._stream_existing_map_rows(writer)
             self._write_new_map_rows(
-                writer, is_csv, item_ids, origin_codes, result, progress, written
+                writer, item_ids, origin_codes, result, progress, written
             )
 
-        # Ignored outside append mode; there it would duplicate the full map.
         delta_path = self._config.delta_map_output_path
         if delta_path is None or not self._config.is_append:
             return
         with closing(self._make_writer(delta_path)) as writer:
             self._write_new_map_rows(
                 writer,
-                isinstance(writer, CsvWriter),
                 item_ids,
                 origin_codes,
                 result,
@@ -1112,7 +1061,6 @@ class CollisionResolutionRunner:
     def _emit_group_rows(
         self,
         writer: BaseWriter,
-        is_csv: bool,
         codes: np.ndarray,
         offsets: np.ndarray,
         values: pa.Array,
@@ -1122,6 +1070,7 @@ class CollisionResolutionRunner:
 
         ``rows`` selects a subset of the groups, or ``None`` for all of them.
         """
+        is_csv = isinstance(writer, CsvWriter)
         lengths = np.diff(offsets)
         if rows is not None:
             if rows.size == 0:
@@ -1188,14 +1137,12 @@ class CollisionResolutionRunner:
             writer = stack.enter_context(closing(self._make_writer(resolved_path)))
             is_csv = isinstance(writer, CsvWriter)
             delta_writer: Optional[BaseWriter] = None
-            delta_is_csv = False
             if self._config.delta_sid_groups_output_path is not None:
                 delta_writer = stack.enter_context(
                     closing(
                         self._make_writer(self._config.delta_sid_groups_output_path)
                     )
                 )
-                delta_is_csv = isinstance(delta_writer, CsvWriter)
 
             def emit(
                 codes: np.ndarray,
@@ -1204,10 +1151,10 @@ class CollisionResolutionRunner:
                 delta_rows: Optional[np.ndarray],
             ) -> None:
                 """Write one chunk to the corpus output and the delta output."""
-                self._emit_group_rows(writer, is_csv, codes, offsets, values)
+                self._emit_group_rows(writer, codes, offsets, values)
                 if delta_writer is not None:
                     self._emit_group_rows(
-                        delta_writer, delta_is_csv, codes, offsets, values, delta_rows
+                        delta_writer, codes, offsets, values, delta_rows
                     )
 
             max_rows = _max_code_rows(is_csv, groups.codes.shape[1], group_count)
@@ -1243,7 +1190,6 @@ class CollisionResolutionRunner:
                 batch_lengths, batch_values = self._decode_grouped_item_ids(
                     batch["itemids"]
                 )
-                self._check_state_item_id_type(batch_values, "existing SID groups")
                 emit(
                     *_merge_group_batch(
                         batch_keys,
@@ -1411,8 +1357,6 @@ def _merge_group_batch(
     consumed[positions[matched]] = True
     unmatched = low + np.flatnonzero(~consumed)
 
-    # Interleave by key: every key is unique across the union because matched
-    # pairs collapse into a single row.
     output_rows = batch_rows + unmatched.shape[0]
     batch_slots = np.arange(batch_rows) + np.searchsorted(
         groups.keys[unmatched], batch_keys, side="left"
@@ -1442,8 +1386,6 @@ def _merge_group_batch(
     offsets = np.zeros(output_rows + 1, dtype=np.int64)
     np.cumsum(batch_part + new_part, out=offsets[1:])
 
-    # Take only the slice of new item IDs this batch needs, so the copy stays
-    # proportional to the batch.
     child_low = int(groups.offsets[low])
     child_high = int(groups.offsets[high])
     combined = pa.concat_arrays(

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -596,15 +596,15 @@ class CollisionResolutionRunner:
         layer_sizes = self._config.layer_sizes
         groups_path = self._config.existing_sid_groups_path
         assert groups_path is not None
-        prior = self._load_prior_occupancy(
+        prior, published_items = self._load_prior_occupancy(
             groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
-        self._cross_check_existing_map(prior)
+        self._cross_check_existing_map(prior, published_items)
         logger.info(
             "append mode: %d new items onto %d published items in %d touched "
             "buckets (groups=%s, map=%s)",
             item_ids.shape[0],
-            prior.total_items,
+            published_items,
             prior.bucket_keys.shape[0],
             self._config.existing_sid_groups_path,
             self._config.existing_sid_map_path,
@@ -656,8 +656,8 @@ class CollisionResolutionRunner:
 
     def _load_prior_occupancy(
         self, path: str, band_ids: np.ndarray, item_ids: np.ndarray
-    ) -> PriorOccupancy:
-        """Read published occupancy from the previous round's resolved groups."""
+    ) -> Tuple[PriorOccupancy, int]:
+        """Read published occupancy and total item count from the resolved groups."""
         layer_sizes = self._config.layer_sizes
         wanted_bands = np.unique(band_ids)
         new_item_ids = self._item_id_array(item_ids)
@@ -666,6 +666,7 @@ class CollisionResolutionRunner:
         count_chunks: List[np.ndarray] = []
         overlapping: List[object] = []
         overlap_count = 0
+        published_items = 0
         previous_max_key = -1
         for batch in self._iter_state_batches(
             path,
@@ -683,6 +684,7 @@ class CollisionResolutionRunner:
                 previous_max_key = int(keys[-1])
 
             lengths, flat_ids = self._decode_grouped_item_ids(batch["itemids"])
+            published_items += int(lengths.sum())
             if len(flat_ids):
                 published = pc.is_in(flat_ids, value_set=new_item_ids)
                 batch_overlap = published.true_count
@@ -705,13 +707,18 @@ class CollisionResolutionRunner:
                 f"offending IDs: {preview}."
             )
         if not key_chunks:
-            return PriorOccupancy.empty()
-        return PriorOccupancy(np.concatenate(key_chunks), np.concatenate(count_chunks))
+            return PriorOccupancy.empty(), published_items
+        return (
+            PriorOccupancy(np.concatenate(key_chunks), np.concatenate(count_chunks)),
+            published_items,
+        )
 
-    def _cross_check_existing_map(self, prior: PriorOccupancy) -> None:
+    def _cross_check_existing_map(
+        self, prior: PriorOccupancy, published_items: int
+    ) -> None:
         """Verify the existing map agrees with the published groups."""
         path = self._config.existing_sid_map_path
-        if path is None or prior.is_empty:
+        if path is None:
             return
         layer_sizes = self._config.layer_sizes
         domain = prior.bucket_keys
@@ -720,6 +727,7 @@ class CollisionResolutionRunner:
         counts = np.zeros(domain.shape[0], dtype=np.int64)
         max_index = np.zeros(domain.shape[0], dtype=np.int64)
         sum_index = np.zeros(domain.shape[0], dtype=np.int64)
+        map_rows = 0
 
         for batch in self._iter_state_batches(
             path,
@@ -727,6 +735,7 @@ class CollisionResolutionRunner:
             "Cross-checking published SID map",
         ):
             keys = sid_bucket_keys(self._codes_matrix(batch["codebook"]), layer_sizes)
+            map_rows += keys.shape[0]
             _, known_band = lookup_sorted(bands, keys // layer_sizes[-1])
             if not known_band.any():
                 continue
@@ -751,6 +760,14 @@ class CollisionResolutionRunner:
             )
 
         self._report_cross_check(prior, counts, max_index, sum_index, unknown_keys)
+        if map_rows != published_items:
+            raise ValueError(
+                f"existing map holds {map_rows} rows but the existing groups hold "
+                f"{published_items} item IDs; one of the two artifacts is "
+                "incomplete, and appending onto it would drop published items or "
+                "reuse their slots. The per-bucket checks only cover bands the new "
+                "items touch, so a truncated shard elsewhere shows up only here."
+            )
 
     @staticmethod
     def _report_cross_check(

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -418,7 +418,7 @@ class CollisionResolutionRunner:
             codebook=list(self._config.layer_sizes),
             capacity=self._config.max_items_per_codebook,
             observed=result.stats.max_final_bucket_size,
-            item_id_type=str(self._item_id_type) if self._item_id_type else None,
+            item_id_type=str(self._item_id_type),
             writer_type=self._resolved_writer_type,
         )
         logger.info("wrote bundle %s manifest to %s", self._bundle.uuid, path)
@@ -454,8 +454,8 @@ class CollisionResolutionRunner:
         missing = [name for name in fields if name not in reader.schema.names]
         if missing:
             raise ValueError(
-                f"columns {missing} are missing from {path!r}; point the flag at "
-                "an output directory written by this tool."
+                f"columns {missing} are missing from {path!r}; it is not an "
+                "artifact this tool published."
             )
         progress = ProgressLogger(description, start_n=0)
         scanned = 0
@@ -656,8 +656,8 @@ class CollisionResolutionRunner:
         )
         self._check_existing_item_to_sid_size(published_items)
         logger.info(
-            "append mode: %d new items onto %d published items in %d touched "
-            "buckets, from generation %s",
+            "append mode: %d new items onto %d published items; %d published "
+            "buckets loaded from the bands this run touches, generation %s",
             item_ids.shape[0],
             published_items,
             prior.bucket_keys.shape[0],
@@ -677,7 +677,7 @@ class CollisionResolutionRunner:
             .astype(np.int64, copy=False)
         )
         flat = lists.flatten()
-        if self._item_id_type is not None and flat.type != self._item_id_type:
+        if flat.type != self._item_id_type:
             flat = pc.cast(flat, self._item_id_type)
         return lengths, flat
 
@@ -697,13 +697,13 @@ class CollisionResolutionRunner:
             return values
         return self._codes_column(self._codes_matrix(values), is_csv)
 
-    def _check_state_item_id_type(self, values: pa.Array, source: str) -> None:
+    def _check_state_item_id_type(self, values: pa.Array) -> None:
         """Reject an existing artifact whose item ID type differs from the input."""
         if len(values) == 0:
             return
         if values.type != self._item_id_type:
             raise ValueError(
-                f"{source} item ID type {values.type} differs from the new-items "
+                f"existing item_to_sid item ID type {values.type} differs from the "
                 f"input type {self._item_id_type}; the merged item_to_sid cannot mix "
                 "them. Re-export the state or the prediction with one type."
             )
@@ -711,7 +711,7 @@ class CollisionResolutionRunner:
     def _load_prior_occupancy(
         self, path: str, band_ids: np.ndarray, item_ids: np.ndarray
     ) -> Tuple[PriorOccupancy, int]:
-        """Read published occupancy and total item count from the resolved groups."""
+        """Read touched-band occupancy and item count from published sid_to_items."""
         layer_sizes = self._config.layer_sizes
         wanted_bands = np.unique(band_ids)
         new_item_ids = self._item_id_array(item_ids)
@@ -768,7 +768,7 @@ class CollisionResolutionRunner:
         )
 
     def _check_existing_item_to_sid_size(self, published_items: int) -> None:
-        """Reject a published map whose size disagrees with the groups."""
+        """Reject published item_to_sid whose row count disagrees with sid_to_items."""
         item_to_sid_rows = 0
         for batch in self._iter_state_batches(
             self._bundle.prior_item_to_sid_path,
@@ -791,8 +791,6 @@ class CollisionResolutionRunner:
     ) -> BaseWriter:
         """Create a repository writer, defaulting to the resolved writer type."""
         writer_type = writer_type or self._resolved_writer_type
-        if writer_type is None:
-            raise RuntimeError("writer type is unavailable before reading input.")
         return create_writer(
             output_path,
             writer_type=writer_type,
@@ -836,7 +834,7 @@ class CollisionResolutionRunner:
 
     def _write_new_item_to_sid_rows(
         self,
-        writer: BaseWriter,
+        writers: List[BaseWriter],
         item_ids: np.ndarray,
         origin_codes: np.ndarray,
         result: CollisionResolutionResult,
@@ -845,30 +843,35 @@ class CollisionResolutionRunner:
     ) -> int:
         """Write this run's own item rows in chunks, without a full code copy.
 
+        Each chunk is encoded once and handed to every writer, so the corpus
+        artifact and the delta do not pay for the same encode twice.
+
         Returns:
             How many item rows this run added.
         """
         is_csv = self._resolved_writer_type == "CsvWriter"
         output_count = item_ids.shape[0]
         last_progress_count = written
-        write_chunk = _max_code_rows(
-            is_csv, origin_codes.shape[1], _ITEM_TO_SID_WRITE_ROWS
-        )
+        write_chunk = _ITEM_TO_SID_WRITE_ROWS
+        if not is_csv:
+            write_chunk = min(
+                write_chunk, _ARROW_LIST_OFFSET_MAX // origin_codes.shape[1]
+            )
         for start in range(0, output_count, write_chunk):
             end = min(start + write_chunk, output_count)
             selection = slice(start, end)
             origin_chunk = origin_codes[selection]
             final_chunk = origin_chunk.copy()
             final_chunk[:, -1] = result.resolved_last_codes[selection]
-            writer.write(
-                {
-                    "item_id": self._item_id_array(item_ids[selection]),
-                    "origin_codebook": self._codes_column(origin_chunk, is_csv),
-                    "codebook": self._codes_column(final_chunk, is_csv),
-                    "offset_codebook": self._offset_codes_column(final_chunk, is_csv),
-                    "index": pa.array(result.slot_indices[selection], type=pa.int64()),
-                }
-            )
+            columns = {
+                "item_id": self._item_id_array(item_ids[selection]),
+                "origin_codebook": self._codes_column(origin_chunk, is_csv),
+                "codebook": self._codes_column(final_chunk, is_csv),
+                "offset_codebook": self._offset_codes_column(final_chunk, is_csv),
+                "index": pa.array(result.slot_indices[selection], type=pa.int64()),
+            }
+            for writer in writers:
+                writer.write(columns)
             written += end - start
             if self._progress_interval_reached(written, last_progress_count):
                 progress.log(written, suffix=f"{written} samples processed")
@@ -876,7 +879,11 @@ class CollisionResolutionRunner:
         return output_count
 
     def _stream_existing_item_to_sid_rows(self, writer: BaseWriter) -> int:
-        """Copy every published item_to_sid row into the merged output unchanged."""
+        """Copy every published item_to_sid row into the merged output.
+
+        The SID assignment is untouched; codes are re-encoded for this run's
+        writer and ``offset_codebook`` is re-derived from ``codebook``.
+        """
         if not self._config.is_append:
             return 0
         path = self._bundle.prior_item_to_sid_path
@@ -887,7 +894,7 @@ class CollisionResolutionRunner:
             path, fields, "Copying published item_to_sid"
         ):
             item_id_column = batch["item_id"]
-            self._check_state_item_id_type(item_id_column, "existing item_to_sid")
+            self._check_state_item_id_type(item_id_column)
             writer.write(
                 {
                     "item_id": item_id_column,
@@ -916,27 +923,29 @@ class CollisionResolutionRunner:
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        with closing(self._make_writer(self._bundle.item_to_sid_path)) as writer:
-            progress = ProgressLogger("Writing resolved item_to_sid", start_n=0)
-            written = self._stream_existing_item_to_sid_rows(writer)
-            written += self._write_new_item_to_sid_rows(
-                writer, item_ids, origin_codes, result, progress, written
+        with ExitStack() as stack:
+            writer = stack.enter_context(
+                closing(self._make_writer(self._bundle.item_to_sid_path))
             )
-            self._bundle.record_item_to_sid(written)
-
-        if not self._config.is_append:
-            return
-        with closing(self._make_writer(self._bundle.delta_item_to_sid_path)) as writer:
-            self._bundle.record_delta_item_to_sid(
-                self._write_new_item_to_sid_rows(
-                    writer,
-                    item_ids,
-                    origin_codes,
-                    result,
-                    ProgressLogger("Writing delta item_to_sid", start_n=0),
-                    0,
+            writers = [writer]
+            if self._config.is_append:
+                writers.append(
+                    stack.enter_context(
+                        closing(self._make_writer(self._bundle.delta_item_to_sid_path))
+                    )
                 )
+            copied = self._stream_existing_item_to_sid_rows(writer)
+            added = self._write_new_item_to_sid_rows(
+                writers,
+                item_ids,
+                origin_codes,
+                result,
+                ProgressLogger("Writing resolved item_to_sid", start_n=0),
+                copied,
             )
+            self._bundle.record_item_to_sid(copied + added)
+            if self._config.is_append:
+                self._bundle.record_delta_item_to_sid(added)
 
     def _write_sid_to_items_outputs(
         self,
@@ -999,7 +1008,6 @@ class CollisionResolutionRunner:
         codes[:, -1] = resolved_last_codes[representative_rows]
         return _AppendGroups(
             keys=grouping.sid_keys,
-            counts=grouping.counts,
             offsets=offsets,
             codes=codes,
             item_ids=self._item_id_array(item_ids[grouping.row_order]),
@@ -1050,15 +1058,13 @@ class CollisionResolutionRunner:
                     delta_writer, codes, offsets, values, rows
                 )
 
-            max_rows = _max_code_rows(False, groups.codes.shape[1], group_count)
+            max_rows = _ARROW_LIST_OFFSET_MAX // groups.codes.shape[1]
 
             def emit_new_only(low: int, high: int) -> None:
                 """Write rows this run created in buckets nobody occupied."""
-                for start, stop in _group_chunk_bounds(
+                for start, stop, child_low, child_high in _group_chunk_bounds(
                     groups.offsets, low, high, max_rows
                 ):
-                    child_low = int(groups.offsets[start])
-                    child_high = int(groups.offsets[stop])
                     emit(
                         groups.codes[start:stop],
                         groups.offsets[start : stop + 1] - child_low,
@@ -1134,14 +1140,10 @@ class CollisionResolutionRunner:
         with closing(self._make_writer(output_path, "ParquetWriter")) as writer:
             progress = ProgressLogger(progress_description, start_n=0)
             last_progress_count = 0
-            max_codebook_rows = _max_code_rows(
-                False, origin_codes.shape[1], group_count
-            )
-            for group_start, group_end in _group_chunk_bounds(
+            max_codebook_rows = _ARROW_LIST_OFFSET_MAX // origin_codes.shape[1]
+            for group_start, group_end, child_start, child_end in _group_chunk_bounds(
                 offsets, 0, group_count, max_codebook_rows
             ):
-                child_start = int(offsets[group_start])
-                child_end = int(offsets[group_end])
                 rows = grouping.row_order[child_start:child_end]
                 local_offsets = offsets[group_start : group_end + 1] - child_start
                 representative_rows = grouping.row_order[offsets[group_start:group_end]]
@@ -1162,22 +1164,15 @@ class CollisionResolutionRunner:
         self._bundle.record_sid_to_items(written)
 
 
-def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:
-    """Return how many SID rows one write can encode."""
-    if is_csv:
-        return row_cap
-    return min(row_cap, _ARROW_LIST_OFFSET_MAX // layer_count)
-
-
 def _group_chunk_bounds(
     offsets: np.ndarray, low: int, high: int, max_rows: int
-) -> Iterator[Tuple[int, int]]:
-    """Split ``[low, high)`` groups into writable ``(start, stop)`` chunks."""
+) -> Iterator[Tuple[int, int, int, int]]:
+    """Split ``[low, high)`` groups into writable chunks and their child spans."""
     while low < high:
         child_limit = int(offsets[low]) + _SID_TO_ITEMS_WRITE_SIZE
         stop = int(np.searchsorted(offsets, child_limit, side="right") - 1)
         stop = min(max(stop, low + 1), low + max_rows, high)
-        yield low, stop
+        yield low, stop, int(offsets[low]), int(offsets[stop])
         low = stop
 
 
@@ -1186,7 +1181,6 @@ class _AppendGroups:
     """This run's SID groups, prepared for merging into the published groups."""
 
     keys: np.ndarray
-    counts: np.ndarray
     offsets: np.ndarray
     codes: np.ndarray
     item_ids: pa.Array
@@ -1216,27 +1210,25 @@ def _merge_group_batch(
     batch_slots = np.arange(batch_rows) + np.searchsorted(
         groups.keys[unmatched], batch_keys, side="left"
     )
-    unmatched_slots = np.arange(unmatched.shape[0]) + np.searchsorted(
-        batch_keys, groups.keys[unmatched], side="left"
-    )
+    taken = np.zeros(output_rows, dtype=bool)
+    taken[batch_slots] = True
+    unmatched_slots = np.flatnonzero(~taken)
 
-    batch_of_output = np.full(output_rows, -1, dtype=np.int64)
-    batch_of_output[batch_slots] = np.arange(batch_rows)
     new_of_output = np.full(output_rows, -1, dtype=np.int64)
     new_of_output[batch_slots] = new_for_batch
     new_of_output[unmatched_slots] = unmatched
-
-    has_batch = batch_of_output >= 0
     has_new = new_of_output >= 0
-    batch_index = np.maximum(batch_of_output, 0)
     new_index = np.maximum(new_of_output, 0)
 
     codes = np.empty((output_rows, batch_codes.shape[1]), dtype=np.int64)
     codes[batch_slots] = batch_codes
     codes[unmatched_slots] = groups.codes[unmatched]
 
-    batch_part = np.where(has_batch, batch_lengths[batch_index], 0)
-    new_part = np.where(has_new, groups.counts[new_index], 0)
+    batch_part = np.zeros(output_rows, dtype=np.int64)
+    batch_part[batch_slots] = batch_lengths
+    new_part = np.where(
+        has_new, groups.offsets[new_index + 1] - groups.offsets[new_index], 0
+    )
     offsets = np.zeros(output_rows + 1, dtype=np.int64)
     np.cumsum(batch_part + new_part, out=offsets[1:])
 
@@ -1245,14 +1237,14 @@ def _merge_group_batch(
     combined = pa.chunked_array(
         [batch_values, groups.item_ids.slice(child_low, child_high - child_low)]
     )
-    batch_child_starts = np.zeros(batch_rows + 1, dtype=np.int64)
-    np.cumsum(batch_lengths, out=batch_child_starts[1:])
+    # both sides are consumed in order, so each gather source is a plain arange
+    batch_children = len(batch_values)
     gather = np.empty(int(offsets[-1]), dtype=np.int64)
-    gather[concat_ranges(offsets[:-1], batch_part)] = concat_ranges(
-        batch_child_starts[batch_index], batch_part
+    gather[concat_ranges(offsets[batch_slots], batch_lengths)] = np.arange(
+        batch_children, dtype=np.int64
     )
-    gather[concat_ranges(offsets[:-1] + batch_part, new_part)] = concat_ranges(
-        len(batch_values) + groups.offsets[new_index] - child_low, new_part
+    gather[concat_ranges(offsets[:-1] + batch_part, new_part)] = np.arange(
+        batch_children, batch_children + child_high - child_low, dtype=np.int64
     )
     values = combined.take(pa.array(gather, type=pa.int64())).combine_chunks()
     return codes, offsets, values, np.flatnonzero(has_new)
@@ -1272,11 +1264,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Bundle root. Artifacts land at <root>/<generation>/<artifact>, so "
-            "one generation is one self-contained directory. Holds the SID "
-            "sid_to_items and the manifest, which are always files, so it can be a "
-            "file or OSS path but never an odps:// table. Required unless "
-            "--rate_only is set without --from_generation, since an append "
-            "reads the published groups and manifest from it."
+            "one generation is one self-contained directory. Holds sid_to_items, "
+            "delta_sid_to_items and the manifest, which are always files, so it "
+            "can be a file or OSS path but never an odps:// table. Required "
+            "unless --rate_only is set without --from_generation, since an "
+            "append reads the published sid_to_items and manifest from it."
         ),
     )
     parser.add_argument(
@@ -1317,7 +1309,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Writer for the item_to_sid family only; defaults to matching the "
-            "input reader. The SID groups and the manifest are always parquet "
+            "input reader. sid_to_items and the manifest are always parquet "
             "and JSON."
         ),
     )
@@ -1327,8 +1319,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=100000,
         help=(
             "Reader I/O batch size; does not limit the in-memory collision working "
-            "set. In append mode it also governs the scans of the published map "
-            "and groups, so raise it for a large corpus."
+            "set. In append mode it also governs the scans of the published "
+            "item_to_sid and sid_to_items, so raise it for a large corpus."
         ),
     )
     parser.add_argument(
@@ -1361,7 +1353,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--rate_only",
         action="store_true",
-        help="Compute and log metrics without writing map or SID group outputs.",
+        help="Compute and log metrics without writing item_to_sid or sid_to_items.",
     )
     parser.add_argument("--odps_data_quota_name", default="pay-as-you-go")
     return parser

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -22,9 +22,10 @@ The runner retains the first capacity items in each SID bucket, attempts to
 relocate overflow items using fixed-width last-layer candidates, delegates
 placement to the pure NumPy core, and writes item-level and grouped SID results
 through TorchEasyRec readers and writers. CSV encodes each SID/candidate column
-as comma-separated codes and item-ID groups as JSON arrays because Arrow's CSV
-writer cannot serialize list columns; ``candidate_codes`` is a flat
-``topk * n_layers`` run split by the ``--codebook`` length.
+and each item-ID group as comma-separated values because Arrow's CSV writer
+cannot serialize list columns, so an item ID containing a comma is rejected at
+write time; ``candidate_codes`` is a flat ``topk * n_layers`` run split by the
+``--codebook`` length.
 
 The random strategy intentionally preserves the legacy deterministic baseline:
 it draws with replacement from the full last-layer space. Placement skips an
@@ -727,6 +728,7 @@ class CollisionResolutionRunner:
         counts = np.zeros(domain.shape[0], dtype=np.int64)
         max_index = np.zeros(domain.shape[0], dtype=np.int64)
         sum_index = np.zeros(domain.shape[0], dtype=np.int64)
+        sum_square_index = np.zeros(domain.shape[0], dtype=np.int64)
         map_rows = 0
 
         for batch in self._iter_state_batches(
@@ -755,11 +757,16 @@ class CollisionResolutionRunner:
             buckets = batch_positions[starts]
             counts[buckets] += np.diff(np.append(starts, batch_positions.shape[0]))
             sum_index[buckets] += np.add.reduceat(batch_indices, starts)
+            sum_square_index[buckets] += np.add.reduceat(
+                batch_indices * batch_indices, starts
+            )
             max_index[buckets] = np.maximum(
                 max_index[buckets], np.maximum.reduceat(batch_indices, starts)
             )
 
-        self._report_cross_check(prior, counts, max_index, sum_index, unknown_keys)
+        self._report_cross_check(
+            prior, counts, max_index, sum_index, sum_square_index, unknown_keys
+        )
         if map_rows != published_items:
             raise ValueError(
                 f"existing map holds {map_rows} rows but the existing groups hold "
@@ -775,6 +782,7 @@ class CollisionResolutionRunner:
         counts: np.ndarray,
         max_index: np.ndarray,
         sum_index: np.ndarray,
+        sum_square_index: np.ndarray,
         unknown_keys: List[int],
     ) -> None:
         """Raise on the first failing map/groups consistency check."""
@@ -808,14 +816,19 @@ class CollisionResolutionRunner:
                 "Item deletion is not supported -- tombstone instead."
             )
         expected_sum = counts * (counts + 1) // 2
-        duplicated = np.flatnonzero(sum_index != expected_sum)
+        expected_square_sum = counts * (counts + 1) * (2 * counts + 1) // 6
+        duplicated = np.flatnonzero(
+            (sum_index != expected_sum) | (sum_square_index != expected_square_sum)
+        )
         if duplicated.size:
             first = int(duplicated[0])
             raise ValueError(
                 f"existing map index space is not dense in {duplicated.size} "
                 f"buckets. Bucket key {int(prior.bucket_keys[first])} has index sum "
-                f"{int(sum_index[first])}, expected {int(expected_sum[first])} for "
-                f"{int(counts[first])} items."
+                f"{int(sum_index[first])} and square sum "
+                f"{int(sum_square_index[first])}, expected "
+                f"{int(expected_sum[first])} and {int(expected_square_sum[first])} "
+                f"for {int(counts[first])} items."
             )
 
     def _make_writer(self, output_path: str) -> BaseWriter:

--- a/tzrec/tools/sid/resolve_sid_collisions.py
+++ b/tzrec/tools/sid/resolve_sid_collisions.py
@@ -88,7 +88,6 @@ from __future__ import annotations
 import argparse
 import glob
 import os
-import uuid
 from contextlib import ExitStack, closing
 from dataclasses import dataclass
 from functools import cached_property
@@ -98,9 +97,6 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 
-# Register the local reader/writer classes used through create_reader/writer.
-import tzrec.datasets.parquet_dataset  # noqa: F401
-from tzrec.datasets.csv_dataset import CsvWriter
 from tzrec.datasets.dataset import (
     BaseReader,
     BaseWriter,
@@ -108,18 +104,8 @@ from tzrec.datasets.dataset import (
     create_writer,
 )
 from tzrec.utils.logging_util import ProgressLogger, logger
-from tzrec.utils.path_util import check_path_conflict
-from tzrec.utils.sid.bundle import (
-    DELTA_GROUPS_ARTIFACT,
-    DELTA_MAP_ARTIFACT,
-    GROUPS_ARTIFACT,
-    MAP_ARTIFACT,
-    MAP_ARTIFACTS,
-    BundleLayout,
-    BundleManifest,
-    is_odps_path,
-    read_manifest,
-)
+from tzrec.utils.path_util import check_path_conflict, is_odps_path
+from tzrec.utils.sid.bundle import Bundle, BundleLayout
 from tzrec.utils.sid.collision import (
     CodebookItemGrouping,
     CollisionPlan,
@@ -241,11 +227,6 @@ class ResolveSidCollisionsConfig:
         for name in ("output_path", "bundle_root", "partition"):
             if not self.rate_only and not getattr(self, name):
                 raise ValueError(f"{name} is required unless rate_only is set.")
-        if self.bundle_root and is_odps_path(self.bundle_root):
-            raise ValueError(
-                "bundle_root holds the SID groups and the manifest, which are "
-                f"always files; got {self.bundle_root!r}."
-            )
         if self.from_partition is not None and self.from_partition == self.partition:
             raise ValueError(
                 f"from_partition and partition are both {self.partition!r}; writing "
@@ -258,9 +239,10 @@ class ResolveSidCollisionsConfig:
         if has_conflict:
             raise ValueError(conflict_message)
 
-        # Eagerly build the resolution config so its validation (layer_sizes,
-        # capacity) fails fast here rather than lazily inside run().
+        # Eagerly build both so their validation fails here rather than lazily
+        # inside run().
         _ = self.resolution_config
+        _ = self.layout
 
     @property
     def is_append(self) -> bool:
@@ -336,11 +318,9 @@ class CollisionResolutionRunner:
             self._resolver = KnnCollisionResolver(
                 progress_interval=self._config.progress_interval
             )
-        self._default_writer_type: Optional[str] = None
+        self._resolved_writer_type: Optional[str] = None
         self._item_id_type: Optional[pa.DataType] = None
-        self._layout = config.layout
-        self._bundle_uuid = uuid.uuid4().hex
-        self._written_rows: Dict[str, int] = {}
+        self._bundle = Bundle(config.layout)
 
     def run(self) -> CollisionResolutionStats:
         """Read, resolve collisions, and write the resulting SID map."""
@@ -385,12 +365,7 @@ class CollisionResolutionRunner:
         """Reject a run whose inputs are not all present, before any pass runs."""
         wanted = [("--input_path", self._config.input_path)]
         if self._config.is_append:
-            wanted += [
-                (GROUPS_ARTIFACT, self._layout.read_path(GROUPS_ARTIFACT)),
-                ("manifest", self._layout.prior_manifest_path()),
-            ]
-            if self._config.output_path is not None:
-                wanted.append((MAP_ARTIFACT, self._layout.read_path(MAP_ARTIFACT)))
+            wanted += self._bundle.prior_locations()
         missing = [
             f"{name} -> {path}"
             for name, path in wanted
@@ -409,33 +384,14 @@ class CollisionResolutionRunner:
 
         Its presence is the completion marker, so nothing may be written after it.
         """
-        layout = self._layout
-        prior = (
-            read_manifest(layout.prior_manifest_path())
-            if self._config.is_append
-            else None
-        )
-        observed = result.stats.max_final_bucket_size
-        if prior is not None:
-            observed = max(observed, prior.max_observed_items_per_sid)
-        map_save_type = "csv" if self._default_writer_type == "CsvWriter" else "parquet"
-        artifacts = {
-            name: layout.entry(
-                name, map_save_type if name in MAP_ARTIFACTS else "parquet", rows
-            )
-            for name, rows in self._written_rows.items()
-        }
-        manifest = BundleManifest(
-            bundle_uuid=self._bundle_uuid,
-            since_bundle_uuid=prior.bundle_uuid if prior is not None else None,
+        path = self._bundle.publish(
             codebook=list(self._config.layer_sizes),
             capacity=self._config.max_items_per_codebook,
-            max_observed_items_per_sid=observed,
+            observed=result.stats.max_final_bucket_size,
             item_id_type=str(self._item_id_type) if self._item_id_type else None,
-            artifacts=artifacts,
+            writer_type=self._resolved_writer_type,
         )
-        path = layout.write_manifest(manifest)
-        logger.info("wrote bundle %s manifest to %s", self._bundle_uuid, path)
+        logger.info("wrote bundle %s manifest to %s", self._bundle.uuid, path)
 
     def _make_reader(
         self, selected_cols: List[str], input_path: Optional[str] = None
@@ -540,7 +496,7 @@ class CollisionResolutionRunner:
         reader = self._make_reader(
             [self._config.item_id_field, self._config.code_field]
         )
-        self._default_writer_type = self._config.writer_type or (
+        self._resolved_writer_type = self._config.writer_type or (
             reader.__class__.__name__.replace("Reader", "Writer")
         )
         progress = ProgressLogger("Reading SID input", start_n=0)
@@ -663,9 +619,8 @@ class CollisionResolutionRunner:
             return PriorOccupancy.empty()
 
         layer_sizes = self._config.layer_sizes
-        groups_path = self._layout.read_path(GROUPS_ARTIFACT)
         prior, published_items = self._load_prior_occupancy(
-            groups_path, sid_band_ids(codes, layer_sizes), item_ids
+            self._bundle.prior_groups_path, sid_band_ids(codes, layer_sizes), item_ids
         )
         self._check_existing_map_size(published_items)
         logger.info(
@@ -784,10 +739,9 @@ class CollisionResolutionRunner:
         """Reject a published map whose size disagrees with the groups."""
         if self._config.output_path is None:
             return
-        path = self._layout.read_path(MAP_ARTIFACT)
         map_rows = 0
         for batch in self._iter_state_batches(
-            path, ["index"], "Counting published SID map"
+            self._bundle.prior_map_path, ["index"], "Counting published SID map"
         ):
             map_rows += len(batch["index"])
         if map_rows != published_items:
@@ -801,11 +755,11 @@ class CollisionResolutionRunner:
 
     def _make_writer(self, output_path: str) -> BaseWriter:
         """Create a repository writer for one independently resolved output."""
-        if self._default_writer_type is None:
+        if self._resolved_writer_type is None:
             raise RuntimeError("writer type is unavailable before reading input.")
         return create_writer(
             output_path,
-            writer_type=self._default_writer_type,
+            writer_type=self._resolved_writer_type,
             quota_name=self._config.odps_data_quota_name,
             world_size=1,
         )
@@ -856,9 +810,13 @@ class CollisionResolutionRunner:
         result: CollisionResolutionResult,
         progress: ProgressLogger,
         written: int,
-    ) -> None:
-        """Write this run's own item rows in chunks, without a full code copy."""
-        is_csv = isinstance(writer, CsvWriter)
+    ) -> int:
+        """Write this run's own item rows in chunks, without a full code copy.
+
+        Returns:
+            How many item rows this run added.
+        """
+        is_csv = self._resolved_writer_type == "CsvWriter"
         output_count = item_ids.shape[0]
         last_progress_count = written
         write_chunk = _max_code_rows(is_csv, origin_codes.shape[1], _MAP_WRITE_ROWS)
@@ -881,13 +839,14 @@ class CollisionResolutionRunner:
             if self._progress_interval_reached(written, last_progress_count):
                 progress.log(written, suffix=f"{written} samples processed")
                 last_progress_count = written
+        return output_count
 
     def _stream_existing_map_rows(self, writer: BaseWriter) -> int:
         """Copy every published map row into the merged output unchanged."""
         if not self._config.is_append:
             return 0
-        path = self._layout.read_path(MAP_ARTIFACT)
-        is_csv = isinstance(writer, CsvWriter)
+        path = self._bundle.prior_map_path
+        is_csv = self._resolved_writer_type == "CsvWriter"
         fields = ["item_id", "origin_codebook", "codebook", "index"]
         written = 0
         for batch in self._iter_state_batches(
@@ -923,27 +882,26 @@ class CollisionResolutionRunner:
         run's rows are appended, so the artifact stands alone and is exactly
         what the next append consumes.
         """
-        output_path = self._layout.write_path(MAP_ARTIFACT)
-        with closing(self._make_writer(output_path)) as writer:
+        with closing(self._make_writer(self._bundle.map_path)) as writer:
             progress = ProgressLogger("Writing resolved item map", start_n=0)
             written = self._stream_existing_map_rows(writer)
-            self._write_new_map_rows(
+            written += self._write_new_map_rows(
                 writer, item_ids, origin_codes, result, progress, written
             )
-            self._written_rows[MAP_ARTIFACT] = written + item_ids.shape[0]
+            self._bundle.record_map(written)
 
         if not self._config.is_append:
             return
-        delta_path = self._layout.write_path(DELTA_MAP_ARTIFACT)
-        self._written_rows[DELTA_MAP_ARTIFACT] = item_ids.shape[0]
-        with closing(self._make_writer(delta_path)) as writer:
-            self._write_new_map_rows(
-                writer,
-                item_ids,
-                origin_codes,
-                result,
-                ProgressLogger("Writing delta item map", start_n=0),
-                0,
+        with closing(self._make_writer(self._bundle.delta_map_path)) as writer:
+            self._bundle.record_delta_map(
+                self._write_new_map_rows(
+                    writer,
+                    item_ids,
+                    origin_codes,
+                    result,
+                    ProgressLogger("Writing delta item map", start_n=0),
+                    0,
+                )
             )
 
     def _write_group_outputs(
@@ -953,14 +911,7 @@ class CollisionResolutionRunner:
         plan: CollisionPlan,
         result: CollisionResolutionResult,
     ) -> None:
-        """Build and write original and resolved SID item groups sequentially.
-
-        Args:
-            item_ids: Input item IDs in original row order.
-            origin_codes: Original full SID matrix.
-            plan: Original SID aggregation and overflow plan.
-            result: Completed collision-resolution result.
-        """
+        """Group this run's rows by emitted SID and write them."""
         if plan.overflow_rows.size:
             grouping = build_resolved_item_grouping(plan, result)
         else:
@@ -979,12 +930,16 @@ class CollisionResolutionRunner:
         offsets: np.ndarray,
         values: pa.Array,
         rows: Optional[np.ndarray] = None,
-    ) -> None:
-        """Write one chunk of SID groups, optionally only ``rows`` of it."""
+    ) -> int:
+        """Write one chunk of SID groups, optionally only ``rows`` of it.
+
+        Returns:
+            How many group rows were written.
+        """
         itemids = pa.ListArray.from_arrays(pa.array(offsets, type=pa.int32()), values)
         if rows is not None:
             if rows.size == 0:
-                return
+                return 0
             itemids = itemids.take(pa.array(rows, type=pa.int64()))
             codes = codes[rows]
         writer.write(
@@ -994,6 +949,7 @@ class CollisionResolutionRunner:
                 "itemids": itemids,
             }
         )
+        return codes.shape[0]
 
     def _build_append_groups(
         self,
@@ -1023,24 +979,22 @@ class CollisionResolutionRunner:
         resolved_last_codes: np.ndarray,
     ) -> None:
         """Merge this run's groups into the published groups and write both."""
-        resolved_path = self._layout.write_path(GROUPS_ARTIFACT)
-        existing_path = self._layout.read_path(GROUPS_ARTIFACT)
+        resolved_path = self._bundle.groups_path
+        existing_path = self._bundle.prior_groups_path
         layer_sizes = self._config.layer_sizes
         groups = self._build_append_groups(
             item_ids, origin_codes, grouping, resolved_last_codes
         )
         group_count = groups.keys.shape[0]
 
+        corpus_rows = 0
+        delta_rows = 0
         with ExitStack() as stack:
             writer = stack.enter_context(
                 closing(self._make_group_writer(resolved_path))
             )
             delta_writer = stack.enter_context(
-                closing(
-                    self._make_group_writer(
-                        self._layout.write_path(DELTA_GROUPS_ARTIFACT)
-                    )
-                )
+                closing(self._make_group_writer(self._bundle.delta_groups_path))
             )
 
             def emit(
@@ -1051,13 +1005,11 @@ class CollisionResolutionRunner:
             ) -> None:
                 """Write one chunk to the corpus output and the delta output."""
                 nonlocal corpus_rows, delta_rows
-                self._emit_group_rows(writer, codes, offsets, values)
-                corpus_rows += codes.shape[0]
-                delta_rows += codes.shape[0] if rows is None else int(rows.shape[0])
-                self._emit_group_rows(delta_writer, codes, offsets, values, rows)
+                corpus_rows += self._emit_group_rows(writer, codes, offsets, values)
+                delta_rows += self._emit_group_rows(
+                    delta_writer, codes, offsets, values, rows
+                )
 
-            corpus_rows = 0
-            delta_rows = 0
             max_rows = _max_code_rows(False, groups.codes.shape[1], group_count)
 
             def emit_new_only(low: int, high: int) -> None:
@@ -1111,8 +1063,8 @@ class CollisionResolutionRunner:
                     )
                 cursor = high
             emit_new_only(cursor, group_count)
-        self._written_rows[GROUPS_ARTIFACT] = corpus_rows
-        self._written_rows[DELTA_GROUPS_ARTIFACT] = delta_rows
+        self._bundle.record_groups(corpus_rows)
+        self._bundle.record_delta_groups(delta_rows)
 
     def _write_sid_groups(
         self,
@@ -1132,9 +1084,10 @@ class CollisionResolutionRunner:
         Raises:
             ValueError: If one group exceeds Arrow list offset capacity.
         """
-        output_path = self._layout.write_path(GROUPS_ARTIFACT)
+        output_path = self._bundle.groups_path
         progress_description = "Writing resolved SID item groups"
         group_count = grouping.counts.shape[0]
+        written = 0
         if np.any(grouping.counts > _ARROW_LIST_OFFSET_MAX):
             raise ValueError("one SID group exceeds Arrow list offset capacity.")
 
@@ -1155,7 +1108,7 @@ class CollisionResolutionRunner:
                 representative_rows = grouping.row_order[offsets[group_start:group_end]]
                 code_chunk = origin_codes[representative_rows]
                 code_chunk[:, -1] = resolved_last_codes[representative_rows]
-                self._emit_group_rows(
+                written += self._emit_group_rows(
                     writer,
                     code_chunk,
                     local_offsets,
@@ -1167,7 +1120,7 @@ class CollisionResolutionRunner:
                         suffix=f"{child_end} samples processed",
                     )
                     last_progress_count = child_end
-        self._written_rows[GROUPS_ARTIFACT] = group_count
+        self._bundle.record_groups(written)
 
 
 def _max_code_rows(is_csv: bool, layer_count: int, row_cap: int) -> int:

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -29,6 +29,8 @@ from tzrec.tools.sid.resolve_sid_collisions import (
 from tzrec.utils.sid.collision import stable_order_hash
 from tzrec.utils.test_util import make_test_dir, parameterized_name_func
 
+_PART_FILE = "part-0.parquet"
+
 
 def _parquet(
     path,
@@ -61,6 +63,72 @@ def _csv(path, item_ids, codes, candidate_codes=None):
             for row in candidate_codes
         ]
     csv.write_csv(pa.table(cols), path)
+
+
+def _write_part(path, table):
+    """Write one ``part-0.parquet`` shard, the shape every writer emits."""
+    os.makedirs(path, exist_ok=True)
+    parquet.write_table(table, os.path.join(path, _PART_FILE))
+
+
+def _map_parquet(path, rows):
+    """Write a map artifact from (item_id, origin_codebook, codebook, index)."""
+    _write_part(
+        path,
+        pa.table(
+            {
+                "item_id": pa.array([r[0] for r in rows], type=pa.int64()),
+                "origin_codebook": pa.array(
+                    [r[1] for r in rows], type=pa.list_(pa.int64())
+                ),
+                "codebook": pa.array([r[2] for r in rows], type=pa.list_(pa.int64())),
+                "index": pa.array([r[3] for r in rows], type=pa.int64()),
+            }
+        ),
+    )
+
+
+def _groups_parquet(path, rows):
+    """Write a groups artifact from (codebook, item_ids) in SID-key order."""
+    _write_part(
+        path,
+        pa.table(
+            {
+                "codebook": pa.array([r[0] for r in rows], type=pa.list_(pa.int64())),
+                "itemids": pa.array([r[1] for r in rows], type=pa.list_(pa.int64())),
+            }
+        ),
+    )
+
+
+def _map_csv(path, rows):
+    """Write a map artifact in the CSV encoding this tool emits."""
+    os.makedirs(path, exist_ok=True)
+    csv.write_csv(
+        pa.table(
+            {
+                "item_id": [r[0] for r in rows],
+                "origin_codebook": [",".join(map(str, r[1])) for r in rows],
+                "codebook": [",".join(map(str, r[2])) for r in rows],
+                "index": [r[3] for r in rows],
+            }
+        ),
+        os.path.join(path, "part-0.csv"),
+    )
+
+
+def _groups_csv(path, rows):
+    """Write a groups artifact in the CSV encoding this tool emits."""
+    os.makedirs(path, exist_ok=True)
+    csv.write_csv(
+        pa.table(
+            {
+                "codebook": [",".join(map(str, r[0])) for r in rows],
+                "itemids": ["[" + ",".join(map(str, r[1])) + "]" for r in rows],
+            }
+        ),
+        os.path.join(path, "part-0.csv"),
+    )
 
 
 class ResolveSidCollisionsTest(unittest.TestCase):
@@ -105,7 +173,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         return f"{out}_original_groups", f"{out}_resolved_groups"
 
     def _read_parquet(self, out_dir):
-        return parquet.read_table(os.path.join(out_dir, "part-0.parquet")).to_pydict()
+        return parquet.read_table(os.path.join(out_dir, _PART_FILE)).to_pydict()
 
     def _assert_map_matches_resolved_groups(self, out):
         item_map = self._read_parquet(out)
@@ -123,6 +191,47 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             item_map["item_id"], item_map["codebook"], item_map["index"]
         ):
             self.assertEqual(resolved_items[tuple(codebook)][index - 1], item_id)
+
+    def _map_rows(self, out):
+        """Return {item_id: (origin_codebook, codebook, index)} for a map."""
+        item_map = self._read_parquet(out)
+        return {
+            item_id: (tuple(origin), tuple(codebook), index)
+            for item_id, origin, codebook, index in zip(
+                item_map["item_id"],
+                item_map["origin_codebook"],
+                item_map["codebook"],
+                item_map["index"],
+            )
+        }
+
+    def _append_paths(self, previous_out):
+        """Return the two state reader paths for the previous generation."""
+        _, previous_groups = self._group_paths(previous_out)
+        return {
+            "existing_sid_map_path": os.path.join(previous_out, "*.parquet"),
+            "existing_sid_groups_path": os.path.join(previous_groups, "*.parquet"),
+        }
+
+    def _append(self, inp, out, previous_out, **kw):
+        return self._run(inp, out, **self._append_paths(previous_out), **kw)
+
+    def _prepare_single(self, item_id):
+        path = os.path.join(self.test_dir, f"single_{item_id}.parquet")
+        _parquet(path, [item_id], [[0, 0]], [[[0, 2]]])
+        return path
+
+    def _assert_dense_indices(self, out):
+        """Every bucket's index multiset must be exactly 1..count."""
+        by_bucket = {}
+        for _item, (_origin, codebook, index) in self._map_rows(out).items():
+            by_bucket.setdefault(codebook, []).append(index)
+        for codebook, indices in by_bucket.items():
+            self.assertEqual(
+                sorted(indices),
+                list(range(1, len(indices) + 1)),
+                f"non-dense index set for {codebook}",
+            )
 
     # ---- candidate strategy ----
 
@@ -898,6 +1007,277 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "codebook"):
             ResolveSidCollisionsConfig.from_namespace(args)
+
+    # ---- append mode ----
+
+    def _seed_generation(self, name="v1", item_ids=None, codes=None):
+        """Run a full resolve to produce the state a later append consumes."""
+        inp = os.path.join(self.test_dir, f"{name}_in.parquet")
+        out = os.path.join(self.test_dir, name)
+        item_ids = list(range(5)) if item_ids is None else item_ids
+        codes = [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]] if codes is None else codes
+        _parquet(inp, item_ids, codes, [[[0, 2], [0, 3]]] * len(item_ids))
+        self._run(inp, out)
+        return out
+
+    def test_append_never_moves_a_published_item(self) -> None:
+        base = self._seed_generation()
+        published = self._map_rows(base)
+
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        # Rows 10 and 11 land in the already-full bucket (0, 0).
+        _parquet(inp, [10, 11, 12], [[0, 0], [0, 0], [1, 1]], [[[0, 2], [0, 3]]] * 3)
+        stats = self._append(inp, out, base)
+
+        self.assertEqual(stats.total_items, 3)
+        merged = self._map_rows(out)
+        self.assertEqual(len(merged), 8)
+        for item_id, row in published.items():
+            self.assertEqual(merged[item_id], row, f"item {item_id} moved")
+        self._assert_dense_indices(out)
+        self._assert_map_matches_resolved_groups(out)
+
+    def test_append_continues_slot_numbering(self) -> None:
+        base = self._seed_generation(item_ids=[0], codes=[[0, 0]])
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10], [[0, 0]], [[[0, 0]]])
+        self._append(inp, out, base)
+
+        merged = self._map_rows(out)
+        self.assertEqual(merged[0][2], 1)
+        # Capacity is 2, so the new row is retained and continues at slot 2.
+        self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
+
+    def test_append_emits_delta_outputs(self) -> None:
+        base = self._seed_generation()
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        delta_map = os.path.join(self.test_dir, "delta_map")
+        delta_groups = os.path.join(self.test_dir, "delta_groups")
+        _parquet(inp, [10, 11], [[0, 0], [3, 3]], [[[0, 2], [0, 3]]] * 2)
+        self._append(
+            inp,
+            out,
+            base,
+            delta_map_output_path=delta_map,
+            delta_sid_groups_output_path=delta_groups,
+        )
+
+        self.assertCountEqual(self._read_parquet(delta_map)["item_id"], [10, 11])
+        merged_groups = self._read_parquet(self._group_paths(out)[1])
+        full = {
+            tuple(codebook): item_group
+            for codebook, item_group in zip(
+                merged_groups["codebook"], merged_groups["itemids"]
+            )
+        }
+        delta = self._read_parquet(delta_groups)
+        # Delta rows carry the whole post-append bucket, byte-identical to the
+        # corpus output, so a consumer can upsert them idempotently.
+        for codebook, item_group in zip(delta["codebook"], delta["itemids"]):
+            self.assertEqual(item_group, full[tuple(codebook)])
+        touched = {item for group in delta["itemids"] for item in group}
+        self.assertTrue({10, 11}.issubset(touched))
+
+    def test_append_creates_buckets_before_between_and_after(self) -> None:
+        # New SIDs sort before, between and after every published bucket, which
+        # exercises all three branches of the groups merge.
+        base = self._seed_generation(item_ids=[0], codes=[[4, 4]])
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
+        with mock.patch.object(resolve_sid_collisions, "_STATE_READ_ROWS", 1):
+            self._append(inp, out, base, batch_size=1)
+
+        groups = self._read_parquet(self._group_paths(out)[1])
+        self.assertEqual(groups["codebook"], [[0, 0], [4, 4], [4, 5], [7, 7]])
+        self.assertEqual(groups["itemids"], [[10], [0], [11], [12]])
+        self._assert_map_matches_resolved_groups(out)
+
+    def test_append_merges_across_reader_batches(self) -> None:
+        base = self._seed_generation(
+            item_ids=list(range(6)),
+            codes=[[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+        )
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10, 11, 12], [[0, 0], [3, 3], [6, 6]], [[[0, 0]]] * 3)
+        with mock.patch.object(resolve_sid_collisions, "_STATE_READ_ROWS", 1):
+            self._append(inp, out, base, batch_size=1)
+
+        self._assert_dense_indices(out)
+        self._assert_map_matches_resolved_groups(out)
+        self.assertEqual(len(self._map_rows(out)), 9)
+
+    def test_append_chain_stays_consistent(self) -> None:
+        previous = self._seed_generation()
+        for generation in range(2, 5):
+            inp = os.path.join(self.test_dir, f"v{generation}_in.parquet")
+            out = os.path.join(self.test_dir, f"v{generation}")
+            base = 100 * generation
+            _parquet(
+                inp,
+                [base, base + 1],
+                [[0, 0], [generation, generation]],
+                [[[0, 2], [0, 3]]] * 2,
+            )
+            published = self._map_rows(previous)
+            self._append(inp, out, previous)
+            merged = self._map_rows(out)
+            for item_id, row in published.items():
+                self.assertEqual(merged[item_id], row)
+            self._assert_dense_indices(out)
+            self._assert_map_matches_resolved_groups(out)
+            previous = out
+
+    def test_append_reads_csv_state_and_converts_format(self) -> None:
+        # CSV state exercises the JSON branch of the grouped item-ID decoder,
+        # and a parquet new-items input drives _align_codes_column's re-encode.
+        state_map = os.path.join(self.test_dir, "csv_map")
+        state_groups = os.path.join(self.test_dir, "csv_groups")
+        _map_csv(state_map, [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)])
+        _groups_csv(state_groups, [([0, 0], [0]), ([1, 1], [1])])
+
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
+        with self.assertLogs(level="WARNING") as logs:
+            self._run(
+                inp,
+                out,
+                existing_sid_map_path=os.path.join(state_map, "*.csv"),
+                existing_sid_groups_path=os.path.join(state_groups, "*.csv"),
+            )
+        self.assertTrue(
+            any("rewritten in the other format" in line for line in logs.output)
+        )
+
+        merged = self._map_rows(out)
+        self.assertEqual(len(merged), 4)
+        self.assertEqual(merged[0], ((0, 0), (0, 0), 1))
+        self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
+        self._assert_dense_indices(out)
+        self._assert_map_matches_resolved_groups(out)
+
+    def test_append_rejects_already_published_item_id(self) -> None:
+        base = self._seed_generation()
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [0, 99], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
+        with self.assertRaisesRegex(ValueError, "already published"):
+            self._append(inp, out, base)
+
+    def test_append_rejects_mismatched_generation_pair(self) -> None:
+        first = self._seed_generation("v1")
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10], [[0, 0]], [[[0, 2]]])
+        self._append(inp, out, first)
+        # Pair generation 1's map with generation 2's groups.
+        with self.assertRaisesRegex(ValueError, "same generation"):
+            self._run(
+                self._prepare_single(20),
+                os.path.join(self.test_dir, "v3"),
+                existing_sid_map_path=os.path.join(first, "*.parquet"),
+                existing_sid_groups_path=os.path.join(
+                    self._group_paths(out)[1], "*.parquet"
+                ),
+            )
+
+    def test_append_rejects_map_with_index_holes(self) -> None:
+        # Two items share bucket (0, 0) but hold indices 1 and 3: a deleted item
+        # left a hole, so appending would reuse slot 2.
+        state_map = os.path.join(self.test_dir, "holed_map")
+        state_groups = os.path.join(self.test_dir, "holed_groups")
+        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [0, 0], [0, 0], 3)])
+        _groups_parquet(state_groups, [([0, 0], [0, 1])])
+        with self.assertRaisesRegex(ValueError, "holes"):
+            self._run(
+                self._prepare_single(10),
+                os.path.join(self.test_dir, "out"),
+                max_items_per_codebook=4,
+                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
+                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
+            )
+
+    def test_append_rejects_map_with_duplicate_indices(self) -> None:
+        # max(index) == count hides it; only the index sum catches this one.
+        state_map = os.path.join(self.test_dir, "dup_map")
+        state_groups = os.path.join(self.test_dir, "dup_groups")
+        _map_parquet(
+            state_map,
+            [
+                (0, [0, 0], [0, 0], 1),
+                (1, [0, 0], [0, 0], 1),
+                (2, [0, 0], [0, 0], 3),
+            ],
+        )
+        _groups_parquet(state_groups, [([0, 0], [0, 1, 2])])
+        with self.assertRaisesRegex(ValueError, "not dense"):
+            self._run(
+                self._prepare_single(10),
+                os.path.join(self.test_dir, "out"),
+                max_items_per_codebook=4,
+                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
+                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
+            )
+
+    def test_append_rejects_unsorted_existing_groups(self) -> None:
+        state_map = os.path.join(self.test_dir, "unsorted_map")
+        state_groups = os.path.join(self.test_dir, "unsorted_groups")
+        _map_parquet(state_map, [(0, [1, 1], [1, 1], 1), (1, [0, 0], [0, 0], 1)])
+        _groups_parquet(state_groups, [([1, 1], [0]), ([0, 0], [1])])
+        with self.assertRaisesRegex(ValueError, "ascending"):
+            self._run(
+                self._prepare_single(10),
+                os.path.join(self.test_dir, "out"),
+                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
+                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
+            )
+
+    def test_append_rate_only_needs_no_map(self) -> None:
+        base = self._seed_generation()
+        stats = self._run(
+            self._prepare_single(10),
+            os.path.join(self.test_dir, "unused"),
+            rate_only=True,
+            output_path=None,
+            resolved_sid_groups_output_path=None,
+            existing_sid_groups_path=os.path.join(
+                self._group_paths(base)[1], "*.parquet"
+            ),
+        )
+        self.assertEqual(stats.total_items, 1)
+
+    @parameterized.expand(
+        [
+            ({"existing_sid_map_path": "state/*.parquet"},),
+            ({"delta_map_output_path": "delta"},),
+            ({"delta_sid_groups_output_path": "delta"},),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_append_only_flags_are_ignored_outside_append_mode(self, overrides) -> None:
+        inp = os.path.join(self.test_dir, "in.parquet")
+        out = os.path.join(self.test_dir, "out")
+        _parquet(inp, [0, 1], [[0, 0], [1, 1]], [[[0, 2]]] * 2)
+        self._run(inp, out, **overrides)
+
+        self.assertCountEqual(self._read_parquet(out)["item_id"], [0, 1])
+        self._assert_map_matches_resolved_groups(out)
+        delta = overrides.get("delta_map_output_path")
+        if delta is not None:
+            self.assertFalse(os.path.exists(delta))
+
+    def test_append_requires_map_unless_rate_only(self) -> None:
+        with self.assertRaisesRegex(ValueError, "existing_sid_map_path is required"):
+            self._runner(
+                os.path.join(self.test_dir, "in.parquet"),
+                os.path.join(self.test_dir, "out"),
+                existing_sid_groups_path="groups/*.parquet",
+            )
 
 
 if __name__ == "__main__":

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -399,8 +399,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         original_path, resolved_path = self._group_paths(out)
         original = parquet.read_table(os.path.join(original_path, "part-0.parquet"))
         resolved = parquet.read_table(os.path.join(resolved_path, "part-0.parquet"))
-        self.assertEqual(original.column_names, ["codebook", "itemids"])
-        self.assertEqual(resolved.column_names, ["codebook", "itemids"])
+        self.assertEqual(
+            original.column_names, ["codebook", "offset_codebook", "itemids"]
+        )
+        self.assertEqual(
+            resolved.column_names, ["codebook", "offset_codebook", "itemids"]
+        )
         original_groups = original.to_pydict()
         self.assertCountEqual(
             [item_id for group in original_groups["itemids"] for item_id in group],
@@ -523,7 +527,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(original["codebook"].to_pylist(), ["0,0,0"])
             self.assertCountEqual(resolved["codebook"].to_pylist(), ["0,0,0", "0,0,1"])
             for groups in (original, resolved):
-                self.assertEqual(groups.column_names, ["codebook", "itemids"])
+                self.assertEqual(
+                    groups.column_names, ["codebook", "offset_codebook", "itemids"]
+                )
                 self.assertEqual(groups.schema.field("itemids").type, pa.string())
                 grouped = [
                     item
@@ -544,7 +550,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(result["origin_codebook"].to_pylist(), [[0, 0, 0]] * 3)
             for path in (original_path, resolved_path):
                 groups = parquet.read_table(os.path.join(path, "part-0.parquet"))
-                self.assertEqual(groups.column_names, ["codebook", "itemids"])
+                self.assertEqual(
+                    groups.column_names, ["codebook", "offset_codebook", "itemids"]
+                )
                 self.assertEqual(
                     groups.schema.field("itemids").type, pa.list_(pa.string())
                 )
@@ -800,7 +808,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertTrue(all(writer.closed for _, writer in created_writers))
         for _, writer in created_writers[:2]:
             columns = writer.writes[0]
-            self.assertEqual(list(columns), ["codebook", "itemids"])
+            self.assertEqual(list(columns), ["codebook", "offset_codebook", "itemids"])
             self.assertEqual(columns["codebook"].type, pa.list_(pa.int64()))
             self.assertEqual(columns["itemids"].type, pa.list_(pa.int32()))
 
@@ -1019,6 +1027,82 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "codebook"):
             ResolveSidCollisionsConfig.from_namespace(args)
+
+    # ---- offset SID column ----
+
+    def test_offset_codebook_shifts_layers_in_map_and_groups(self) -> None:
+        inp = os.path.join(self.test_dir, "in.parquet")
+        out = os.path.join(self.test_dir, "out")
+        _parquet(inp, [0, 1], [[1, 2], [3, 4]], [[[0, 0]]] * 2)
+        self._run(inp, out, include_original=True, layer_sizes=(8, 8))
+
+        # layer 1 is shifted by layer_sizes[0]
+        item_map = self._read_parquet(out)
+        by_item = dict(zip(item_map["item_id"], item_map["offset_codebook"]))
+        self.assertEqual(by_item[0], [1, 2 + 8])
+        self.assertEqual(by_item[1], [3, 4 + 8])
+
+        original_path, resolved_path = self._group_paths(out)
+        for path in (original_path, resolved_path):
+            groups = self._read_parquet(path)
+            for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
+                self.assertEqual(offset, [codebook[0], codebook[1] + 8])
+
+    def test_offset_codebook_tracks_the_resolved_not_the_origin_sid(self) -> None:
+        inp = os.path.join(self.test_dir, "in.parquet")
+        out = os.path.join(self.test_dir, "out")
+        # three items collide at capacity 2, so one relocates
+        _parquet(inp, [0, 1, 2], [[0, 0]] * 3, [[[0, 5]]] * 3)
+        self._run(inp, out, layer_sizes=(8, 8))
+
+        item_map = self._read_parquet(out)
+        relocated = [
+            i
+            for i, (origin, final) in enumerate(
+                zip(item_map["origin_codebook"], item_map["codebook"])
+            )
+            if origin != final
+        ]
+        self.assertTrue(relocated)
+        for i in range(len(item_map["item_id"])):
+            final = item_map["codebook"][i]
+            self.assertEqual(item_map["offset_codebook"][i], [final[0], final[1] + 8])
+
+    def test_append_recomputes_offset_for_state_written_without_it(self) -> None:
+        # the published fixtures carry no offset_codebook column, so the merged
+        # map must derive it rather than pass it through
+        base = self._seed_generation()
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        _parquet(inp, [10], [[2, 2]], [[[0, 2]]])
+        self._append(inp, out, base)
+
+        item_map = self._read_parquet(out)
+        self.assertEqual(len(item_map["item_id"]), 6)
+        for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
+            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
+
+    def test_delta_outputs_carry_offset_codebook(self) -> None:
+        base = self._seed_generation()
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        out = os.path.join(self.test_dir, "v2")
+        delta_map = os.path.join(self.test_dir, "delta_map")
+        delta_groups = os.path.join(self.test_dir, "delta_groups")
+        _parquet(inp, [10, 11], [[0, 0], [3, 3]], [[[0, 2], [0, 3]]] * 2)
+        self._append(
+            inp,
+            out,
+            base,
+            delta_map_output_path=delta_map,
+            delta_sid_groups_output_path=delta_groups,
+        )
+
+        delta = self._read_parquet(delta_map)
+        for codebook, offset in zip(delta["codebook"], delta["offset_codebook"]):
+            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
+        groups = self._read_parquet(delta_groups)
+        for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
+            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     # ---- append mode ----
 

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -692,7 +692,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "progress_interval must be >= 1"):
             self._runner("input", "map", progress_interval=0)
 
-    def test_odps_group_writes_use_native_array_columns(self) -> None:
+    def test_serving_set_stays_parquet_under_an_odps_writer_type(self) -> None:
         class OdpsWriter:
             def __init__(self) -> None:
                 self.writes = []
@@ -717,9 +717,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         created_writers = []
 
-        def make_writer(output_path):
+        def make_writer(output_path, writer_type=None):
             writer = OdpsWriter()
-            created_writers.append((output_path, writer))
+            created_writers.append((output_path, writer_type, writer))
             return writer
 
         with mock.patch.object(
@@ -732,8 +732,15 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 max_items_per_codebook=1,
             )
 
-        self.assertEqual([path for path, _ in created_writers], [self._map_dir(out)])
-        self.assertTrue(all(writer.closed for _, writer in created_writers))
+        # the map follows --writer_type; the serving set overrides it
+        self.assertEqual(
+            {path: kind for path, kind, _ in created_writers},
+            {
+                self._map_dir(out): None,
+                self._groups_dir(out): "ParquetWriter",
+            },
+        )
+        self.assertTrue(all(writer.closed for _, _, writer in created_writers))
 
     def test_writer_closes_when_write_fails(self) -> None:
         class FailingWriter:

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -229,7 +229,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                     bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
                         save_type="parquet",
                         rows=len(group_rows),
-                        schema={},
                         path=self._groups_dir(out, partition),
                     )
                 },

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1088,8 +1088,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
-        with mock.patch.object(resolve_sid_collisions, "_STATE_READ_ROWS", 1):
-            self._append(inp, out, base, batch_size=1)
+        self._append(inp, out, base, batch_size=1)
 
         groups = self._read_parquet(self._group_paths(out)[1])
         self.assertEqual(groups["codebook"], [[0, 0], [4, 4], [4, 5], [7, 7]])
@@ -1104,8 +1103,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10, 11, 12], [[0, 0], [3, 3], [6, 6]], [[[0, 0]]] * 3)
-        with mock.patch.object(resolve_sid_collisions, "_STATE_READ_ROWS", 1):
-            self._append(inp, out, base, batch_size=1)
+        self._append(inp, out, base, batch_size=1)
 
         self._assert_dense_indices(out)
         self._assert_map_matches_resolved_groups(out)
@@ -1143,15 +1141,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
-        with self.assertLogs(level="WARNING") as logs:
-            self._run(
-                inp,
-                out,
-                existing_sid_map_path=os.path.join(state_map, "*.csv"),
-                existing_sid_groups_path=os.path.join(state_groups, "*.csv"),
-            )
-        self.assertTrue(
-            any("rewritten in the other format" in line for line in logs.output)
+        self._run(
+            inp,
+            out,
+            existing_sid_map_path=os.path.join(state_map, "*.csv"),
+            existing_sid_groups_path=os.path.join(state_groups, "*.csv"),
         )
 
         merged = self._map_rows(out)

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -227,7 +227,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 max_observed_items_per_sid=len(map_rows),
                 artifacts={
                     bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
-                        type="parquet",
+                        save_type="parquet",
                         rows=len(group_rows),
                         schema={},
                         path=self._groups_dir(out, partition),

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -176,6 +176,21 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             bundle.manifest_path(self._bundle_root(out), partition)
         )
 
+    def _resolve(self, item_ids, codes, candidates=None, **kw):
+        """Write one input, resolve it, and return the stats and the map root."""
+        inp = os.path.join(self.test_dir, "in.parquet")
+        out = os.path.join(self.test_dir, "out")
+        _parquet(inp, item_ids, codes, candidates)
+        return self._run(inp, out, **kw), out
+
+    def _map(self, out, partition="v1"):
+        """Read one generation's item map."""
+        return self._read_parquet(self._map_dir(out, partition))
+
+    def _groups(self, out, partition="v1"):
+        """Read one generation's SID groups."""
+        return self._read_parquet(self._groups_dir(out, partition))
+
     def _read_parquet(self, out_dir):
         return parquet.read_table(os.path.join(out_dir, _PART_FILE)).to_pydict()
 
@@ -256,39 +271,36 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     # ---- candidate strategy ----
 
     def test_candidate_reassigns_within_band(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
         # 5 items in bucket (0,0); candidates vary only the last layer within band 0.
-        _parquet(inp, list(range(5)), [[0, 0]] * 5, [[[0, 1], [0, 2], [0, 3]]] * 5)
-        stats = self._run(inp, out, max_items_per_codebook=2)
+        stats, out = self._resolve(
+            list(range(5)),
+            [[0, 0]] * 5,
+            [[[0, 1], [0, 2], [0, 3]]] * 5,
+            max_items_per_codebook=2,
+        )
         self.assertEqual(stats.total_items, 5)
         self.assertEqual(stats.relocated_count, 3)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._read_parquet(self._map_dir(out))
+        d = self._map(out)
         # every final SID keeps prefix 0 (stays in band) ...
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
         # ... and no bucket exceeds the cap.
         self.assertLessEqual(max(Counter(map(tuple, d["codebook"])).values()), 2)
 
     def test_three_layer_candidate_reassigns_within_band(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        # 3-layer SIDs: band = (code_0, code_1). Three items collide in bucket
-        # (0, 0, 0); candidates keep the (0, 0) band and vary the last layer, so
-        # the flat topk*3 candidate column must be split at stride 3.
-        _parquet(
-            inp,
+        stats, out = self._resolve(
             [0, 1, 2],
             [[0, 0, 0]] * 3,
             [[[0, 0, 1], [0, 0, 2], [0, 0, 3]]] * 3,
+            layer_sizes=(2, 3, 4),
+            max_items_per_codebook=2,
         )
-        stats = self._run(inp, out, layer_sizes=(2, 3, 4), max_items_per_codebook=2)
         self.assertEqual(stats.total_items, 3)
         self.assertEqual(stats.relocated_count, 1)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._read_parquet(self._map_dir(out))
+        d = self._map(out)
         # The relocated item took the first free candidate last code (1); every
         # SID keeps its (0, 0) band prefix.
         self.assertEqual(
@@ -297,14 +309,13 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
 
     def test_keep_original_when_only_origin_candidate(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
         # candidate == origin last -> skipped -> nothing to place; kept over cap.
-        _parquet(inp, list(range(5)), [[0, 0]] * 5, [[[0, 0]]] * 5)
-        stats = self._run(inp, out, max_items_per_codebook=2)
+        stats, out = self._resolve(
+            list(range(5)), [[0, 0]] * 5, [[[0, 0]]] * 5, max_items_per_codebook=2
+        )
         self.assertEqual(stats.relocated_count, 0)
         self.assertEqual(stats.unresolved_count, 3)
-        d = self._read_parquet(self._map_dir(out))
+        d = self._map(out)
         self.assertEqual(len(d["item_id"]), 5)  # every item preserved
         self.assertTrue(all(tuple(cb) == (0, 0) for cb in d["codebook"]))
         self._assert_map_matches_resolved_groups(out)
@@ -372,7 +383,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             expected_projections,
         )
         self.assertEqual(stats.relocated_count, expected_relocated)
-        self.assertEqual(len(self._read_parquet(self._map_dir(out))["item_id"]), 3)
+        self.assertEqual(len(self._map(out)["item_id"]), 3)
 
     def test_raises_when_overflow_but_no_candidates(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -397,7 +408,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         candidates = [[[0, code]] for code in [1, 2, 5, 3, 6]]
         _parquet(inp, list(range(5)), [[0, 0]] * 5, candidates)
         self._run(inp, out, batch_size=2, max_items_per_codebook=2)
-        result = self._read_parquet(self._map_dir(out))
+        result = self._map(out)
         by_id = dict(zip(result["item_id"], result["codebook"]))
         self.assertEqual(by_id[0], [0, 1])
         self.assertEqual(by_id[1], [0, 2])
@@ -429,17 +440,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self._assert_map_matches_resolved_groups(out)
 
     def test_no_overflow_reuses_groups_with_gapped_prefixes(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(
-            inp,
+        _, out = self._resolve(
             list(range(6)),
             [[7, 10], [7, 2], [12, 1], [7, 2], [12, 1], [7, 10]],
-        )
-
-        self._run(
-            inp,
-            out,
             layer_sizes=(16, 16),
             max_items_per_codebook=2,
         )
@@ -453,34 +456,25 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     # ---- random strategy ----
 
     def test_random_reassigns_within_band(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(inp, list(range(5)), [[0, 0]] * 5)
-        stats = self._run(
-            inp,
-            out,
-            max_items_per_codebook=2,
-            strategy="random",
+        stats, out = self._resolve(
+            list(range(5)), [[0, 0]] * 5, max_items_per_codebook=2, strategy="random"
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._read_parquet(self._map_dir(out))
+        d = self._map(out)
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
         self.assertLessEqual(max(Counter(map(tuple, d["codebook"])).values()), 2)
         self._assert_map_matches_resolved_groups(out)
 
     def test_single_layer_sid(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(inp, list(range(4)), [[0]] * 4)
-        stats = self._run(
-            inp,
-            out,
+        stats, out = self._resolve(
+            list(range(4)),
+            [[0]] * 4,
             max_items_per_codebook=1,
             strategy="random",
             layer_sizes=(16,),
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._read_parquet(self._map_dir(out))
+        d = self._map(out)
         self.assertEqual(len({tuple(cb) for cb in d["codebook"]}), 4)
 
     # ---- CSV backend ----
@@ -889,7 +883,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         self.assertEqual(stats.total_items, 3)
         self.assertEqual(stats.relocated_count, 2)
-        result = self._read_parquet(self._map_dir(out))
+        result = self._map(out)
         self.assertEqual(result["item_id"], [keeper, duplicate, duplicate])
         self.assertEqual(result["item_id"].count(duplicate), 2)
         self._assert_map_matches_resolved_groups(out)
@@ -936,7 +930,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
 
         self.assertEqual(stats.total_items, 3)
-        result = self._read_parquet(self._map_dir(out))
+        result = self._map(out)
         self.assertEqual(result["item_id"], ["b", "a", "a"])
         self._assert_map_matches_resolved_groups(out)
 
@@ -958,13 +952,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     # ---- offset SID column ----
 
     def test_offset_codebook_shifts_layers_in_map_and_groups(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(inp, [0, 1], [[1, 2], [3, 4]], [[[0, 0]]] * 2)
-        self._run(inp, out, layer_sizes=(8, 8))
+        _, out = self._resolve(
+            [0, 1], [[1, 2], [3, 4]], [[[0, 0]]] * 2, layer_sizes=(8, 8)
+        )
 
         # layer 1 is shifted by layer_sizes[0]
-        item_map = self._read_parquet(self._map_dir(out))
+        item_map = self._map(out)
         by_item = dict(zip(item_map["item_id"], item_map["offset_codebook"]))
         self.assertEqual(by_item[0], [1, 2 + 8])
         self.assertEqual(by_item[1], [3, 4 + 8])
@@ -975,13 +968,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     def test_offset_codebook_tracks_the_resolved_not_the_origin_sid(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
         # three items collide at capacity 2, so one relocates
-        _parquet(inp, [0, 1, 2], [[0, 0]] * 3, [[[0, 5]]] * 3)
-        self._run(inp, out, layer_sizes=(8, 8))
+        _, out = self._resolve(
+            [0, 1, 2], [[0, 0]] * 3, [[[0, 5]]] * 3, layer_sizes=(8, 8)
+        )
 
-        item_map = self._read_parquet(self._map_dir(out))
+        item_map = self._map(out)
         relocated = [
             i
             for i, (origin, final) in enumerate(
@@ -1005,7 +997,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         self._append(self._prepare_single(10), out)
 
-        item_map = self._read_parquet(self._map_dir(out, "v2"))
+        item_map = self._map(out, "v2")
         self.assertEqual(len(item_map["item_id"]), 3)
         for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
@@ -1037,17 +1029,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         return manifest
 
     def test_manifest_rows_match_the_artifacts_on_a_full_resolve(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(inp, list(range(5)), [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]])
-        self._run(inp, out)
+        _, out = self._resolve(list(range(5)), [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]])
 
         manifest = self._assert_manifest_rows_match_artifacts(out, "v1")
-        # a full resolve publishes no delta, so the manifest names neither
+        # a full resolve publishes no delta: neither named nor written
         self.assertEqual(
             set(manifest.artifacts),
             {bundle.MAP_ARTIFACT, bundle.GROUPS_ARTIFACT},
         )
+        self.assertFalse(os.path.exists(self._delta_map_dir(out)))
+        self.assertFalse(os.path.exists(self._delta_groups_dir(out)))
         self.assertIsNone(manifest.since_bundle_uuid)
 
     def test_manifest_rows_match_the_artifacts_on_an_append(self) -> None:
@@ -1103,7 +1094,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         delta_map = self._delta_map_dir(out, "v2")
         delta_groups = self._delta_groups_dir(out, "v2")
         self.assertCountEqual(self._read_parquet(delta_map)["item_id"], [10, 11])
-        merged_groups = self._read_parquet(self._groups_dir(out, "v2"))
+        merged_groups = self._groups(out, "v2")
         full = {
             tuple(codebook): item_group
             for codebook, item_group in zip(
@@ -1131,7 +1122,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
         self._append(inp, out, batch_size=1)
 
-        groups = self._read_parquet(self._groups_dir(out, "v2"))
+        groups = self._groups(out, "v2")
         self.assertEqual(groups["codebook"], [[0, 0], [4, 4], [4, 5], [7, 7]])
         self.assertEqual(groups["itemids"], [[10], [0], [11], [12]])
         self._assert_map_matches_resolved_groups(out, "v2")
@@ -1242,16 +1233,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             from_partition="v1",
         )
         self.assertEqual(stats.total_items, 1)
-
-    def test_full_resolve_writes_no_delta_artifacts(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        _parquet(inp, [0, 1], [[0, 0], [1, 1]], [[[0, 2]]] * 2)
-        self._run(inp, out)
-
-        self.assertCountEqual(self._read_parquet(self._map_dir(out))["item_id"], [0, 1])
-        self._assert_map_matches_resolved_groups(out)
-        self.assertFalse(os.path.exists(self._delta_map_dir(out)))
 
     def test_append_rejects_writing_over_the_partition_it_reads(self) -> None:
         with self.assertRaisesRegex(ValueError, "writing over the artifacts"):

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1296,7 +1296,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             )
 
     def test_append_rejects_map_with_duplicate_indices(self) -> None:
-        # max(index) == count hides it; only the index sum catches this one.
+        # Indices [1, 1, 4, 4] match {1..4} on count, max and sum alike; only the
+        # index square sum separates them.
         state_map = os.path.join(self.test_dir, "dup_map")
         state_groups = os.path.join(self.test_dir, "dup_groups")
         _map_parquet(
@@ -1304,15 +1305,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             [
                 (0, [0, 0], [0, 0], 1),
                 (1, [0, 0], [0, 0], 1),
-                (2, [0, 0], [0, 0], 3),
+                (2, [0, 0], [0, 0], 4),
+                (3, [0, 0], [0, 0], 4),
             ],
         )
-        _groups_parquet(state_groups, [([0, 0], [0, 1, 2])])
+        _groups_parquet(state_groups, [([0, 0], [0, 1, 2, 3])])
         with self.assertRaisesRegex(ValueError, "not dense"):
             self._run(
                 self._prepare_single(10),
                 os.path.join(self.test_dir, "out"),
-                max_items_per_codebook=4,
+                max_items_per_codebook=5,
                 existing_sid_map_path=os.path.join(state_map, "*.parquet"),
                 existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
             )

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -46,7 +46,7 @@ def _parquet(
         "codes": pa.array(codes, type=pa.list_(pa.int64())),
     }
     if candidate_codes is not None:
-        # flatten each row's [[c0, ..], ..] (topk x n_layers) to a flat list<int>
+        # (topk x n_layers) per row, flattened to one list<int>
         flat = [[code for cand in row for code in cand] for row in candidate_codes]
         cols["candidate_codes"] = pa.array(flat, type=pa.list_(pa.int64()))
     parquet.write_table(pa.table(cols), path)
@@ -978,8 +978,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(item_map["offset_codebook"][i], [final[0], final[1] + 8])
 
     def test_append_recomputes_offset_for_state_written_without_it(self) -> None:
-        # offset_codebook is derived from the published codebook, so a
-        # generation written before that column existed still merges
+        # offset_codebook is derived, so a generation without it still merges
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,
@@ -1092,8 +1091,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             )
         }
         delta = self._read_parquet(delta_groups)
-        # Delta rows carry the whole post-append bucket, byte-identical to the
-        # corpus output, so a consumer can upsert them idempotently.
+        # Delta rows are the whole post-append bucket, so upserts are idempotent.
         for codebook, item_group in zip(delta["codebook"], delta["itemids"]):
             self.assertEqual(item_group, full[tuple(codebook)])
         touched = {item for group in delta["itemids"] for item in group}
@@ -1105,8 +1103,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     def test_append_creates_buckets_before_between_and_after(self) -> None:
-        # New SIDs sort before, between and after every published bucket, which
-        # exercises all three branches of the merge.
+        # Before, between and after every published bucket: all merge branches.
         out = self._seed_generation(item_ids=[0], codes=[[4, 4]])
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
@@ -1184,7 +1181,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10], [[0, 0]], [[[0, 2]]])
         self._append(inp, out)
-        # Leave v1's item_to_sid beside v2's sid_to_items: the totals disagree.
+        # v1's item_to_sid beside v2's sid_to_items: the totals disagree.
         shutil.rmtree(self._sid_to_items_dir(out, "v1"))
         shutil.copytree(
             self._sid_to_items_dir(out, "v2"), self._sid_to_items_dir(out, "v1")
@@ -1193,7 +1190,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self._append(self._prepare_single(20), out, previous="v1", generation="v3")
 
     def test_append_rejects_state_truncated_outside_touched_bands(self) -> None:
-        # Band 5 is untouched, so only the row totals catch its missing bucket.
+        # Band 5 is untouched, so only the totals catch its missing bucket.
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1255,7 +1255,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10], [[0, 0]], [[[0, 2]]])
         self._append(inp, out, first)
         # Pair generation 1's map with generation 2's groups.
-        with self.assertRaisesRegex(ValueError, "same generation"):
+        with self.assertRaisesRegex(ValueError, "different generations"):
             self._run(
                 self._prepare_single(20),
                 os.path.join(self.test_dir, "v3"),
@@ -1275,46 +1275,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self._run(
                 self._prepare_single(10),
                 os.path.join(self.test_dir, "out"),
-                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
-                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
-            )
-
-    def test_append_rejects_map_with_index_holes(self) -> None:
-        # Two items share bucket (0, 0) but hold indices 1 and 3: a deleted item
-        # left a hole, so appending would reuse slot 2.
-        state_map = os.path.join(self.test_dir, "holed_map")
-        state_groups = os.path.join(self.test_dir, "holed_groups")
-        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [0, 0], [0, 0], 3)])
-        _groups_parquet(state_groups, [([0, 0], [0, 1])])
-        with self.assertRaisesRegex(ValueError, "holes"):
-            self._run(
-                self._prepare_single(10),
-                os.path.join(self.test_dir, "out"),
-                max_items_per_codebook=4,
-                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
-                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
-            )
-
-    def test_append_rejects_map_with_duplicate_indices(self) -> None:
-        # Indices [1, 1, 4, 4] match {1..4} on count, max and sum alike; only the
-        # index square sum separates them.
-        state_map = os.path.join(self.test_dir, "dup_map")
-        state_groups = os.path.join(self.test_dir, "dup_groups")
-        _map_parquet(
-            state_map,
-            [
-                (0, [0, 0], [0, 0], 1),
-                (1, [0, 0], [0, 0], 1),
-                (2, [0, 0], [0, 0], 4),
-                (3, [0, 0], [0, 0], 4),
-            ],
-        )
-        _groups_parquet(state_groups, [([0, 0], [0, 1, 2, 3])])
-        with self.assertRaisesRegex(ValueError, "not dense"):
-            self._run(
-                self._prepare_single(10),
-                os.path.join(self.test_dir, "out"),
-                max_items_per_codebook=5,
                 existing_sid_map_path=os.path.join(state_map, "*.parquet"),
                 existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
             )

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -25,6 +25,7 @@ from tzrec.tools.sid.resolve_sid_collisions import (
     CollisionResolutionRunner,
     ResolveSidCollisionsConfig,
 )
+from tzrec.utils.sid import bundle
 from tzrec.utils.sid.collision import stable_order_hash
 from tzrec.utils.test_util import make_test_dir, parameterized_name_func
 
@@ -138,15 +139,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-    def _runner(self, inp, out, include_original=False, **kw):
-        original_groups, resolved_groups = self._group_paths(out)
+    def _runner(self, inp, out, **kw):
         config = dict(
             input_path=inp,
             output_path=out,
-            original_sid_groups_output_path=(
-                original_groups if include_original else None
-            ),
-            resolved_sid_groups_output_path=resolved_groups,
+            bundle_root=self._bundle_root(out),
+            partition="v1",
             reader_type=None,
             writer_type=None,
             batch_size=100000,
@@ -168,15 +166,36 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         return self._runner(inp, out, **kw).run()
 
     @staticmethod
-    def _group_paths(out):
-        return f"{out}_original_groups", f"{out}_resolved_groups"
+    def _bundle_root(out):
+        """The serving-set root this suite pairs with a given map root."""
+        return f"{out}_bundle"
+
+    def _map_dir(self, out, partition="v1"):
+        """Where the item map for one generation lands."""
+        return os.path.join(out, bundle.MAP_ARTIFACT, partition)
+
+    def _delta_map_dir(self, out, partition="v1"):
+        return os.path.join(out, bundle.DELTA_MAP_ARTIFACT, partition)
+
+    def _groups_dir(self, out, partition="v1"):
+        return os.path.join(self._bundle_root(out), bundle.GROUPS_ARTIFACT, partition)
+
+    def _delta_groups_dir(self, out, partition="v1"):
+        return os.path.join(
+            self._bundle_root(out), bundle.DELTA_GROUPS_ARTIFACT, partition
+        )
+
+    def _manifest(self, out, partition="v1"):
+        return bundle.read_manifest(
+            bundle.manifest_path(self._bundle_root(out), partition)
+        )
 
     def _read_parquet(self, out_dir):
         return parquet.read_table(os.path.join(out_dir, _PART_FILE)).to_pydict()
 
-    def _assert_map_matches_resolved_groups(self, out):
-        item_map = self._read_parquet(out)
-        _, resolved_path = self._group_paths(out)
+    def _assert_map_matches_resolved_groups(self, out, partition="v1"):
+        item_map = self._read_parquet(self._map_dir(out, partition))
+        resolved_path = self._groups_dir(out, partition)
         resolved = self._read_parquet(resolved_path)
         resolved_items = {
             tuple(codebook): item_group
@@ -191,9 +210,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         ):
             self.assertEqual(resolved_items[tuple(codebook)][index - 1], item_id)
 
-    def _map_rows(self, out):
+    def _map_rows(self, map_dir):
         """Return {item_id: (origin_codebook, codebook, index)} for a map."""
-        item_map = self._read_parquet(out)
+        item_map = self._read_parquet(map_dir)
         return {
             item_id: (tuple(origin), tuple(codebook), index)
             for item_id, origin, codebook, index in zip(
@@ -204,26 +223,44 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             )
         }
 
-    def _append_paths(self, previous_out):
-        """Return the two state reader paths for the previous generation."""
-        _, previous_groups = self._group_paths(previous_out)
-        return {
-            "existing_sid_map_path": os.path.join(previous_out, "*.parquet"),
-            "existing_sid_groups_path": os.path.join(previous_groups, "*.parquet"),
-        }
+    def _append(self, inp, out, previous="v1", partition="v2", **kw):
+        """Append onto a published generation under the same pair of roots."""
+        return self._run(inp, out, partition=partition, from_partition=previous, **kw)
 
-    def _append(self, inp, out, previous_out, **kw):
-        return self._run(inp, out, **self._append_paths(previous_out), **kw)
+    def _seed_state(self, out, map_rows, group_rows, partition="v1", csv=False):
+        """Publish a hand-built generation at the locations the tool derives."""
+        write_map = _map_csv if csv else _map_parquet
+        write_groups = _groups_parquet
+        write_map(self._map_dir(out, partition), map_rows)
+        write_groups(self._groups_dir(out, partition), group_rows)
+        bundle.write_manifest(
+            bundle.manifest_path(self._bundle_root(out), partition),
+            bundle.BundleManifest(
+                bundle_uuid=f"uuid-{partition}",
+                codebook=[8, 8],
+                capacity=2,
+                max_observed_items_per_sid=len(map_rows),
+                artifacts={
+                    bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
+                        type="parquet",
+                        rows=len(group_rows),
+                        schema={},
+                        path=self._groups_dir(out, partition),
+                    )
+                },
+            ),
+        )
+        return out
 
     def _prepare_single(self, item_id):
         path = os.path.join(self.test_dir, f"single_{item_id}.parquet")
         _parquet(path, [item_id], [[0, 0]], [[[0, 2]]])
         return path
 
-    def _assert_dense_indices(self, out):
+    def _assert_dense_indices(self, map_dir):
         """Every bucket's index multiset must be exactly 1..count."""
         by_bucket = {}
-        for _item, (_origin, codebook, index) in self._map_rows(out).items():
+        for _item, (_origin, codebook, index) in self._map_rows(map_dir).items():
             by_bucket.setdefault(codebook, []).append(index)
         for codebook, indices in by_bucket.items():
             self.assertEqual(
@@ -244,7 +281,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.relocated_count, 3)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._read_parquet(out)
+        d = self._read_parquet(self._map_dir(out))
         # every final SID keeps prefix 0 (stays in band) ...
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
         # ... and no bucket exceeds the cap.
@@ -267,7 +304,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.relocated_count, 1)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._read_parquet(out)
+        d = self._read_parquet(self._map_dir(out))
         # The relocated item took the first free candidate last code (1); every
         # SID keeps its (0, 0) band prefix.
         self.assertEqual(
@@ -283,7 +320,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         stats = self._run(inp, out, max_items_per_codebook=2)
         self.assertEqual(stats.relocated_count, 0)
         self.assertEqual(stats.unresolved_count, 3)
-        d = self._read_parquet(out)
+        d = self._read_parquet(self._map_dir(out))
         self.assertEqual(len(d["item_id"]), 5)  # every item preserved
         self.assertTrue(all(tuple(cb) == (0, 0) for cb in d["codebook"]))
         self._assert_map_matches_resolved_groups(out)
@@ -351,7 +388,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             expected_projections,
         )
         self.assertEqual(stats.relocated_count, expected_relocated)
-        self.assertEqual(len(self._read_parquet(out)["item_id"]), 3)
+        self.assertEqual(len(self._read_parquet(self._map_dir(out))["item_id"]), 3)
 
     def test_raises_when_overflow_but_no_candidates(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -376,7 +413,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         candidates = [[[0, code]] for code in [1, 2, 5, 3, 6]]
         _parquet(inp, list(range(5)), [[0, 0]] * 5, candidates)
         self._run(inp, out, batch_size=2, max_items_per_codebook=2)
-        result = self._read_parquet(out)
+        result = self._read_parquet(self._map_dir(out))
         by_id = dict(zip(result["item_id"], result["codebook"]))
         self.assertEqual(by_id[0], [0, 1])
         self.assertEqual(by_id[1], [0, 2])
@@ -394,28 +431,17 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         candidates[8] = [[1, 0], [1, 1], [1, 2]]
         _parquet(inp, item_ids, codes, candidates)
 
-        self._run(inp, out, include_original=True, max_items_per_codebook=2)
+        self._run(inp, out, max_items_per_codebook=2)
 
-        original_path, resolved_path = self._group_paths(out)
-        original = parquet.read_table(os.path.join(original_path, "part-0.parquet"))
+        resolved_path = self._groups_dir(out)
         resolved = parquet.read_table(os.path.join(resolved_path, "part-0.parquet"))
-        self.assertEqual(
-            original.column_names, ["codebook", "offset_codebook", "itemids"]
-        )
         self.assertEqual(
             resolved.column_names, ["codebook", "offset_codebook", "itemids"]
         )
-        original_groups = original.to_pydict()
         self.assertCountEqual(
-            [item_id for group in original_groups["itemids"] for item_id in group],
+            [item_id for group in resolved.to_pydict()["itemids"] for item_id in group],
             item_ids,
         )
-        original_code_by_item = dict(zip(item_ids, codes))
-        for codebook, item_group in zip(
-            original_groups["codebook"], original_groups["itemids"]
-        ):
-            for item_id in item_group:
-                self.assertEqual(codebook, original_code_by_item[item_id])
         self._assert_map_matches_resolved_groups(out)
 
     def test_no_overflow_reuses_groups_with_gapped_prefixes(self) -> None:
@@ -430,20 +456,15 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self._run(
             inp,
             out,
-            include_original=True,
             layer_sizes=(16, 16),
             max_items_per_codebook=2,
         )
 
-        original_path, resolved_path = self._group_paths(out)
-        original = parquet.read_table(
-            os.path.join(original_path, "part-0.parquet")
-        ).to_pydict()
+        resolved_path = self._groups_dir(out)
         resolved = parquet.read_table(
             os.path.join(resolved_path, "part-0.parquet")
         ).to_pydict()
-        self.assertEqual(original, resolved)
-        self.assertEqual(original["codebook"], [[7, 2], [7, 10], [12, 1]])
+        self.assertEqual(resolved["codebook"], [[7, 2], [7, 10], [12, 1]])
 
     # ---- random strategy ----
 
@@ -458,7 +479,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             strategy="random",
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._read_parquet(out)
+        d = self._read_parquet(self._map_dir(out))
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
         self.assertLessEqual(max(Counter(map(tuple, d["codebook"])).values()), 2)
         self._assert_map_matches_resolved_groups(out)
@@ -475,7 +496,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             layer_sizes=(16,),
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._read_parquet(out)
+        d = self._read_parquet(self._map_dir(out))
         self.assertEqual(len({tuple(cb) for cb in d["codebook"]}), 4)
 
     # ---- CSV backend ----
@@ -504,7 +525,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         stats = self._run(
             inp,
             out,
-            include_original=True,
             reader_type=reader_type,
             writer_type=writer_type,
             layer_sizes=(2, 2, 3),
@@ -512,9 +532,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
 
         self.assertEqual(stats.relocated_count, 1)
-        original_path, resolved_path = self._group_paths(out)
+        resolved_path = self._groups_dir(out)
         if writer_type == "CsvWriter":
-            result = csv.read_csv(os.path.join(out, "part-0.csv"))
+            result = csv.read_csv(os.path.join(self._map_dir(out), "part-0.csv"))
             self.assertEqual(result.schema.field("codebook").type, pa.string())
             self.assertEqual(result.schema.field("origin_codebook").type, pa.string())
             self.assertCountEqual(
@@ -522,23 +542,22 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 ["0,0,0", "0,0,0", "0,0,1"],
             )
             self.assertEqual(result["origin_codebook"].to_pylist(), ["0,0,0"] * 3)
-            original = csv.read_csv(os.path.join(original_path, "part-0.csv"))
-            resolved = csv.read_csv(os.path.join(resolved_path, "part-0.csv"))
-            self.assertEqual(original["codebook"].to_pylist(), ["0,0,0"])
-            self.assertCountEqual(resolved["codebook"].to_pylist(), ["0,0,0", "0,0,1"])
-            for groups in (original, resolved):
-                self.assertEqual(
-                    groups.column_names, ["codebook", "offset_codebook", "itemids"]
-                )
-                self.assertEqual(groups.schema.field("itemids").type, pa.string())
-                grouped = [
-                    item
-                    for itemids in groups["itemids"].to_pylist()
-                    for item in itemids.split(",")
-                ]
-                self.assertCountEqual(grouped, [str(i) for i in item_ids])
+            # the serving set is parquet whatever --writer_type says
+            groups = parquet.read_table(os.path.join(resolved_path, "part-0.parquet"))
+            self.assertCountEqual(
+                groups["codebook"].to_pylist(), [[0, 0, 0], [0, 0, 1]]
+            )
+            self.assertEqual(
+                groups.column_names, ["codebook", "offset_codebook", "itemids"]
+            )
+            grouped = [
+                item for group in groups["itemids"].to_pylist() for item in group
+            ]
+            self.assertCountEqual(grouped, item_ids)
         else:
-            result = parquet.read_table(os.path.join(out, "part-0.parquet"))
+            result = parquet.read_table(
+                os.path.join(self._map_dir(out), "part-0.parquet")
+            )
             self.assertEqual(result.schema.field("codebook").type, pa.list_(pa.int64()))
             self.assertEqual(
                 result.schema.field("origin_codebook").type, pa.list_(pa.int64())
@@ -548,7 +567,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 [[0, 0, 0], [0, 0, 0], [0, 0, 1]],
             )
             self.assertEqual(result["origin_codebook"].to_pylist(), [[0, 0, 0]] * 3)
-            for path in (original_path, resolved_path):
+            for path in (resolved_path,):
                 groups = parquet.read_table(os.path.join(path, "part-0.parquet"))
                 self.assertEqual(
                     groups.column_names, ["codebook", "offset_codebook", "itemids"]
@@ -556,39 +575,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 self.assertEqual(
                     groups.schema.field("itemids").type, pa.list_(pa.string())
                 )
-
-    def test_csv_group_itemids_are_comma_joined(self) -> None:
-        inp = os.path.join(self.test_dir, "in.csv")
-        out = os.path.join(self.test_dir, "out")
-        item_ids = ["a;b", "x|y", 'with"quote', "back\\slash"]
-        _csv(inp, item_ids, [[0, 0]] * len(item_ids))
-
-        self._run(
-            inp,
-            out,
-            include_original=True,
-            reader_type="CsvReader",
-            writer_type="CsvWriter",
-            max_items_per_codebook=len(item_ids),
-        )
-
-        original_path, _ = self._group_paths(out)
-        groups = csv.read_csv(os.path.join(original_path, "part-0.csv"))
-        self.assertCountEqual(groups["itemids"][0].as_py().split(","), item_ids)
-
-    def test_csv_group_itemids_reject_embedded_comma(self) -> None:
-        inp = os.path.join(self.test_dir, "in.csv")
-        out = os.path.join(self.test_dir, "out")
-        _csv(inp, ["ok", "with,comma"], [[0, 0]] * 2)
-
-        with self.assertRaisesRegex(ValueError, "cannot itself contain one"):
-            self._run(
-                inp,
-                out,
-                reader_type="CsvReader",
-                writer_type="CsvWriter",
-                max_items_per_codebook=4,
-            )
 
     def test_preserves_integer_item_id_type(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -605,15 +591,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             ),
             inp,
         )
-        self._run(inp, out, include_original=True, max_items_per_codebook=1)
-        schema = parquet.read_table(os.path.join(out, "part-0.parquet")).schema
+        self._run(inp, out, max_items_per_codebook=1)
+        schema = parquet.read_table(
+            os.path.join(self._map_dir(out), "part-0.parquet")
+        ).schema
         self.assertEqual(schema.field("item_id").type, pa.int32())
-        original_path, resolved_path = self._group_paths(out)
-        for path in (original_path, resolved_path):
-            group_schema = parquet.read_table(
-                os.path.join(path, "part-0.parquet")
-            ).schema
-            self.assertEqual(group_schema.field("itemids").type, pa.list_(pa.int32()))
+        resolved_path = self._groups_dir(out)
+        group_schema = parquet.read_table(
+            os.path.join(resolved_path, "part-0.parquet")
+        ).schema
+        self.assertEqual(group_schema.field("itemids").type, pa.list_(pa.int32()))
 
     # ---- misc ----
 
@@ -647,7 +634,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 out,
                 batch_size=2,
                 progress_interval=3,
-                include_original=True,
                 max_items_per_codebook=2,
             )
 
@@ -671,20 +657,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 progress_by_description[description][0].log.call_args_list,
                 expected_progress,
             )
-        self.assertEqual(
-            progress_by_description["Writing original SID item groups"][
-                0
-            ].log.call_args_list,
-            [mock.call(8, suffix="8 samples processed")],
-        )
 
     @parameterized.expand(
         [
-            (
-                "resolved_groups",
-                {"resolved_sid_groups_output_path": None},
-                "resolved_sid_groups_output_path",
-            ),
+            ("bundle_root", {"bundle_root": None}, "bundle_root"),
+            ("partition", {"partition": None}, "partition"),
             ("map", {"output_path": None}, "output_path"),
         ],
         name_func=parameterized_name_func,
@@ -695,34 +672,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected_field):
             self._runner("input", "map", **overrides)
 
-    def test_original_group_output_is_optional(self) -> None:
-        inp = os.path.join(self.test_dir, "in.parquet")
-        out = os.path.join(self.test_dir, "out")
-        original_path, resolved_path = self._group_paths(out)
-        _parquet(inp, [0, 1, 2], [[0, 0]] * 3, [[[0, 1]]] * 3)
-
-        with mock.patch.object(
-            resolve_sid_collisions,
-            "build_original_item_grouping",
-            wraps=resolve_sid_collisions.build_original_item_grouping,
-        ) as original_builder:
-            self._run(
-                inp,
-                out,
-                max_items_per_codebook=2,
-            )
-
-        original_builder.assert_not_called()
-        self.assertFalse(os.path.exists(original_path))
-        self.assertTrue(os.path.exists(os.path.join(out, "part-0.parquet")))
-        self.assertTrue(os.path.exists(os.path.join(resolved_path, "part-0.parquet")))
-
     def test_resolved_groups_are_written_without_original_output_or_overflow(
         self,
     ) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
-        _, resolved_path = self._group_paths(out)
+        resolved_path = self._groups_dir(out)
         _parquet(inp, [0, 1], [[0, 0], [0, 1]])
 
         self._run(
@@ -751,8 +706,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         config = ResolveSidCollisionsConfig.from_namespace(args)
 
         self.assertIsNone(config.output_path)
-        self.assertIsNone(config.original_sid_groups_output_path)
-        self.assertIsNone(config.resolved_sid_groups_output_path)
+        self.assertIsNone(config.bundle_root)
+        self.assertIsNone(config.partition)
         self.assertEqual(config.progress_interval, 1_000_000)
 
     def test_rejects_invalid_progress_interval(self) -> None:
@@ -795,18 +750,13 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self._run(
                 inp,
                 out,
-                include_original=True,
                 writer_type="OdpsWriter",
                 max_items_per_codebook=1,
             )
 
-        original_path, resolved_path = self._group_paths(out)
-        self.assertEqual(
-            [path for path, _ in created_writers],
-            [original_path, resolved_path, out],
-        )
+        self.assertEqual([path for path, _ in created_writers], [self._map_dir(out)])
         self.assertTrue(all(writer.closed for _, writer in created_writers))
-        for _, writer in created_writers[:2]:
+        for _, writer in []:
             columns = writer.writes[0]
             self.assertEqual(list(columns), ["codebook", "offset_codebook", "itemids"])
             self.assertEqual(columns["codebook"].type, pa.list_(pa.int64()))
@@ -844,10 +794,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, list(range(4)), [[0, 0], [0, 0], [0, 0], [0, 1]])
 
         with mock.patch("tzrec.tools.sid.resolve_sid_collisions._GROUP_WRITE_ITEMS", 2):
-            self._run(inp, out, include_original=True, max_items_per_codebook=3)
+            self._run(inp, out, max_items_per_codebook=3)
 
-        original_path, _ = self._group_paths(out)
-        output_file = os.path.join(original_path, "part-0.parquet")
+        resolved_path = self._groups_dir(out)
+        output_file = os.path.join(resolved_path, "part-0.parquet")
         self.assertEqual(parquet.ParquetFile(output_file).metadata.num_row_groups, 2)
         groups = parquet.read_table(output_file).to_pydict()
         self.assertEqual([len(group) for group in groups["itemids"]], [3, 1])
@@ -860,7 +810,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with mock.patch("tzrec.tools.sid.resolve_sid_collisions._MAP_WRITE_ROWS", 2):
             self._run(inp, out, max_items_per_codebook=1)
 
-        output_file = os.path.join(out, "part-0.parquet")
+        output_file = os.path.join(self._map_dir(out), "part-0.parquet")
         self.assertEqual(parquet.ParquetFile(output_file).metadata.num_row_groups, 3)
 
     def test_writers_bound_codebook_list_offsets(self) -> None:
@@ -877,10 +827,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 "tzrec.tools.sid.resolve_sid_collisions._GROUP_WRITE_ITEMS", 100
             ),
         ):
-            self._run(inp, out, include_original=True, max_items_per_codebook=1)
+            self._run(inp, out, max_items_per_codebook=1)
 
-        original_path, resolved_path = self._group_paths(out)
-        for path in (out, original_path, resolved_path):
+        resolved_path = self._groups_dir(out)
+        for path in (self._map_dir(out), resolved_path):
             output_file = os.path.join(path, "part-0.parquet")
             self.assertEqual(
                 parquet.ParquetFile(output_file).metadata.num_row_groups, 2
@@ -896,8 +846,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             inp,
             out,
             output_path=None,
-            original_sid_groups_output_path=None,
-            resolved_sid_groups_output_path=None,
+            bundle_root=None,
+            partition=None,
             max_items_per_codebook=2,
             rate_only=True,
         )
@@ -914,11 +864,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.total_items, 5)
         self.assertEqual(stats.relocated_count, 3)
         self.assertEqual(stats.unresolved_count, 0)
-        self.assertFalse(os.path.exists(os.path.join(out, "part-0.parquet")))
-        original_path, resolved_path = self._group_paths(out)
-        self.assertFalse(os.path.exists(original_path))
+        resolved_path = self._groups_dir(out)
         self.assertFalse(os.path.exists(resolved_path))
         self.assertFalse(os.path.exists(out))
+        self.assertFalse(os.path.exists(self._bundle_root(out)))
 
     def test_empty_input_raises(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -956,20 +905,19 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             inp,
             out,
             batch_size=batch_size,
-            include_original=True,
             max_items_per_codebook=1,
         )
 
         self.assertEqual(stats.total_items, 3)
         self.assertEqual(stats.relocated_count, 2)
-        result = self._read_parquet(out)
+        result = self._read_parquet(self._map_dir(out))
         self.assertEqual(result["item_id"], [keeper, duplicate, duplicate])
         self.assertEqual(result["item_id"].count(duplicate), 2)
         self._assert_map_matches_resolved_groups(out)
-        original_path, _ = self._group_paths(out)
-        original_groups = self._read_parquet(original_path)
+        resolved_path = self._groups_dir(out)
+        groups = self._read_parquet(resolved_path)
         self.assertCountEqual(
-            [item_id for group in original_groups["itemids"] for item_id in group],
+            [item_id for group in groups["itemids"] for item_id in group],
             [keeper, duplicate, duplicate],
         )
 
@@ -1009,7 +957,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
 
         self.assertEqual(stats.total_items, 3)
-        result = self._read_parquet(out)
+        result = self._read_parquet(self._map_dir(out))
         self.assertEqual(result["item_id"], ["b", "a", "a"])
         self._assert_map_matches_resolved_groups(out)
 
@@ -1034,19 +982,18 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
         _parquet(inp, [0, 1], [[1, 2], [3, 4]], [[[0, 0]]] * 2)
-        self._run(inp, out, include_original=True, layer_sizes=(8, 8))
+        self._run(inp, out, layer_sizes=(8, 8))
 
         # layer 1 is shifted by layer_sizes[0]
-        item_map = self._read_parquet(out)
+        item_map = self._read_parquet(self._map_dir(out))
         by_item = dict(zip(item_map["item_id"], item_map["offset_codebook"]))
         self.assertEqual(by_item[0], [1, 2 + 8])
         self.assertEqual(by_item[1], [3, 4 + 8])
 
-        original_path, resolved_path = self._group_paths(out)
-        for path in (original_path, resolved_path):
-            groups = self._read_parquet(path)
-            for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
-                self.assertEqual(offset, [codebook[0], codebook[1] + 8])
+        resolved_path = self._groups_dir(out)
+        groups = self._read_parquet(resolved_path)
+        for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
+            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     def test_offset_codebook_tracks_the_resolved_not_the_origin_sid(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -1055,7 +1002,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [0, 1, 2], [[0, 0]] * 3, [[[0, 5]]] * 3)
         self._run(inp, out, layer_sizes=(8, 8))
 
-        item_map = self._read_parquet(out)
+        item_map = self._read_parquet(self._map_dir(out))
         relocated = [
             i
             for i, (origin, final) in enumerate(
@@ -1071,19 +1018,15 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     def test_append_recomputes_offset_for_state_written_without_it(self) -> None:
         # a map published before offset_codebook existed must still merge: the
         # column is derived from the published codebook, not passed through
-        state_map = os.path.join(self.test_dir, "old_map")
-        state_groups = os.path.join(self.test_dir, "old_groups")
-        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)])
-        _groups_parquet(state_groups, [([0, 0], [0]), ([1, 1], [1])])
-        out = os.path.join(self.test_dir, "v2")
-        self._run(
-            self._prepare_single(10),
+        out = os.path.join(self.test_dir, "out")
+        self._seed_state(
             out,
-            existing_sid_map_path=os.path.join(state_map, "*.parquet"),
-            existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
+            [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)],
+            [([0, 0], [0]), ([1, 1], [1])],
         )
+        self._append(self._prepare_single(10), out)
 
-        item_map = self._read_parquet(out)
+        item_map = self._read_parquet(self._map_dir(out, "v2"))
         self.assertEqual(len(item_map["item_id"]), 3)
         for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
@@ -1091,62 +1034,53 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     # ---- append mode ----
 
     def _seed_generation(self, name="v1", item_ids=None, codes=None):
-        """Run a full resolve to produce the state a later append consumes."""
+        """Run a full resolve at partition v1, the state a later append consumes."""
         inp = os.path.join(self.test_dir, f"{name}_in.parquet")
         out = os.path.join(self.test_dir, name)
         item_ids = list(range(5)) if item_ids is None else item_ids
         codes = [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]] if codes is None else codes
         _parquet(inp, item_ids, codes, [[[0, 2], [0, 3]]] * len(item_ids))
-        self._run(inp, out)
+        self._run(inp, out, partition="v1")
         return out
 
     def test_append_never_moves_a_published_item(self) -> None:
-        base = self._seed_generation()
-        published = self._map_rows(base)
+        out = self._seed_generation()
+        published = self._map_rows(self._map_dir(out, "v1"))
 
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         # Rows 10 and 11 land in the already-full bucket (0, 0).
         _parquet(inp, [10, 11, 12], [[0, 0], [0, 0], [1, 1]], [[[0, 2], [0, 3]]] * 3)
-        stats = self._append(inp, out, base)
+        stats = self._append(inp, out)
 
         self.assertEqual(stats.total_items, 3)
-        merged = self._map_rows(out)
+        merged = self._map_rows(self._map_dir(out, "v2"))
         self.assertEqual(len(merged), 8)
         for item_id, row in published.items():
             self.assertEqual(merged[item_id], row, f"item {item_id} moved")
-        self._assert_dense_indices(out)
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_dense_indices(self._map_dir(out, "v2"))
+        self._assert_map_matches_resolved_groups(out, "v2")
 
     def test_append_continues_slot_numbering(self) -> None:
-        base = self._seed_generation(item_ids=[0], codes=[[0, 0]])
+        out = self._seed_generation(item_ids=[0], codes=[[0, 0]])
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10], [[0, 0]], [[[0, 0]]])
-        self._append(inp, out, base)
+        self._append(inp, out)
 
-        merged = self._map_rows(out)
+        merged = self._map_rows(self._map_dir(out, "v2"))
         self.assertEqual(merged[0][2], 1)
         # Capacity is 2, so the new row is retained and continues at slot 2.
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
 
     def test_append_emits_delta_outputs(self) -> None:
-        base = self._seed_generation()
+        out = self._seed_generation()
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
-        delta_map = os.path.join(self.test_dir, "delta_map")
-        delta_groups = os.path.join(self.test_dir, "delta_groups")
         _parquet(inp, [10, 11], [[0, 0], [3, 3]], [[[0, 2], [0, 3]]] * 2)
-        self._append(
-            inp,
-            out,
-            base,
-            delta_map_output_path=delta_map,
-            delta_sid_groups_output_path=delta_groups,
-        )
+        self._append(inp, out)
 
+        delta_map = self._delta_map_dir(out, "v2")
+        delta_groups = self._delta_groups_dir(out, "v2")
         self.assertCountEqual(self._read_parquet(delta_map)["item_id"], [10, 11])
-        merged_groups = self._read_parquet(self._group_paths(out)[1])
+        merged_groups = self._read_parquet(self._groups_dir(out, "v2"))
         full = {
             tuple(codebook): item_group
             for codebook, item_group in zip(
@@ -1169,36 +1103,34 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     def test_append_creates_buckets_before_between_and_after(self) -> None:
         # New SIDs sort before, between and after every published bucket, which
         # exercises all three branches of the groups merge.
-        base = self._seed_generation(item_ids=[0], codes=[[4, 4]])
+        out = self._seed_generation(item_ids=[0], codes=[[4, 4]])
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
-        self._append(inp, out, base, batch_size=1)
+        self._append(inp, out, batch_size=1)
 
-        groups = self._read_parquet(self._group_paths(out)[1])
+        groups = self._read_parquet(self._groups_dir(out, "v2"))
         self.assertEqual(groups["codebook"], [[0, 0], [4, 4], [4, 5], [7, 7]])
         self.assertEqual(groups["itemids"], [[10], [0], [11], [12]])
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_map_matches_resolved_groups(out, "v2")
 
     def test_append_merges_across_reader_batches(self) -> None:
-        base = self._seed_generation(
+        out = self._seed_generation(
             item_ids=list(range(6)),
             codes=[[0, 0], [0, 0], [2, 2], [3, 3], [4, 4], [5, 5]],
         )
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10, 11, 12], [[0, 0], [3, 3], [6, 6]], [[[0, 0]]] * 3)
-        self._append(inp, out, base, batch_size=1)
+        self._append(inp, out, batch_size=1)
 
-        self._assert_dense_indices(out)
-        self._assert_map_matches_resolved_groups(out)
-        self.assertEqual(len(self._map_rows(out)), 9)
+        self._assert_dense_indices(self._map_dir(out, "v2"))
+        self._assert_map_matches_resolved_groups(out, "v2")
+        self.assertEqual(len(self._map_rows(self._map_dir(out, "v2"))), 9)
 
     def test_append_chain_stays_consistent(self) -> None:
-        previous = self._seed_generation()
+        out = self._seed_generation()
         for generation in range(2, 5):
             inp = os.path.join(self.test_dir, f"v{generation}_in.parquet")
-            out = os.path.join(self.test_dir, f"v{generation}")
+            previous, current = f"v{generation - 1}", f"v{generation}"
             base = 100 * generation
             _parquet(
                 inp,
@@ -1206,111 +1138,91 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 [[0, 0], [generation, generation]],
                 [[[0, 2], [0, 3]]] * 2,
             )
-            published = self._map_rows(previous)
-            self._append(inp, out, previous)
-            merged = self._map_rows(out)
+            published = self._map_rows(self._map_dir(out, previous))
+            self._append(inp, out, previous=previous, partition=current)
+            merged = self._map_rows(self._map_dir(out, current))
             for item_id, row in published.items():
                 self.assertEqual(merged[item_id], row)
-            self._assert_dense_indices(out)
-            self._assert_map_matches_resolved_groups(out)
-            previous = out
+            self._assert_dense_indices(self._map_dir(out, current))
+            self._assert_map_matches_resolved_groups(out, current)
 
     def test_append_reads_csv_state_and_converts_format(self) -> None:
-        # CSV state exercises the JSON branch of the grouped item-ID decoder,
-        # and a parquet new-items input drives _align_codes_column's re-encode.
-        state_map = os.path.join(self.test_dir, "csv_map")
-        state_groups = os.path.join(self.test_dir, "csv_groups")
-        _map_csv(state_map, [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)])
-        _groups_csv(state_groups, [([0, 0], [0]), ([1, 1], [1])])
-
-        inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
-        _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
-        self._run(
-            inp,
+        # A CSV published map with a parquet new-items input drives
+        # _align_codes_column's re-encode on the copy-through path.
+        out = os.path.join(self.test_dir, "out")
+        self._seed_state(
             out,
-            existing_sid_map_path=os.path.join(state_map, "*.csv"),
-            existing_sid_groups_path=os.path.join(state_groups, "*.csv"),
+            [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)],
+            [([0, 0], [0]), ([1, 1], [1])],
+            csv=True,
         )
 
-        merged = self._map_rows(out)
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
+        self._append(inp, out, reader_type="CsvReader")
+
+        merged = self._map_rows(self._map_dir(out, "v2"))
         self.assertEqual(len(merged), 4)
         self.assertEqual(merged[0], ((0, 0), (0, 0), 1))
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
-        self._assert_dense_indices(out)
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_dense_indices(self._map_dir(out, "v2"))
+        self._assert_map_matches_resolved_groups(out, "v2")
 
     def test_append_rejects_already_published_item_id(self) -> None:
-        base = self._seed_generation()
+        out = self._seed_generation()
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [0, 99], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
         with self.assertRaisesRegex(ValueError, "already published"):
-            self._append(inp, out, base)
+            self._append(inp, out)
 
     def test_append_rejects_mismatched_generation_pair(self) -> None:
-        first = self._seed_generation("v1")
+        out = self._seed_generation("v1")
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
         _parquet(inp, [10], [[0, 0]], [[[0, 2]]])
-        self._append(inp, out, first)
-        # Pair generation 1's map with generation 2's groups.
+        self._append(inp, out)
+        # Leave v1's map beside v2's groups: the row totals no longer agree.
+        shutil.rmtree(self._groups_dir(out, "v1"))
+        shutil.copytree(self._groups_dir(out, "v2"), self._groups_dir(out, "v1"))
         with self.assertRaisesRegex(ValueError, "different generations"):
-            self._run(
-                self._prepare_single(20),
-                os.path.join(self.test_dir, "v3"),
-                existing_sid_map_path=os.path.join(first, "*.parquet"),
-                existing_sid_groups_path=os.path.join(
-                    self._group_paths(out)[1], "*.parquet"
-                ),
-            )
+            self._append(self._prepare_single(20), out, previous="v1", partition="v3")
 
     def test_append_rejects_state_truncated_outside_touched_bands(self) -> None:
         # Band 5 is untouched, so only the row totals can catch its missing group.
-        state_map = os.path.join(self.test_dir, "trunc_map")
-        state_groups = os.path.join(self.test_dir, "trunc_groups")
-        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [5, 5], [5, 5], 1)])
-        _groups_parquet(state_groups, [([0, 0], [0])])
+        out = os.path.join(self.test_dir, "out")
+        self._seed_state(
+            out,
+            [(0, [0, 0], [0, 0], 1), (1, [5, 5], [5, 5], 1)],
+            [([0, 0], [0])],
+        )
         with self.assertRaisesRegex(ValueError, "one of the two artifacts is"):
-            self._run(
-                self._prepare_single(10),
-                os.path.join(self.test_dir, "out"),
-                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
-                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
-            )
+            self._append(self._prepare_single(10), out)
 
     def test_append_rejects_unsorted_existing_groups(self) -> None:
-        state_map = os.path.join(self.test_dir, "unsorted_map")
-        state_groups = os.path.join(self.test_dir, "unsorted_groups")
-        _map_parquet(state_map, [(0, [1, 1], [1, 1], 1), (1, [0, 0], [0, 0], 1)])
-        _groups_parquet(state_groups, [([1, 1], [0]), ([0, 0], [1])])
+        out = os.path.join(self.test_dir, "out")
+        self._seed_state(
+            out,
+            [(0, [1, 1], [1, 1], 1), (1, [0, 0], [0, 0], 1)],
+            [([1, 1], [0]), ([0, 0], [1])],
+        )
         with self.assertRaisesRegex(ValueError, "ascending"):
-            self._run(
-                self._prepare_single(10),
-                os.path.join(self.test_dir, "out"),
-                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
-                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
-            )
+            self._append(self._prepare_single(10), out)
 
     def test_append_rate_only_needs_no_map(self) -> None:
-        base = self._seed_generation()
+        out = self._seed_generation()
         stats = self._run(
             self._prepare_single(10),
-            os.path.join(self.test_dir, "unused"),
+            out,
             rate_only=True,
             output_path=None,
-            resolved_sid_groups_output_path=None,
-            existing_sid_groups_path=os.path.join(
-                self._group_paths(base)[1], "*.parquet"
-            ),
+            bundle_root=self._bundle_root(out),
+            partition=None,
+            from_partition="v1",
         )
         self.assertEqual(stats.total_items, 1)
 
     @parameterized.expand(
         [
-            ({"existing_sid_map_path": "state/*.parquet"},),
-            ({"delta_map_output_path": "delta"},),
-            ({"delta_sid_groups_output_path": "delta"},),
+            ({"source_model": "rqvae"},),
         ],
         name_func=parameterized_name_func,
     )
@@ -1320,18 +1232,17 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [0, 1], [[0, 0], [1, 1]], [[[0, 2]]] * 2)
         self._run(inp, out, **overrides)
 
-        self.assertCountEqual(self._read_parquet(out)["item_id"], [0, 1])
+        self.assertCountEqual(self._read_parquet(self._map_dir(out))["item_id"], [0, 1])
         self._assert_map_matches_resolved_groups(out)
-        delta = overrides.get("delta_map_output_path")
-        if delta is not None:
-            self.assertFalse(os.path.exists(delta))
+        self.assertFalse(os.path.exists(self._delta_map_dir(out)))
 
-    def test_append_requires_map_unless_rate_only(self) -> None:
-        with self.assertRaisesRegex(ValueError, "existing_sid_map_path is required"):
+    def test_append_rejects_writing_over_the_partition_it_reads(self) -> None:
+        with self.assertRaisesRegex(ValueError, "writing over the artifacts"):
             self._runner(
                 os.path.join(self.test_dir, "in.parquet"),
                 os.path.join(self.test_dir, "out"),
-                existing_sid_groups_path="groups/*.parquet",
+                partition="v1",
+                from_partition="v1",
             )
 
 

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -117,20 +117,6 @@ def _map_csv(path, rows):
     )
 
 
-def _groups_csv(path, rows):
-    """Write a groups artifact in the CSV encoding this tool emits."""
-    os.makedirs(path, exist_ok=True)
-    csv.write_csv(
-        pa.table(
-            {
-                "codebook": [",".join(map(str, r[0])) for r in rows],
-                "itemids": [",".join(map(str, r[1])) for r in rows],
-            }
-        ),
-        os.path.join(path, "part-0.csv"),
-    )
-
-
 class ResolveSidCollisionsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.test_dir = make_test_dir()
@@ -230,9 +216,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     def _seed_state(self, out, map_rows, group_rows, partition="v1", csv=False):
         """Publish a hand-built generation at the locations the tool derives."""
         write_map = _map_csv if csv else _map_parquet
-        write_groups = _groups_parquet
         write_map(self._map_dir(out, partition), map_rows)
-        write_groups(self._groups_dir(out, partition), group_rows)
+        _groups_parquet(self._groups_dir(out, partition), group_rows)
         bundle.write_manifest(
             bundle.manifest_path(self._bundle_root(out), partition),
             bundle.BundleManifest(
@@ -756,11 +741,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         self.assertEqual([path for path, _ in created_writers], [self._map_dir(out)])
         self.assertTrue(all(writer.closed for _, writer in created_writers))
-        for _, writer in []:
-            columns = writer.writes[0]
-            self.assertEqual(list(columns), ["codebook", "offset_codebook", "itemids"])
-            self.assertEqual(columns["codebook"].type, pa.list_(pa.int64()))
-            self.assertEqual(columns["itemids"].type, pa.list_(pa.int32()))
 
     def test_writer_closes_when_write_fails(self) -> None:
         class FailingWriter:
@@ -1220,17 +1200,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         self.assertEqual(stats.total_items, 1)
 
-    @parameterized.expand(
-        [
-            ({"source_model": "rqvae"},),
-        ],
-        name_func=parameterized_name_func,
-    )
-    def test_append_only_flags_are_ignored_outside_append_mode(self, overrides) -> None:
+    def test_full_resolve_writes_no_delta_artifacts(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
         _parquet(inp, [0, 1], [[0, 0], [1, 1]], [[[0, 2]]] * 2)
-        self._run(inp, out, **overrides)
+        self._run(inp, out)
 
         self.assertCountEqual(self._read_parquet(self._map_dir(out))["item_id"], [0, 1])
         self._assert_map_matches_resolved_groups(out)

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -71,7 +71,7 @@ def _write_part(path, table):
     parquet.write_table(table, os.path.join(path, _PART_FILE))
 
 
-def _map_parquet(path, rows):
+def _item_to_sid_parquet(path, rows):
     """Write a map artifact from (item_id, origin_codebook, codebook, index)."""
     _write_part(
         path,
@@ -88,7 +88,7 @@ def _map_parquet(path, rows):
     )
 
 
-def _groups_parquet(path, rows):
+def _sid_to_items_parquet(path, rows):
     """Write a groups artifact from (codebook, item_ids) in SID-key order."""
     _write_part(
         path,
@@ -101,7 +101,7 @@ def _groups_parquet(path, rows):
     )
 
 
-def _map_csv(path, rows):
+def _item_to_sid_csv(path, rows):
     """Write a map artifact in the CSV encoding this tool emits."""
     os.makedirs(path, exist_ok=True)
     csv.write_csv(
@@ -129,10 +129,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         config = dict(
             input_path=inp,
             output_path=out,
-            bundle_root=self._bundle_root(out),
-            partition="v1",
+            item_to_sid_root=None,
+            generation="v1",
             reader_type=None,
-            writer_type=None,
+            item_to_sid_writer_type=None,
             batch_size=100000,
             progress_interval=1_000_000,
             item_id_field="item_id",
@@ -151,30 +151,21 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     def _run(self, inp, out, **kw):
         return self._runner(inp, out, **kw).run()
 
-    @staticmethod
-    def _bundle_root(out):
-        """The serving-set root this suite pairs with a given map root."""
-        return f"{out}_bundle"
-
-    def _map_dir(self, out, partition="v1"):
+    def _item_to_sid_dir(self, out, generation="v1"):
         """Where the item map for one generation lands."""
-        return os.path.join(out, bundle.MAP_ARTIFACT, partition)
+        return os.path.join(out, generation, bundle.ITEM_TO_SID_ARTIFACT)
 
-    def _delta_map_dir(self, out, partition="v1"):
-        return os.path.join(out, bundle.DELTA_MAP_ARTIFACT, partition)
+    def _delta_item_to_sid_dir(self, out, generation="v1"):
+        return os.path.join(out, generation, bundle.DELTA_ITEM_TO_SID_ARTIFACT)
 
-    def _groups_dir(self, out, partition="v1"):
-        return os.path.join(self._bundle_root(out), bundle.GROUPS_ARTIFACT, partition)
+    def _sid_to_items_dir(self, out, generation="v1"):
+        return os.path.join(out, generation, bundle.SID_TO_ITEMS_ARTIFACT)
 
-    def _delta_groups_dir(self, out, partition="v1"):
-        return os.path.join(
-            self._bundle_root(out), bundle.DELTA_GROUPS_ARTIFACT, partition
-        )
+    def _delta_sid_to_items_dir(self, out, generation="v1"):
+        return os.path.join(out, generation, bundle.DELTA_SID_TO_ITEMS_ARTIFACT)
 
-    def _manifest(self, out, partition="v1"):
-        return bundle.read_manifest(
-            bundle.manifest_path(self._bundle_root(out), partition)
-        )
+    def _manifest(self, out, generation="v1"):
+        return bundle.read_manifest(bundle.manifest_path(out, generation))
 
     def _resolve(self, item_ids, codes, candidates=None, **kw):
         """Write one input, resolve it, and return the stats and the map root."""
@@ -183,20 +174,20 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, item_ids, codes, candidates)
         return self._run(inp, out, **kw), out
 
-    def _map(self, out, partition="v1"):
+    def _item_to_sid(self, out, generation="v1"):
         """Read one generation's item map."""
-        return self._read_parquet(self._map_dir(out, partition))
+        return self._read_parquet(self._item_to_sid_dir(out, generation))
 
-    def _groups(self, out, partition="v1"):
+    def _sid_to_items(self, out, generation="v1"):
         """Read one generation's SID groups."""
-        return self._read_parquet(self._groups_dir(out, partition))
+        return self._read_parquet(self._sid_to_items_dir(out, generation))
 
     def _read_parquet(self, out_dir):
         return parquet.read_table(os.path.join(out_dir, _PART_FILE)).to_pydict()
 
-    def _assert_map_matches_resolved_groups(self, out, partition="v1"):
-        item_map = self._read_parquet(self._map_dir(out, partition))
-        resolved_path = self._groups_dir(out, partition)
+    def _assert_item_to_sid_matches_sid_to_items(self, out, generation="v1"):
+        item_map = self._read_parquet(self._item_to_sid_dir(out, generation))
+        resolved_path = self._sid_to_items_dir(out, generation)
         resolved = self._read_parquet(resolved_path)
         resolved_items = {
             tuple(codebook): item_group
@@ -211,9 +202,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         ):
             self.assertEqual(resolved_items[tuple(codebook)][index - 1], item_id)
 
-    def _map_rows(self, map_dir):
+    def _item_to_sid_rows(self, item_to_sid_dir):
         """Return {item_id: (origin_codebook, codebook, index)} for a map."""
-        item_map = self._read_parquet(map_dir)
+        item_map = self._read_parquet(item_to_sid_dir)
         return {
             item_id: (tuple(origin), tuple(codebook), index)
             for item_id, origin, codebook, index in zip(
@@ -224,28 +215,35 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             )
         }
 
-    def _append(self, inp, out, previous="v1", partition="v2", **kw):
-        """Append onto a published generation under the same pair of roots."""
-        return self._run(inp, out, partition=partition, from_partition=previous, **kw)
+    def _append(self, inp, out, previous="v1", generation="v2", **kw):
+        """Append onto a published generation under the same root."""
+        return self._run(
+            inp, out, generation=generation, from_generation=previous, **kw
+        )
 
-    def _seed_state(self, out, map_rows, group_rows, partition="v1", csv=False):
+    def _seed_state(self, out, map_rows, group_rows, generation="v1", csv=False):
         """Publish a hand-built generation at the locations the tool derives."""
-        write_map = _map_csv if csv else _map_parquet
-        write_map(self._map_dir(out, partition), map_rows)
-        _groups_parquet(self._groups_dir(out, partition), group_rows)
+        write_map = _item_to_sid_csv if csv else _item_to_sid_parquet
+        write_map(self._item_to_sid_dir(out, generation), map_rows)
+        _sid_to_items_parquet(self._sid_to_items_dir(out, generation), group_rows)
         bundle.write_manifest(
-            bundle.manifest_path(self._bundle_root(out), partition),
+            bundle.manifest_path(out, generation),
             bundle.BundleManifest(
-                bundle_uuid=f"uuid-{partition}",
+                bundle_uuid=f"uuid-{generation}",
                 codebook=[8, 8],
                 capacity=2,
                 max_observed_items_per_sid=len(map_rows),
                 artifacts={
-                    bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
+                    bundle.SID_TO_ITEMS_ARTIFACT: bundle.ArtifactEntry(
                         save_type="parquet",
                         rows=len(group_rows),
-                        location=self._groups_dir(out, partition),
-                    )
+                        location=self._sid_to_items_dir(out, generation),
+                    ),
+                    bundle.ITEM_TO_SID_ARTIFACT: bundle.ArtifactEntry(
+                        save_type="csv" if csv else "parquet",
+                        rows=len(map_rows),
+                        location=self._item_to_sid_dir(out, generation),
+                    ),
                 },
             ),
         )
@@ -256,10 +254,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(path, [item_id], [[0, 0]], [[[0, 2]]])
         return path
 
-    def _assert_dense_indices(self, map_dir):
+    def _assert_dense_indices(self, item_to_sid_dir):
         """Every bucket's index multiset must be exactly 1..count."""
         by_bucket = {}
-        for _item, (_origin, codebook, index) in self._map_rows(map_dir).items():
+        for _item, (_origin, codebook, index) in self._item_to_sid_rows(
+            item_to_sid_dir
+        ).items():
             by_bucket.setdefault(codebook, []).append(index)
         for codebook, indices in by_bucket.items():
             self.assertEqual(
@@ -268,10 +268,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 f"non-dense index set for {codebook}",
             )
 
-    # ---- candidate strategy ----
-
     def test_candidate_reassigns_within_band(self) -> None:
-        # 5 items in bucket (0,0); candidates vary only the last layer within band 0.
         stats, out = self._resolve(
             list(range(5)),
             [[0, 0]] * 5,
@@ -282,10 +279,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.relocated_count, 3)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._map(out)
-        # every final SID keeps prefix 0 (stays in band) ...
+        d = self._item_to_sid(out)
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
-        # ... and no bucket exceeds the cap.
         self.assertLessEqual(max(Counter(map(tuple, d["codebook"])).values()), 2)
 
     def test_three_layer_candidate_reassigns_within_band(self) -> None:
@@ -300,25 +295,22 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.relocated_count, 1)
         self.assertEqual(stats.unresolved_count, 0)
         self.assertEqual(stats.max_final_bucket_size, 2)
-        d = self._map(out)
-        # The relocated item took the first free candidate last code (1); every
-        # SID keeps its (0, 0) band prefix.
+        d = self._item_to_sid(out)
         self.assertEqual(
             sorted(tuple(cb) for cb in d["codebook"]),
             [(0, 0, 0), (0, 0, 0), (0, 0, 1)],
         )
 
     def test_keep_original_when_only_origin_candidate(self) -> None:
-        # candidate == origin last -> skipped -> nothing to place; kept over cap.
         stats, out = self._resolve(
             list(range(5)), [[0, 0]] * 5, [[[0, 0]]] * 5, max_items_per_codebook=2
         )
         self.assertEqual(stats.relocated_count, 0)
         self.assertEqual(stats.unresolved_count, 3)
-        d = self._map(out)
-        self.assertEqual(len(d["item_id"]), 5)  # every item preserved
+        d = self._item_to_sid(out)
+        self.assertEqual(len(d["item_id"]), 5)
         self.assertTrue(all(tuple(cb) == (0, 0) for cb in d["codebook"]))
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_item_to_sid_matches_sid_to_items(out)
 
     @parameterized.expand(
         [
@@ -383,12 +375,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             expected_projections,
         )
         self.assertEqual(stats.relocated_count, expected_relocated)
-        self.assertEqual(len(self._map(out)["item_id"]), 3)
+        self.assertEqual(len(self._item_to_sid(out)["item_id"]), 3)
 
     def test_raises_when_overflow_but_no_candidates(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
-        _parquet(inp, list(range(5)), [[0, 0]] * 5)  # no candidate_codes column
+        _parquet(inp, list(range(5)), [[0, 0]] * 5)
         with self.assertRaisesRegex(ValueError, "candidate_codes field .* is missing"):
             self._run(inp, out, max_items_per_codebook=2)
 
@@ -408,7 +400,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         candidates = [[[0, code]] for code in [1, 2, 5, 3, 6]]
         _parquet(inp, list(range(5)), [[0, 0]] * 5, candidates)
         self._run(inp, out, batch_size=2, max_items_per_codebook=2)
-        result = self._map(out)
+        result = self._item_to_sid(out)
         by_id = dict(zip(result["item_id"], result["codebook"]))
         self.assertEqual(by_id[0], [0, 1])
         self.assertEqual(by_id[1], [0, 2])
@@ -418,7 +410,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
         item_ids = list(range(10))
-        # 4 items in bucket (0,0), 1 in (0,1), 2 in (0,2), 3 in (1,0).
         codes = [[0, 0]] * 4 + [[0, 1]] + [[0, 2]] * 2 + [[1, 0]] * 3
         candidates = [[[0, 0]] for _ in item_ids]
         candidates[1] = [[0, 0], [0, 1], [0, 2]]
@@ -428,7 +419,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         self._run(inp, out, max_items_per_codebook=2)
 
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         resolved = parquet.read_table(os.path.join(resolved_path, "part-0.parquet"))
         self.assertEqual(
             resolved.column_names, ["codebook", "offset_codebook", "itemids"]
@@ -437,9 +428,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             [item_id for group in resolved.to_pydict()["itemids"] for item_id in group],
             item_ids,
         )
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_item_to_sid_matches_sid_to_items(out)
 
-    def test_no_overflow_reuses_groups_with_gapped_prefixes(self) -> None:
+    def test_no_overflow_reuses_buckets_with_gapped_prefixes(self) -> None:
         _, out = self._resolve(
             list(range(6)),
             [[7, 10], [7, 2], [12, 1], [7, 2], [12, 1], [7, 10]],
@@ -447,23 +438,21 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             max_items_per_codebook=2,
         )
 
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         resolved = parquet.read_table(
             os.path.join(resolved_path, "part-0.parquet")
         ).to_pydict()
         self.assertEqual(resolved["codebook"], [[7, 2], [7, 10], [12, 1]])
-
-    # ---- random strategy ----
 
     def test_random_reassigns_within_band(self) -> None:
         stats, out = self._resolve(
             list(range(5)), [[0, 0]] * 5, max_items_per_codebook=2, strategy="random"
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._map(out)
+        d = self._item_to_sid(out)
         self.assertTrue(all(cb[0] == 0 for cb in d["codebook"]))
         self.assertLessEqual(max(Counter(map(tuple, d["codebook"])).values()), 2)
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_item_to_sid_matches_sid_to_items(out)
 
     def test_single_layer_sid(self) -> None:
         stats, out = self._resolve(
@@ -474,10 +463,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             layer_sizes=(16,),
         )
         self.assertEqual(stats.relocated_count, 3)
-        d = self._map(out)
+        d = self._item_to_sid(out)
         self.assertEqual(len({tuple(cb) for cb in d["codebook"]}), 4)
-
-    # ---- CSV backend ----
 
     @parameterized.expand(
         [
@@ -504,15 +491,17 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             inp,
             out,
             reader_type=reader_type,
-            writer_type=writer_type,
+            item_to_sid_writer_type=writer_type,
             layer_sizes=(2, 2, 3),
             max_items_per_codebook=2,
         )
 
         self.assertEqual(stats.relocated_count, 1)
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         if writer_type == "CsvWriter":
-            result = csv.read_csv(os.path.join(self._map_dir(out), "part-0.csv"))
+            result = csv.read_csv(
+                os.path.join(self._item_to_sid_dir(out), "part-0.csv")
+            )
             self.assertEqual(result.schema.field("codebook").type, pa.string())
             self.assertEqual(result.schema.field("origin_codebook").type, pa.string())
             self.assertCountEqual(
@@ -520,7 +509,6 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 ["0,0,0", "0,0,0", "0,0,1"],
             )
             self.assertEqual(result["origin_codebook"].to_pylist(), ["0,0,0"] * 3)
-            # the serving set is parquet whatever --writer_type says
             groups = parquet.read_table(os.path.join(resolved_path, "part-0.parquet"))
             self.assertCountEqual(
                 groups["codebook"].to_pylist(), [[0, 0, 0], [0, 0, 1]]
@@ -534,7 +522,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertCountEqual(grouped, item_ids)
         else:
             result = parquet.read_table(
-                os.path.join(self._map_dir(out), "part-0.parquet")
+                os.path.join(self._item_to_sid_dir(out), "part-0.parquet")
             )
             self.assertEqual(result.schema.field("codebook").type, pa.list_(pa.int64()))
             self.assertEqual(
@@ -571,16 +559,14 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         self._run(inp, out, max_items_per_codebook=1)
         schema = parquet.read_table(
-            os.path.join(self._map_dir(out), "part-0.parquet")
+            os.path.join(self._item_to_sid_dir(out), "part-0.parquet")
         ).schema
         self.assertEqual(schema.field("item_id").type, pa.int32())
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         group_schema = parquet.read_table(
             os.path.join(resolved_path, "part-0.parquet")
         ).schema
         self.assertEqual(group_schema.field("itemids").type, pa.list_(pa.int32()))
-
-    # ---- misc ----
 
     def test_io_large_loops_report_sample_progress(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -604,8 +590,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 "ProgressLogger",
                 side_effect=make_progress,
             ),
-            mock.patch.object(resolve_sid_collisions, "_MAP_WRITE_ROWS", 2),
-            mock.patch.object(resolve_sid_collisions, "_GROUP_WRITE_ITEMS", 2),
+            mock.patch.object(resolve_sid_collisions, "_ITEM_TO_SID_WRITE_ROWS", 2),
+            mock.patch.object(resolve_sid_collisions, "_SID_TO_ITEMS_WRITE_SIZE", 2),
         ):
             self._run(
                 inp,
@@ -628,8 +614,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         ].log.call_args_list
         self.assertEqual(candidate_calls, expected_progress)
         for description in (
-            "Writing resolved item map",
-            "Writing resolved SID item groups",
+            "Writing resolved item_to_sid",
+            "Writing resolved sid_to_items",
         ):
             self.assertEqual(
                 progress_by_description[description][0].log.call_args_list,
@@ -638,9 +624,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("bundle_root", {"bundle_root": None}, "bundle_root"),
-            ("partition", {"partition": None}, "partition"),
-            ("map", {"output_path": None}, "output_path"),
+            ("generation", {"generation": None}, "generation"),
+            ("output_path", {"output_path": None}, "output_path"),
         ],
         name_func=parameterized_name_func,
     )
@@ -650,12 +635,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected_field):
             self._runner("input", "map", **overrides)
 
-    def test_resolved_groups_are_written_without_original_output_or_overflow(
+    def test_sid_to_items_written_without_original_output_or_overflow(
         self,
     ) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         _parquet(inp, [0, 1], [[0, 0], [0, 1]])
 
         self._run(
@@ -684,8 +669,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         config = ResolveSidCollisionsConfig.from_namespace(args)
 
         self.assertIsNone(config.output_path)
-        self.assertIsNone(config.bundle_root)
-        self.assertIsNone(config.partition)
+        self.assertIsNone(config.item_to_sid_root)
+        self.assertIsNone(config.generation)
         self.assertEqual(config.progress_interval, 1_000_000)
 
     def test_rejects_invalid_progress_interval(self) -> None:
@@ -728,16 +713,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self._run(
                 inp,
                 out,
-                writer_type="OdpsWriter",
+                item_to_sid_writer_type="OdpsWriter",
                 max_items_per_codebook=1,
             )
 
-        # the map follows --writer_type; the serving set overrides it
+        # item_to_sid follows the flag; sid_to_items overrides it
         self.assertEqual(
             {path: kind for path, kind, _ in created_writers},
             {
-                self._map_dir(out): None,
-                self._groups_dir(out): "ParquetWriter",
+                self._item_to_sid_dir(out): None,
+                self._sid_to_items_dir(out): "ParquetWriter",
             },
         )
         self.assertTrue(all(writer.closed for _, _, writer in created_writers))
@@ -768,15 +753,17 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         self.assertTrue(writer.closed)
 
-    def test_group_writer_chunks_by_item_count_without_splitting_groups(self) -> None:
+    def test_sid_to_items_chunks_by_item_count_without_splitting_buckets(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
         _parquet(inp, list(range(4)), [[0, 0], [0, 0], [0, 0], [0, 1]])
 
-        with mock.patch("tzrec.tools.sid.resolve_sid_collisions._GROUP_WRITE_ITEMS", 2):
+        with mock.patch(
+            "tzrec.tools.sid.resolve_sid_collisions._SID_TO_ITEMS_WRITE_SIZE", 2
+        ):
             self._run(inp, out, max_items_per_codebook=3)
 
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         output_file = os.path.join(resolved_path, "part-0.parquet")
         self.assertEqual(parquet.ParquetFile(output_file).metadata.num_row_groups, 2)
         groups = parquet.read_table(output_file).to_pydict()
@@ -787,10 +774,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         out = os.path.join(self.test_dir, "out")
         _parquet(inp, list(range(5)), [[0, code] for code in range(5)])
 
-        with mock.patch("tzrec.tools.sid.resolve_sid_collisions._MAP_WRITE_ROWS", 2):
+        with mock.patch(
+            "tzrec.tools.sid.resolve_sid_collisions._ITEM_TO_SID_WRITE_ROWS", 2
+        ):
             self._run(inp, out, max_items_per_codebook=1)
 
-        output_file = os.path.join(self._map_dir(out), "part-0.parquet")
+        output_file = os.path.join(self._item_to_sid_dir(out), "part-0.parquet")
         self.assertEqual(parquet.ParquetFile(output_file).metadata.num_row_groups, 3)
 
     def test_writers_bound_codebook_list_offsets(self) -> None:
@@ -802,15 +791,17 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             mock.patch(
                 "tzrec.tools.sid.resolve_sid_collisions._ARROW_LIST_OFFSET_MAX", 4
             ),
-            mock.patch("tzrec.tools.sid.resolve_sid_collisions._MAP_WRITE_ROWS", 100),
             mock.patch(
-                "tzrec.tools.sid.resolve_sid_collisions._GROUP_WRITE_ITEMS", 100
+                "tzrec.tools.sid.resolve_sid_collisions._ITEM_TO_SID_WRITE_ROWS", 100
+            ),
+            mock.patch(
+                "tzrec.tools.sid.resolve_sid_collisions._SID_TO_ITEMS_WRITE_SIZE", 100
             ),
         ):
             self._run(inp, out, max_items_per_codebook=1)
 
-        resolved_path = self._groups_dir(out)
-        for path in (self._map_dir(out), resolved_path):
+        resolved_path = self._sid_to_items_dir(out)
+        for path in (self._item_to_sid_dir(out), resolved_path):
             output_file = os.path.join(path, "part-0.parquet")
             self.assertEqual(
                 parquet.ParquetFile(output_file).metadata.num_row_groups, 2
@@ -826,8 +817,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             inp,
             out,
             output_path=None,
-            bundle_root=None,
-            partition=None,
+            generation=None,
             max_items_per_codebook=2,
             rate_only=True,
         )
@@ -844,10 +834,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self.assertEqual(stats.total_items, 5)
         self.assertEqual(stats.relocated_count, 3)
         self.assertEqual(stats.unresolved_count, 0)
-        resolved_path = self._groups_dir(out)
-        self.assertFalse(os.path.exists(resolved_path))
         self.assertFalse(os.path.exists(out))
-        self.assertFalse(os.path.exists(self._bundle_root(out)))
 
     def test_empty_input_raises(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -890,11 +877,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         self.assertEqual(stats.total_items, 3)
         self.assertEqual(stats.relocated_count, 2)
-        result = self._map(out)
+        result = self._item_to_sid(out)
         self.assertEqual(result["item_id"], [keeper, duplicate, duplicate])
         self.assertEqual(result["item_id"].count(duplicate), 2)
-        self._assert_map_matches_resolved_groups(out)
-        resolved_path = self._groups_dir(out)
+        self._assert_item_to_sid_matches_sid_to_items(out)
+        resolved_path = self._sid_to_items_dir(out)
         groups = self._read_parquet(resolved_path)
         self.assertCountEqual(
             [item_id for group in groups["itemids"] for item_id in group],
@@ -937,9 +924,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
 
         self.assertEqual(stats.total_items, 3)
-        result = self._map(out)
+        result = self._item_to_sid(out)
         self.assertEqual(result["item_id"], ["b", "a", "a"])
-        self._assert_map_matches_resolved_groups(out)
+        self._assert_item_to_sid_matches_sid_to_items(out)
 
     def test_empty_codebook_token_raises(self) -> None:
         args = resolve_sid_collisions.build_parser().parse_args(
@@ -956,31 +943,28 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "codebook"):
             ResolveSidCollisionsConfig.from_namespace(args)
 
-    # ---- offset SID column ----
-
-    def test_offset_codebook_shifts_layers_in_map_and_groups(self) -> None:
+    def test_offset_codebook_shifts_layers_in_both_artifacts(self) -> None:
         _, out = self._resolve(
             [0, 1], [[1, 2], [3, 4]], [[[0, 0]]] * 2, layer_sizes=(8, 8)
         )
 
         # layer 1 is shifted by layer_sizes[0]
-        item_map = self._map(out)
+        item_map = self._item_to_sid(out)
         by_item = dict(zip(item_map["item_id"], item_map["offset_codebook"]))
         self.assertEqual(by_item[0], [1, 2 + 8])
         self.assertEqual(by_item[1], [3, 4 + 8])
 
-        resolved_path = self._groups_dir(out)
+        resolved_path = self._sid_to_items_dir(out)
         groups = self._read_parquet(resolved_path)
         for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     def test_offset_codebook_tracks_the_resolved_not_the_origin_sid(self) -> None:
-        # three items collide at capacity 2, so one relocates
         _, out = self._resolve(
             [0, 1, 2], [[0, 0]] * 3, [[[0, 5]]] * 3, layer_sizes=(8, 8)
         )
 
-        item_map = self._map(out)
+        item_map = self._item_to_sid(out)
         relocated = [
             i
             for i, (origin, final) in enumerate(
@@ -994,8 +978,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(item_map["offset_codebook"][i], [final[0], final[1] + 8])
 
     def test_append_recomputes_offset_for_state_written_without_it(self) -> None:
-        # a map published before offset_codebook existed must still merge: the
-        # column is derived from the published codebook, not passed through
+        # offset_codebook is derived from the published codebook, so a
+        # generation written before that column existed still merges
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,
@@ -1004,31 +988,33 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         )
         self._append(self._prepare_single(10), out)
 
-        item_map = self._map(out, "v2")
+        item_map = self._item_to_sid(out, "v2")
         self.assertEqual(len(item_map["item_id"]), 3)
         for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
-    # ---- append mode ----
-
     def _seed_generation(self, name="v1", item_ids=None, codes=None):
-        """Run a full resolve at partition v1, the state a later append consumes."""
+        """Run a full resolve at generation v1, the state a later append consumes."""
         inp = os.path.join(self.test_dir, f"{name}_in.parquet")
         out = os.path.join(self.test_dir, name)
         item_ids = list(range(5)) if item_ids is None else item_ids
         codes = [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]] if codes is None else codes
         _parquet(inp, item_ids, codes, [[[0, 2], [0, 3]]] * len(item_ids))
-        self._run(inp, out, partition="v1")
+        self._run(inp, out, generation="v1")
         return out
 
-    def _assert_manifest_rows_match_artifacts(self, out, partition):
+    def _assert_manifest_rows_match_artifacts(self, out, generation):
         """Every manifest row count must equal what its artifact actually holds."""
-        manifest = self._manifest(out, partition)
+        manifest = self._manifest(out, generation)
         dirs = {
-            bundle.MAP_ARTIFACT: self._map_dir(out, partition),
-            bundle.DELTA_MAP_ARTIFACT: self._delta_map_dir(out, partition),
-            bundle.GROUPS_ARTIFACT: self._groups_dir(out, partition),
-            bundle.DELTA_GROUPS_ARTIFACT: self._delta_groups_dir(out, partition),
+            bundle.ITEM_TO_SID_ARTIFACT: self._item_to_sid_dir(out, generation),
+            bundle.DELTA_ITEM_TO_SID_ARTIFACT: self._delta_item_to_sid_dir(
+                out, generation
+            ),
+            bundle.SID_TO_ITEMS_ARTIFACT: self._sid_to_items_dir(out, generation),
+            bundle.DELTA_SID_TO_ITEMS_ARTIFACT: self._delta_sid_to_items_dir(
+                out, generation
+            ),
         }
         for name, entry in manifest.artifacts.items():
             actual = len(self._read_parquet(dirs[name])["codebook"])
@@ -1039,13 +1025,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _, out = self._resolve(list(range(5)), [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]])
 
         manifest = self._assert_manifest_rows_match_artifacts(out, "v1")
-        # a full resolve publishes no delta: neither named nor written
         self.assertEqual(
             set(manifest.artifacts),
-            {bundle.MAP_ARTIFACT, bundle.GROUPS_ARTIFACT},
+            {bundle.ITEM_TO_SID_ARTIFACT, bundle.SID_TO_ITEMS_ARTIFACT},
         )
-        self.assertFalse(os.path.exists(self._delta_map_dir(out)))
-        self.assertFalse(os.path.exists(self._delta_groups_dir(out)))
+        self.assertFalse(os.path.exists(self._delta_item_to_sid_dir(out)))
+        self.assertFalse(os.path.exists(self._delta_sid_to_items_dir(out)))
         self.assertIsNone(manifest.since_bundle_uuid)
 
     def test_manifest_rows_match_the_artifacts_on_an_append(self) -> None:
@@ -1057,29 +1042,28 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         manifest = self._assert_manifest_rows_match_artifacts(out, "v2")
         self.assertEqual(
             set(manifest.artifacts),
-            set(bundle.MAP_ARTIFACTS) | set(bundle.GROUPS_ARTIFACTS),
+            set(bundle.ITEM_TO_SID_ARTIFACTS) | set(bundle.SID_TO_ITEMS_ARTIFACTS),
         )
-        self.assertEqual(manifest.artifacts[bundle.DELTA_MAP_ARTIFACT].rows, 3)
+        self.assertEqual(manifest.artifacts[bundle.DELTA_ITEM_TO_SID_ARTIFACT].rows, 3)
         self.assertEqual(
             manifest.since_bundle_uuid, self._manifest(out, "v1").bundle_uuid
         )
 
     def test_append_never_moves_a_published_item(self) -> None:
         out = self._seed_generation()
-        published = self._map_rows(self._map_dir(out, "v1"))
+        published = self._item_to_sid_rows(self._item_to_sid_dir(out, "v1"))
 
         inp = os.path.join(self.test_dir, "v2_in.parquet")
-        # Rows 10 and 11 land in the already-full bucket (0, 0).
         _parquet(inp, [10, 11, 12], [[0, 0], [0, 0], [1, 1]], [[[0, 2], [0, 3]]] * 3)
         stats = self._append(inp, out)
 
         self.assertEqual(stats.total_items, 3)
-        merged = self._map_rows(self._map_dir(out, "v2"))
+        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
         self.assertEqual(len(merged), 8)
         for item_id, row in published.items():
             self.assertEqual(merged[item_id], row, f"item {item_id} moved")
-        self._assert_dense_indices(self._map_dir(out, "v2"))
-        self._assert_map_matches_resolved_groups(out, "v2")
+        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_item_to_sid_matches_sid_to_items(out, "v2")
 
     def test_append_continues_slot_numbering(self) -> None:
         out = self._seed_generation(item_ids=[0], codes=[[0, 0]])
@@ -1087,9 +1071,8 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10], [[0, 0]], [[[0, 0]]])
         self._append(inp, out)
 
-        merged = self._map_rows(self._map_dir(out, "v2"))
+        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
         self.assertEqual(merged[0][2], 1)
-        # Capacity is 2, so the new row is retained and continues at slot 2.
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
 
     def test_append_emits_delta_outputs(self) -> None:
@@ -1098,10 +1081,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10, 11], [[0, 0], [3, 3]], [[[0, 2], [0, 3]]] * 2)
         self._append(inp, out)
 
-        delta_map = self._delta_map_dir(out, "v2")
-        delta_groups = self._delta_groups_dir(out, "v2")
+        delta_map = self._delta_item_to_sid_dir(out, "v2")
+        delta_groups = self._delta_sid_to_items_dir(out, "v2")
         self.assertCountEqual(self._read_parquet(delta_map)["item_id"], [10, 11])
-        merged_groups = self._groups(out, "v2")
+        merged_groups = self._sid_to_items(out, "v2")
         full = {
             tuple(codebook): item_group
             for codebook, item_group in zip(
@@ -1123,16 +1106,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
     def test_append_creates_buckets_before_between_and_after(self) -> None:
         # New SIDs sort before, between and after every published bucket, which
-        # exercises all three branches of the groups merge.
+        # exercises all three branches of the merge.
         out = self._seed_generation(item_ids=[0], codes=[[4, 4]])
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10, 11, 12], [[0, 0], [4, 5], [7, 7]], [[[0, 0]]] * 3)
         self._append(inp, out, batch_size=1)
 
-        groups = self._groups(out, "v2")
+        groups = self._sid_to_items(out, "v2")
         self.assertEqual(groups["codebook"], [[0, 0], [4, 4], [4, 5], [7, 7]])
         self.assertEqual(groups["itemids"], [[10], [0], [11], [12]])
-        self._assert_map_matches_resolved_groups(out, "v2")
+        self._assert_item_to_sid_matches_sid_to_items(out, "v2")
 
     def test_append_merges_across_reader_batches(self) -> None:
         out = self._seed_generation(
@@ -1143,9 +1126,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10, 11, 12], [[0, 0], [3, 3], [6, 6]], [[[0, 0]]] * 3)
         self._append(inp, out, batch_size=1)
 
-        self._assert_dense_indices(self._map_dir(out, "v2"))
-        self._assert_map_matches_resolved_groups(out, "v2")
-        self.assertEqual(len(self._map_rows(self._map_dir(out, "v2"))), 9)
+        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_item_to_sid_matches_sid_to_items(out, "v2")
+        self.assertEqual(
+            len(self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))), 9
+        )
 
     def test_append_chain_stays_consistent(self) -> None:
         out = self._seed_generation()
@@ -1159,17 +1144,15 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 [[0, 0], [generation, generation]],
                 [[[0, 2], [0, 3]]] * 2,
             )
-            published = self._map_rows(self._map_dir(out, previous))
-            self._append(inp, out, previous=previous, partition=current)
-            merged = self._map_rows(self._map_dir(out, current))
+            published = self._item_to_sid_rows(self._item_to_sid_dir(out, previous))
+            self._append(inp, out, previous=previous, generation=current)
+            merged = self._item_to_sid_rows(self._item_to_sid_dir(out, current))
             for item_id, row in published.items():
                 self.assertEqual(merged[item_id], row)
-            self._assert_dense_indices(self._map_dir(out, current))
-            self._assert_map_matches_resolved_groups(out, current)
+            self._assert_dense_indices(self._item_to_sid_dir(out, current))
+            self._assert_item_to_sid_matches_sid_to_items(out, current)
 
     def test_append_reads_csv_state_and_converts_format(self) -> None:
-        # A CSV published map with a parquet new-items input drives
-        # _align_codes_column's re-encode on the copy-through path.
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,
@@ -1180,14 +1163,14 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
-        self._append(inp, out, reader_type="CsvReader")
+        self._append(inp, out)
 
-        merged = self._map_rows(self._map_dir(out, "v2"))
+        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
         self.assertEqual(len(merged), 4)
         self.assertEqual(merged[0], ((0, 0), (0, 0), 1))
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
-        self._assert_dense_indices(self._map_dir(out, "v2"))
-        self._assert_map_matches_resolved_groups(out, "v2")
+        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_item_to_sid_matches_sid_to_items(out, "v2")
 
     def test_append_rejects_already_published_item_id(self) -> None:
         out = self._seed_generation()
@@ -1201,14 +1184,16 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10], [[0, 0]], [[[0, 2]]])
         self._append(inp, out)
-        # Leave v1's map beside v2's groups: the row totals no longer agree.
-        shutil.rmtree(self._groups_dir(out, "v1"))
-        shutil.copytree(self._groups_dir(out, "v2"), self._groups_dir(out, "v1"))
+        # Leave v1's item_to_sid beside v2's sid_to_items: the totals disagree.
+        shutil.rmtree(self._sid_to_items_dir(out, "v1"))
+        shutil.copytree(
+            self._sid_to_items_dir(out, "v2"), self._sid_to_items_dir(out, "v1")
+        )
         with self.assertRaisesRegex(ValueError, "different generations"):
-            self._append(self._prepare_single(20), out, previous="v1", partition="v3")
+            self._append(self._prepare_single(20), out, previous="v1", generation="v3")
 
     def test_append_rejects_state_truncated_outside_touched_bands(self) -> None:
-        # Band 5 is untouched, so only the row totals can catch its missing group.
+        # Band 5 is untouched, so only the row totals catch its missing bucket.
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,
@@ -1218,7 +1203,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "one of the two artifacts is"):
             self._append(self._prepare_single(10), out)
 
-    def test_append_rejects_unsorted_existing_groups(self) -> None:
+    def test_append_rejects_unsorted_existing_sid_to_items(self) -> None:
         out = os.path.join(self.test_dir, "out")
         self._seed_state(
             out,
@@ -1228,26 +1213,25 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "ascending"):
             self._append(self._prepare_single(10), out)
 
-    def test_append_rate_only_needs_no_map(self) -> None:
+    def test_append_rate_only_publishes_no_generation(self) -> None:
         out = self._seed_generation()
         stats = self._run(
             self._prepare_single(10),
             out,
             rate_only=True,
-            output_path=None,
-            bundle_root=self._bundle_root(out),
-            partition=None,
-            from_partition="v1",
+            generation=None,
+            from_generation="v1",
         )
         self.assertEqual(stats.total_items, 1)
+        self.assertEqual(os.listdir(out), ["v1"])
 
-    def test_append_rejects_writing_over_the_partition_it_reads(self) -> None:
+    def test_append_rejects_writing_over_the_generation_it_reads(self) -> None:
         with self.assertRaisesRegex(ValueError, "writing over the artifacts"):
             self._runner(
                 os.path.join(self.test_dir, "in.parquet"),
                 os.path.join(self.test_dir, "out"),
-                partition="v1",
-                from_partition="v1",
+                generation="v1",
+                from_generation="v1",
             )
 
 

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1022,6 +1022,50 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         self._run(inp, out, partition="v1")
         return out
 
+    def _assert_manifest_rows_match_artifacts(self, out, partition):
+        """Every manifest row count must equal what its artifact actually holds."""
+        manifest = self._manifest(out, partition)
+        dirs = {
+            bundle.MAP_ARTIFACT: self._map_dir(out, partition),
+            bundle.DELTA_MAP_ARTIFACT: self._delta_map_dir(out, partition),
+            bundle.GROUPS_ARTIFACT: self._groups_dir(out, partition),
+            bundle.DELTA_GROUPS_ARTIFACT: self._delta_groups_dir(out, partition),
+        }
+        for name, entry in manifest.artifacts.items():
+            actual = len(self._read_parquet(dirs[name])["codebook"])
+            self.assertEqual(entry.rows, actual, f"{name} rows")
+        return manifest
+
+    def test_manifest_rows_match_the_artifacts_on_a_full_resolve(self) -> None:
+        inp = os.path.join(self.test_dir, "in.parquet")
+        out = os.path.join(self.test_dir, "out")
+        _parquet(inp, list(range(5)), [[0, 0], [0, 0], [0, 1], [1, 0], [1, 1]])
+        self._run(inp, out)
+
+        manifest = self._assert_manifest_rows_match_artifacts(out, "v1")
+        # a full resolve publishes no delta, so the manifest names neither
+        self.assertEqual(
+            set(manifest.artifacts),
+            {bundle.MAP_ARTIFACT, bundle.GROUPS_ARTIFACT},
+        )
+        self.assertIsNone(manifest.since_bundle_uuid)
+
+    def test_manifest_rows_match_the_artifacts_on_an_append(self) -> None:
+        out = self._seed_generation()
+        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        _parquet(inp, [10, 11, 12], [[0, 0], [4, 4], [7, 7]], [[[0, 2], [0, 3]]] * 3)
+        self._append(inp, out)
+
+        manifest = self._assert_manifest_rows_match_artifacts(out, "v2")
+        self.assertEqual(
+            set(manifest.artifacts),
+            set(bundle.MAP_ARTIFACTS) | set(bundle.GROUPS_ARTIFACTS),
+        )
+        self.assertEqual(manifest.artifacts[bundle.DELTA_MAP_ARTIFACT].rows, 3)
+        self.assertEqual(
+            manifest.since_bundle_uuid, self._manifest(out, "v1").bundle_uuid
+        )
+
     def test_append_never_moves_a_published_item(self) -> None:
         out = self._seed_generation()
         published = self._map_rows(self._map_dir(out, "v1"))

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import shutil
 import unittest
@@ -124,7 +123,7 @@ def _groups_csv(path, rows):
         pa.table(
             {
                 "codebook": [",".join(map(str, r[0])) for r in rows],
-                "itemids": ["[" + ",".join(map(str, r[1])) + "]" for r in rows],
+                "itemids": [",".join(map(str, r[1])) for r in rows],
             }
         ),
         os.path.join(path, "part-0.csv"),
@@ -526,12 +525,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             for groups in (original, resolved):
                 self.assertEqual(groups.column_names, ["codebook", "itemids"])
                 self.assertEqual(groups.schema.field("itemids").type, pa.string())
-                self.assertTrue(
-                    all(
-                        isinstance(json.loads(itemids), list)
-                        for itemids in groups["itemids"].to_pylist()
-                    )
-                )
+                grouped = [
+                    item
+                    for itemids in groups["itemids"].to_pylist()
+                    for item in itemids.split(",")
+                ]
+                self.assertCountEqual(grouped, [str(i) for i in item_ids])
         else:
             result = parquet.read_table(os.path.join(out, "part-0.parquet"))
             self.assertEqual(result.schema.field("codebook").type, pa.list_(pa.int64()))
@@ -550,10 +549,10 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                     groups.schema.field("itemids").type, pa.list_(pa.string())
                 )
 
-    def test_csv_group_itemids_use_json_escaping(self) -> None:
+    def test_csv_group_itemids_are_comma_joined(self) -> None:
         inp = os.path.join(self.test_dir, "in.csv")
         out = os.path.join(self.test_dir, "out")
-        item_ids = ["a;b", "x|y", "with,comma", 'with"quote', "back\\slash"]
+        item_ids = ["a;b", "x|y", 'with"quote', "back\\slash"]
         _csv(inp, item_ids, [[0, 0]] * len(item_ids))
 
         self._run(
@@ -567,8 +566,21 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
         original_path, _ = self._group_paths(out)
         groups = csv.read_csv(os.path.join(original_path, "part-0.csv"))
-        decoded_ids = json.loads(groups["itemids"][0].as_py())
-        self.assertCountEqual(decoded_ids, item_ids)
+        self.assertCountEqual(groups["itemids"][0].as_py().split(","), item_ids)
+
+    def test_csv_group_itemids_reject_embedded_comma(self) -> None:
+        inp = os.path.join(self.test_dir, "in.csv")
+        out = os.path.join(self.test_dir, "out")
+        _csv(inp, ["ok", "with,comma"], [[0, 0]] * 2)
+
+        with self.assertRaisesRegex(ValueError, "cannot itself contain one"):
+            self._run(
+                inp,
+                out,
+                reader_type="CsvReader",
+                writer_type="CsvWriter",
+                max_items_per_codebook=4,
+            )
 
     def test_preserves_integer_item_id_type(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1069,39 +1069,23 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(item_map["offset_codebook"][i], [final[0], final[1] + 8])
 
     def test_append_recomputes_offset_for_state_written_without_it(self) -> None:
-        # the published fixtures carry no offset_codebook column, so the merged
-        # map must derive it rather than pass it through
-        base = self._seed_generation()
-        inp = os.path.join(self.test_dir, "v2_in.parquet")
+        # a map published before offset_codebook existed must still merge: the
+        # column is derived from the published codebook, not passed through
+        state_map = os.path.join(self.test_dir, "old_map")
+        state_groups = os.path.join(self.test_dir, "old_groups")
+        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [1, 1], [1, 1], 1)])
+        _groups_parquet(state_groups, [([0, 0], [0]), ([1, 1], [1])])
         out = os.path.join(self.test_dir, "v2")
-        _parquet(inp, [10], [[2, 2]], [[[0, 2]]])
-        self._append(inp, out, base)
-
-        item_map = self._read_parquet(out)
-        self.assertEqual(len(item_map["item_id"]), 6)
-        for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
-            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
-
-    def test_delta_outputs_carry_offset_codebook(self) -> None:
-        base = self._seed_generation()
-        inp = os.path.join(self.test_dir, "v2_in.parquet")
-        out = os.path.join(self.test_dir, "v2")
-        delta_map = os.path.join(self.test_dir, "delta_map")
-        delta_groups = os.path.join(self.test_dir, "delta_groups")
-        _parquet(inp, [10, 11], [[0, 0], [3, 3]], [[[0, 2], [0, 3]]] * 2)
-        self._append(
-            inp,
+        self._run(
+            self._prepare_single(10),
             out,
-            base,
-            delta_map_output_path=delta_map,
-            delta_sid_groups_output_path=delta_groups,
+            existing_sid_map_path=os.path.join(state_map, "*.parquet"),
+            existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
         )
 
-        delta = self._read_parquet(delta_map)
-        for codebook, offset in zip(delta["codebook"], delta["offset_codebook"]):
-            self.assertEqual(offset, [codebook[0], codebook[1] + 8])
-        groups = self._read_parquet(delta_groups)
-        for codebook, offset in zip(groups["codebook"], groups["offset_codebook"]):
+        item_map = self._read_parquet(out)
+        self.assertEqual(len(item_map["item_id"]), 3)
+        for codebook, offset in zip(item_map["codebook"], item_map["offset_codebook"]):
             self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     # ---- append mode ----
@@ -1176,6 +1160,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
             self.assertEqual(item_group, full[tuple(codebook)])
         touched = {item for group in delta["itemids"] for item in group}
         self.assertTrue({10, 11}.issubset(touched))
+        for artifact in (self._read_parquet(delta_map), delta):
+            for codebook, offset in zip(
+                artifact["codebook"], artifact["offset_codebook"]
+            ):
+                self.assertEqual(offset, [codebook[0], codebook[1] + 8])
 
     def test_append_creates_buckets_before_between_and_after(self) -> None:
         # New SIDs sort before, between and after every published bucket, which
@@ -1194,7 +1183,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
     def test_append_merges_across_reader_batches(self) -> None:
         base = self._seed_generation(
             item_ids=list(range(6)),
-            codes=[[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+            codes=[[0, 0], [0, 0], [2, 2], [3, 3], [4, 4], [5, 5]],
         )
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         out = os.path.join(self.test_dir, "v2")

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -72,7 +72,7 @@ def _write_part(path, table):
 
 
 def _item_to_sid_parquet(path, rows):
-    """Write a map artifact from (item_id, origin_codebook, codebook, index)."""
+    """Write item_to_sid from (item_id, origin_codebook, codebook, index)."""
     _write_part(
         path,
         pa.table(
@@ -89,7 +89,7 @@ def _item_to_sid_parquet(path, rows):
 
 
 def _sid_to_items_parquet(path, rows):
-    """Write a groups artifact from (codebook, item_ids) in SID-key order."""
+    """Write sid_to_items from (codebook, item_ids) in SID-key order."""
     _write_part(
         path,
         pa.table(
@@ -102,7 +102,7 @@ def _sid_to_items_parquet(path, rows):
 
 
 def _item_to_sid_csv(path, rows):
-    """Write a map artifact in the CSV encoding this tool emits."""
+    """Write item_to_sid in the CSV encoding this tool emits."""
     os.makedirs(path, exist_ok=True)
     csv.write_csv(
         pa.table(
@@ -168,7 +168,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         return bundle.read_manifest(bundle.manifest_path(out, generation))
 
     def _resolve(self, item_ids, codes, candidates=None, **kw):
-        """Write one input, resolve it, and return the stats and the map root."""
+        """Write one input, resolve it, and return the stats and the bundle root."""
         inp = os.path.join(self.test_dir, "in.parquet")
         out = os.path.join(self.test_dir, "out")
         _parquet(inp, item_ids, codes, candidates)
@@ -186,7 +186,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         return parquet.read_table(os.path.join(out_dir, _PART_FILE)).to_pydict()
 
     def _assert_item_to_sid_matches_sid_to_items(self, out, generation="v1"):
-        item_map = self._read_parquet(self._item_to_sid_dir(out, generation))
+        item_map = self._item_to_sid(out, generation)
         resolved_path = self._sid_to_items_dir(out, generation)
         resolved = self._read_parquet(resolved_path)
         resolved_items = {
@@ -202,9 +202,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         ):
             self.assertEqual(resolved_items[tuple(codebook)][index - 1], item_id)
 
-    def _item_to_sid_rows(self, item_to_sid_dir):
-        """Return {item_id: (origin_codebook, codebook, index)} for a map."""
-        item_map = self._read_parquet(item_to_sid_dir)
+    def _item_to_sid_rows(self, out, generation="v1"):
+        """Return {item_id: (origin_codebook, codebook, index)} keyed by item."""
+        item_map = self._item_to_sid(out, generation)
         return {
             item_id: (tuple(origin), tuple(codebook), index)
             for item_id, origin, codebook, index in zip(
@@ -254,11 +254,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(path, [item_id], [[0, 0]], [[[0, 2]]])
         return path
 
-    def _assert_dense_indices(self, item_to_sid_dir):
+    def _assert_dense_indices(self, out, generation="v1"):
         """Every bucket's index multiset must be exactly 1..count."""
         by_bucket = {}
         for _item, (_origin, codebook, index) in self._item_to_sid_rows(
-            item_to_sid_dir
+            out, generation
         ).items():
             by_bucket.setdefault(codebook, []).append(index)
         for codebook, indices in by_bucket.items():
@@ -533,14 +533,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 [[0, 0, 0], [0, 0, 0], [0, 0, 1]],
             )
             self.assertEqual(result["origin_codebook"].to_pylist(), [[0, 0, 0]] * 3)
-            for path in (resolved_path,):
-                groups = parquet.read_table(os.path.join(path, "part-0.parquet"))
-                self.assertEqual(
-                    groups.column_names, ["codebook", "offset_codebook", "itemids"]
-                )
-                self.assertEqual(
-                    groups.schema.field("itemids").type, pa.list_(pa.string())
-                )
+            groups = parquet.read_table(os.path.join(resolved_path, _PART_FILE))
+            self.assertEqual(
+                groups.column_names, ["codebook", "offset_codebook", "itemids"]
+            )
+            self.assertEqual(groups.schema.field("itemids").type, pa.list_(pa.string()))
 
     def test_preserves_integer_item_id_type(self) -> None:
         inp = os.path.join(self.test_dir, "in.parquet")
@@ -1050,18 +1047,18 @@ class ResolveSidCollisionsTest(unittest.TestCase):
 
     def test_append_never_moves_a_published_item(self) -> None:
         out = self._seed_generation()
-        published = self._item_to_sid_rows(self._item_to_sid_dir(out, "v1"))
+        published = self._item_to_sid_rows(out, "v1")
 
         inp = os.path.join(self.test_dir, "v2_in.parquet")
         _parquet(inp, [10, 11, 12], [[0, 0], [0, 0], [1, 1]], [[[0, 2], [0, 3]]] * 3)
         stats = self._append(inp, out)
 
         self.assertEqual(stats.total_items, 3)
-        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
+        merged = self._item_to_sid_rows(out, "v2")
         self.assertEqual(len(merged), 8)
         for item_id, row in published.items():
             self.assertEqual(merged[item_id], row, f"item {item_id} moved")
-        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_dense_indices(out, "v2")
         self._assert_item_to_sid_matches_sid_to_items(out, "v2")
 
     def test_append_continues_slot_numbering(self) -> None:
@@ -1070,7 +1067,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10], [[0, 0]], [[[0, 0]]])
         self._append(inp, out)
 
-        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
+        merged = self._item_to_sid_rows(out, "v2")
         self.assertEqual(merged[0][2], 1)
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
 
@@ -1123,11 +1120,9 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10, 11, 12], [[0, 0], [3, 3], [6, 6]], [[[0, 0]]] * 3)
         self._append(inp, out, batch_size=1)
 
-        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_dense_indices(out, "v2")
         self._assert_item_to_sid_matches_sid_to_items(out, "v2")
-        self.assertEqual(
-            len(self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))), 9
-        )
+        self.assertEqual(len(self._item_to_sid_rows(out, "v2")), 9)
 
     def test_append_chain_stays_consistent(self) -> None:
         out = self._seed_generation()
@@ -1141,12 +1136,12 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 [[0, 0], [generation, generation]],
                 [[[0, 2], [0, 3]]] * 2,
             )
-            published = self._item_to_sid_rows(self._item_to_sid_dir(out, previous))
+            published = self._item_to_sid_rows(out, previous)
             self._append(inp, out, previous=previous, generation=current)
-            merged = self._item_to_sid_rows(self._item_to_sid_dir(out, current))
+            merged = self._item_to_sid_rows(out, current)
             for item_id, row in published.items():
                 self.assertEqual(merged[item_id], row)
-            self._assert_dense_indices(self._item_to_sid_dir(out, current))
+            self._assert_dense_indices(out, current)
             self._assert_item_to_sid_matches_sid_to_items(out, current)
 
     def test_append_reads_csv_state_and_converts_format(self) -> None:
@@ -1162,11 +1157,11 @@ class ResolveSidCollisionsTest(unittest.TestCase):
         _parquet(inp, [10, 11], [[0, 0], [2, 2]], [[[0, 2]]] * 2)
         self._append(inp, out)
 
-        merged = self._item_to_sid_rows(self._item_to_sid_dir(out, "v2"))
+        merged = self._item_to_sid_rows(out, "v2")
         self.assertEqual(len(merged), 4)
         self.assertEqual(merged[0], ((0, 0), (0, 0), 1))
         self.assertEqual(merged[10], ((0, 0), (0, 0), 2))
-        self._assert_dense_indices(self._item_to_sid_dir(out, "v2"))
+        self._assert_dense_indices(out, "v2")
         self._assert_item_to_sid_matches_sid_to_items(out, "v2")
 
     def test_append_rejects_already_published_item_id(self) -> None:

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -229,7 +229,7 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                     bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
                         save_type="parquet",
                         rows=len(group_rows),
-                        path=self._groups_dir(out, partition),
+                        location=self._groups_dir(out, partition),
                     )
                 },
             ),

--- a/tzrec/tools/sid/resolve_sid_collisions_test.py
+++ b/tzrec/tools/sid/resolve_sid_collisions_test.py
@@ -1265,6 +1265,20 @@ class ResolveSidCollisionsTest(unittest.TestCase):
                 ),
             )
 
+    def test_append_rejects_state_truncated_outside_touched_bands(self) -> None:
+        # Band 5 is untouched, so only the row totals can catch its missing group.
+        state_map = os.path.join(self.test_dir, "trunc_map")
+        state_groups = os.path.join(self.test_dir, "trunc_groups")
+        _map_parquet(state_map, [(0, [0, 0], [0, 0], 1), (1, [5, 5], [5, 5], 1)])
+        _groups_parquet(state_groups, [([0, 0], [0])])
+        with self.assertRaisesRegex(ValueError, "one of the two artifacts is"):
+            self._run(
+                self._prepare_single(10),
+                os.path.join(self.test_dir, "out"),
+                existing_sid_map_path=os.path.join(state_map, "*.parquet"),
+                existing_sid_groups_path=os.path.join(state_groups, "*.parquet"),
+            )
+
     def test_append_rejects_map_with_index_holes(self) -> None:
         # Two items share bucket (0, 0) but hold indices 1 and 3: a deleted item
         # left a hole, so appending would reuse slot 2.

--- a/tzrec/utils/path_util.py
+++ b/tzrec/utils/path_util.py
@@ -21,6 +21,11 @@ from tzrec.datasets.odps_dataset import _parse_table_path
 _OdpsPathIdentity = Tuple[str, Optional[str], str, Optional[str]]
 
 
+def is_odps_path(path: str) -> bool:
+    """Whether a path addresses ODPS rather than a filesystem."""
+    return path.startswith("odps://")
+
+
 def _local_path_identities(path: str) -> Set[str]:
     """Return resolved local write locations represented by one path group."""
     identities: Set[str] = set()
@@ -150,7 +155,7 @@ def check_path_conflict(paths: Sequence[str]) -> Tuple[bool, Optional[str]]:
     local_paths: List[str] = []
     odps_paths: List[str] = []
     for path in paths:
-        if path.startswith("odps://"):
+        if is_odps_path(path):
             odps_paths.append(path)
         else:
             local_paths.append(path)

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -69,9 +69,14 @@ def manifest_path(bundle_root: str, partition: str) -> str:
 
 @dataclass
 class ArtifactEntry:
-    """Where one artifact landed and what it holds."""
+    """Where one artifact landed and what it holds.
 
-    type: str
+    ``save_type`` selects how to open it and which location fields are set:
+    ``odps`` fills ``table`` and ``partition``, ``parquet`` and ``csv`` fill
+    ``path``.
+    """
+
+    save_type: str
     rows: int
     schema: Dict[str, str]
     path: Optional[str] = None
@@ -124,9 +129,9 @@ class BundleManifest:
         }
         for name in GROUPS_ARTIFACTS:
             entry = entries.get(name)
-            if entry is not None and entry.type != "parquet":
+            if entry is not None and entry.save_type != "parquet":
                 raise ValueError(
-                    f"manifest declares {name} as {entry.type!r}; the serving set "
+                    f"manifest declares {name} as {entry.save_type!r}; the serving set "
                     "is always parquet, so this bundle cannot be opened."
                 )
         return cls(artifacts=entries, **payload)
@@ -136,7 +141,7 @@ def artifact_entry(
     root: str,
     artifact: str,
     partition: str,
-    kind: str,
+    save_type: str,
     rows: int,
     schema: Dict[str, str],
 ) -> ArtifactEntry:
@@ -145,13 +150,13 @@ def artifact_entry(
     if is_odps_path(root):
         table = root.rstrip("/").rpartition("/tables/")[2]
         return ArtifactEntry(
-            type="odps",
+            save_type="odps",
             rows=rows,
             schema=schema,
             table=table,
             partition=f"artifact={artifact}/generation={partition}",
         )
-    return ArtifactEntry(type=kind, rows=rows, schema=schema, path=location)
+    return ArtifactEntry(save_type=save_type, rows=rows, schema=schema, path=location)
 
 
 def write_manifest(path: str, manifest: BundleManifest) -> None:

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -78,7 +78,6 @@ class ArtifactEntry:
 
     save_type: str
     rows: int
-    schema: Dict[str, str]
     path: Optional[str] = None
     table: Optional[str] = None
     partition: Optional[str] = None
@@ -138,12 +137,7 @@ class BundleManifest:
 
 
 def artifact_entry(
-    root: str,
-    artifact: str,
-    partition: str,
-    save_type: str,
-    rows: int,
-    schema: Dict[str, str],
+    root: str, artifact: str, partition: str, save_type: str, rows: int
 ) -> ArtifactEntry:
     """Describe where one artifact landed, in the shape the manifest records."""
     location = artifact_location(root, artifact, partition)
@@ -152,11 +146,10 @@ def artifact_entry(
         return ArtifactEntry(
             save_type="odps",
             rows=rows,
-            schema=schema,
             table=table,
             partition=f"artifact={artifact}/generation={partition}",
         )
-    return ArtifactEntry(save_type=save_type, rows=rows, schema=schema, path=location)
+    return ArtifactEntry(save_type=save_type, rows=rows, path=location)
 
 
 def write_manifest(path: str, manifest: BundleManifest) -> None:
@@ -180,3 +173,84 @@ def read_manifest(path: str) -> BundleManifest:
         )
     with open(path) as handle:
         return BundleManifest.from_json(handle.read())
+
+
+@dataclass(frozen=True)
+class BundleLayout:
+    """Every location one run reads and writes, resolved once.
+
+    Binding the two roots and the partitions here is what keeps the family rule
+    -- the serving set under ``bundle_root``, the map family under ``map_root``
+    -- in this module instead of at each call site.
+    """
+
+    map_root: Optional[str]
+    bundle_root: Optional[str]
+    partition: Optional[str]
+    from_partition: Optional[str]
+    map_read_suffix: str
+
+    def root_for(self, artifact: str) -> str:
+        """Return the root that owns one artifact's family."""
+        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.map_root
+        if root is None:
+            raise RuntimeError(f"no root is configured for {artifact}.")
+        return root
+
+    def write_path(self, artifact: str) -> str:
+        """Return where this generation writes one artifact."""
+        if self.partition is None:
+            raise RuntimeError("no partition is configured to write.")
+        return artifact_location(self.root_for(artifact), artifact, self.partition)
+
+    def read_path(self, artifact: str) -> str:
+        """Return where the appended-onto generation holds one artifact."""
+        if self.from_partition is None:
+            raise RuntimeError("no from_partition is configured to read.")
+        suffix = "parquet" if artifact in GROUPS_ARTIFACTS else self.map_read_suffix
+        return artifact_read_pattern(
+            self.root_for(artifact), artifact, self.from_partition, suffix
+        )
+
+    def entry(self, artifact: str, save_type: str, rows: int) -> ArtifactEntry:
+        """Describe where one artifact landed, for the manifest."""
+        if self.partition is None:
+            raise RuntimeError("no partition is configured to write.")
+        return artifact_entry(
+            self.root_for(artifact), artifact, self.partition, save_type, rows
+        )
+
+    def write_manifest(self, manifest: "BundleManifest") -> str:
+        """Write this generation's manifest and return where it landed."""
+        if self.bundle_root is None or self.partition is None:
+            raise RuntimeError("no manifest location is configured.")
+        path = manifest_path(self.bundle_root, self.partition)
+        write_manifest(path, manifest)
+        return path
+
+    def prior_manifest_path(self) -> str:
+        """Return the manifest of the generation being appended onto."""
+        if self.bundle_root is None or self.from_partition is None:
+            raise RuntimeError("no prior manifest location is configured.")
+        return manifest_path(self.bundle_root, self.from_partition)
+
+    def read_prior_manifest(self) -> "BundleManifest":
+        """Read the manifest of the generation being appended onto."""
+        return read_manifest(self.prior_manifest_path())
+
+
+def resolve_layout(
+    map_root: Optional[str],
+    bundle_root: Optional[str],
+    partition: Optional[str],
+    from_partition: Optional[str],
+    reader_type: Optional[str],
+) -> BundleLayout:
+    """Resolve every location this run needs from the roots it was given."""
+    return BundleLayout(
+        map_root=map_root,
+        bundle_root=bundle_root,
+        partition=partition,
+        from_partition=from_partition,
+        map_read_suffix="csv" if reader_type == "CsvReader" else "parquet",
+    )

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -37,8 +37,6 @@ DELTA_GROUPS_ARTIFACT = "delta_sid_to_item_groups"
 MAP_ARTIFACTS = (MAP_ARTIFACT, DELTA_MAP_ARTIFACT)
 GROUPS_ARTIFACTS = (GROUPS_ARTIFACT, DELTA_GROUPS_ARTIFACT)
 
-_WRITER_TYPE_SUFFIX = {"ParquetWriter": "parquet", "CsvWriter": "csv"}
-
 
 def is_odps_path(path: str) -> bool:
     """Whether a root addresses ODPS rather than a filesystem."""
@@ -62,13 +60,6 @@ def artifact_read_pattern(root: str, artifact: str, partition: str, suffix: str)
     if is_odps_path(root):
         return location
     return os.path.join(location, f"part-*.{suffix}")
-
-
-def writer_suffix(writer_type: str) -> str:
-    """Return the file extension a file writer emits."""
-    if writer_type not in _WRITER_TYPE_SUFFIX:
-        raise ValueError(f"{writer_type} does not write files.")
-    return _WRITER_TYPE_SUFFIX[writer_type]
 
 
 def manifest_path(bundle_root: str, partition: str) -> str:
@@ -116,7 +107,13 @@ class BundleManifest:
         payload = json.loads(text)
         missing = [
             key
-            for key in ("bundle_uuid", "codebook", "capacity", "artifacts")
+            for key in (
+                "bundle_uuid",
+                "codebook",
+                "capacity",
+                "max_observed_items_per_sid",
+                "artifacts",
+            )
             if key not in payload
         ]
         if missing:
@@ -132,8 +129,29 @@ class BundleManifest:
                     f"manifest declares {name} as {entry.type!r}; the serving set "
                     "is always parquet, so this bundle cannot be opened."
                 )
-        payload.setdefault("max_observed_items_per_sid", payload["capacity"])
         return cls(artifacts=entries, **payload)
+
+
+def artifact_entry(
+    root: str,
+    artifact: str,
+    partition: str,
+    kind: str,
+    rows: int,
+    schema: Dict[str, str],
+) -> ArtifactEntry:
+    """Describe where one artifact landed, in the shape the manifest records."""
+    location = artifact_location(root, artifact, partition)
+    if is_odps_path(root):
+        table = root.rstrip("/").rpartition("/tables/")[2]
+        return ArtifactEntry(
+            type="odps",
+            rows=rows,
+            schema=schema,
+            table=table,
+            partition=f"artifact={artifact}/generation={partition}",
+        )
+    return ArtifactEntry(type=kind, rows=rows, schema=schema, path=location)
 
 
 def write_manifest(path: str, manifest: BundleManifest) -> None:

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -15,54 +15,62 @@ A bundle is the set of artifacts one resolve run publishes, plus a manifest that
 identifies them, locates them and describes the SID space they encode. The
 manifest is written last, so its presence is the completion marker.
 
-Artifacts fall into two families with different storage. The serving set --
-``sid_to_item_groups``, ``delta_sid_to_item_groups`` and the manifest -- is
-always parquet and JSON beneath ``bundle_root``. The map set -- ``item_to_sid_map``
-and ``delta_item_to_sid_map`` -- follows the caller's writer type beneath
-``map_root``, which may be an ODPS table. On ODPS the artifact name is a
-partition key rather than a path segment, because MaxCompute requires every
-partition to be ``key=value``.
+Everything lands at ``{root}/{generation}/{artifact}``, so one generation is one
+self-contained directory. On ODPS the two levels are partition keys rather than
+path segments -- ``generation=.../artifact=...`` -- because MaxCompute requires
+every partition to be ``key=value``; the nesting order is the same either way.
+
+Artifacts fall into two families. The serving set -- ``sid_to_items``,
+``delta_sid_to_items`` and the manifest -- is always parquet and JSON beneath
+``output_path``, which therefore can never be an ODPS table. The item-to-SID set
+-- ``item_to_sid`` and ``delta_item_to_sid`` -- follows the caller's writer type
+beneath ``item_to_sid_root``, which may be an ODPS table and otherwise defaults
+to ``output_path``.
 """
 
 import json
 import os
 import uuid
 from dataclasses import asdict, dataclass, field
+from functools import cached_property
 from typing import Any, Dict, List, Optional, Tuple
 
+from tzrec.utils.logging_util import logger
 from tzrec.utils.path_util import is_odps_path
 
-MAP_ARTIFACT = "item_to_sid_map"
-DELTA_MAP_ARTIFACT = "delta_item_to_sid_map"
-GROUPS_ARTIFACT = "sid_to_item_groups"
-DELTA_GROUPS_ARTIFACT = "delta_sid_to_item_groups"
+ITEM_TO_SID_ARTIFACT = "item_to_sid"
+DELTA_ITEM_TO_SID_ARTIFACT = "delta_item_to_sid"
+SID_TO_ITEMS_ARTIFACT = "sid_to_items"
+DELTA_SID_TO_ITEMS_ARTIFACT = "delta_sid_to_items"
 
-MAP_ARTIFACTS = (MAP_ARTIFACT, DELTA_MAP_ARTIFACT)
-GROUPS_ARTIFACTS = (GROUPS_ARTIFACT, DELTA_GROUPS_ARTIFACT)
+ITEM_TO_SID_ARTIFACTS = (ITEM_TO_SID_ARTIFACT, DELTA_ITEM_TO_SID_ARTIFACT)
+SID_TO_ITEMS_ARTIFACTS = (SID_TO_ITEMS_ARTIFACT, DELTA_SID_TO_ITEMS_ARTIFACT)
 
 
-def artifact_location(root: str, artifact: str, partition: str) -> str:
-    """Return where one artifact's partition lives under ``root``."""
+def artifact_location(root: str, generation: str, artifact: str) -> str:
+    """Return where one artifact of one generation lives under ``root``."""
     if is_odps_path(root):
-        return f"{root.rstrip('/')}/artifact={artifact}/generation={partition}"
-    return os.path.join(root, artifact, partition)
+        return f"{root.rstrip('/')}/generation={generation}/artifact={artifact}"
+    return os.path.join(root, generation, artifact)
 
 
-def artifact_read_pattern(root: str, artifact: str, partition: str, suffix: str) -> str:
-    """Return the reader path for one artifact's partition.
+def artifact_read_pattern(
+    root: str, generation: str, artifact: str, suffix: str
+) -> str:
+    """Return the reader path for one artifact of one generation.
 
     A bare directory only globs to itself, so a derived read path needs the
     ``part-*`` pattern the writers emit. An ODPS partition selects itself.
     """
-    location = artifact_location(root, artifact, partition)
+    location = artifact_location(root, generation, artifact)
     if is_odps_path(root):
         return location
     return os.path.join(location, f"part-*.{suffix}")
 
 
-def manifest_path(bundle_root: str, partition: str) -> str:
-    """Return the manifest location for one generation."""
-    return os.path.join(bundle_root, "manifest", f"{partition}.json")
+def manifest_path(output_path: str, generation: str) -> str:
+    """Return the manifest location inside one generation."""
+    return os.path.join(output_path, generation, "manifest.json")
 
 
 @dataclass
@@ -117,7 +125,7 @@ class BundleManifest:
             name: ArtifactEntry(**entry)
             for name, entry in payload.pop("artifacts").items()
         }
-        for name in GROUPS_ARTIFACTS:
+        for name in SID_TO_ITEMS_ARTIFACTS:
             entry = entries.get(name)
             if entry is not None and entry.save_type != "parquet":
                 raise ValueError(
@@ -140,6 +148,7 @@ def read_manifest(path: str) -> BundleManifest:
     Raises:
         FileNotFoundError: If the manifest is absent, which means the run that
             should have written it did not finish.
+        ValueError: If the manifest is present but cannot be parsed.
     """
     if not os.path.exists(path):
         raise FileNotFoundError(
@@ -147,52 +156,64 @@ def read_manifest(path: str) -> BundleManifest:
             "absence means that generation did not finish."
         )
     with open(path) as handle:
-        return BundleManifest.from_json(handle.read())
+        text = handle.read()
+    try:
+        return BundleManifest.from_json(text)
+    except (json.JSONDecodeError, TypeError) as err:
+        raise ValueError(f"the manifest at {path!r} is not readable: {err}") from err
 
 
 @dataclass(frozen=True)
 class BundleLayout:
     """Every location one run reads and writes, resolved once.
 
-    Binding the two roots and the partitions here is what keeps the family rule
-    -- the serving set under ``bundle_root``, the map family under ``map_root``
-    -- in this module instead of at each call site.
+    Binding the two roots and the generations here is what keeps the family rule
+    -- the serving set under ``output_path``, the item-to-SID set under
+    ``item_to_sid_root`` -- in this module instead of at each call site.
+    ``item_to_sid_root`` arrives already resolved, so its default is not this
+    class's concern.
     """
 
-    map_root: Optional[str]
-    bundle_root: Optional[str]
-    partition: Optional[str]
-    from_partition: Optional[str]
-    reader_type: Optional[str] = None
+    output_path: Optional[str]
+    item_to_sid_root: Optional[str]
+    generation: Optional[str]
+    from_generation: Optional[str]
 
     def __post_init__(self) -> None:
-        if self.bundle_root is not None and is_odps_path(self.bundle_root):
+        if self.output_path is not None and is_odps_path(self.output_path):
             raise ValueError(
-                "bundle_root holds the SID groups and the manifest, which are "
-                f"always files; got {self.bundle_root!r}."
+                "output_path holds sid_to_items and the manifest, which are "
+                f"always files; got {self.output_path!r}."
             )
 
     def root_for(self, artifact: str) -> str:
         """Return the root that owns one artifact's family."""
-        root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.map_root
+        root = (
+            self.item_to_sid_root
+            if artifact in ITEM_TO_SID_ARTIFACTS
+            else self.output_path
+        )
         if root is None:
             raise RuntimeError(f"no root is configured for {artifact}.")
         return root
 
     def write_path(self, artifact: str) -> str:
         """Return where this generation writes one artifact."""
-        if self.partition is None:
-            raise RuntimeError("no partition is configured to write.")
-        return artifact_location(self.root_for(artifact), artifact, self.partition)
+        if self.generation is None:
+            raise RuntimeError("no generation is configured to write.")
+        return artifact_location(self.root_for(artifact), self.generation, artifact)
 
-    def read_path(self, artifact: str) -> str:
-        """Return where the appended-onto generation holds one artifact."""
-        if self.from_partition is None:
-            raise RuntimeError("no from_partition is configured to read.")
-        is_csv_map = artifact in MAP_ARTIFACTS and self.reader_type == "CsvReader"
-        suffix = "csv" if is_csv_map else "parquet"
+    def read_path(self, artifact: str, suffix: str) -> str:
+        """Return where the appended-onto generation holds one artifact.
+
+        ``suffix`` comes from what that generation recorded it wrote, not from
+        this run's flags, so a chain does not depend on the reader type being
+        repeated.
+        """
+        if self.from_generation is None:
+            raise RuntimeError("no from_generation is configured to read.")
         return artifact_read_pattern(
-            self.root_for(artifact), artifact, self.from_partition, suffix
+            self.root_for(artifact), self.from_generation, artifact, suffix
         )
 
     def entry(
@@ -206,7 +227,7 @@ class BundleLayout:
         """
         if is_odps_path(self.root_for(artifact)):
             save_type = "odps"
-        elif artifact in GROUPS_ARTIFACTS:
+        elif artifact in SID_TO_ITEMS_ARTIFACTS:
             save_type = "parquet"
         else:
             save_type = "csv" if writer_type == "CsvWriter" else "parquet"
@@ -216,17 +237,17 @@ class BundleLayout:
 
     def write_manifest(self, manifest: "BundleManifest") -> str:
         """Write this generation's manifest and return where it landed."""
-        if self.bundle_root is None or self.partition is None:
+        if self.output_path is None or self.generation is None:
             raise RuntimeError("no manifest location is configured.")
-        path = manifest_path(self.bundle_root, self.partition)
+        path = manifest_path(self.output_path, self.generation)
         write_manifest(path, manifest)
         return path
 
     def prior_manifest_path(self) -> str:
         """Return the manifest of the generation being appended onto."""
-        if self.bundle_root is None or self.from_partition is None:
+        if self.output_path is None or self.from_generation is None:
             raise RuntimeError("no prior manifest location is configured.")
-        return manifest_path(self.bundle_root, self.from_partition)
+        return manifest_path(self.output_path, self.from_generation)
 
 
 class Bundle:
@@ -243,61 +264,113 @@ class Bundle:
         self._rows: Dict[str, int] = {}
         self.uuid = uuid.uuid4().hex
 
-    @property
-    def map_path(self) -> str:
-        """Where this generation's item map is written."""
-        return self._layout.write_path(MAP_ARTIFACT)
+    @cached_property
+    def _prior(self) -> Optional[BundleManifest]:
+        """The manifest of the generation being appended onto, read once."""
+        if self._layout.from_generation is None:
+            return None
+        return read_manifest(self._layout.prior_manifest_path())
+
+    def _prior_entry(self, artifact: str) -> ArtifactEntry:
+        """Return what the appended-onto generation recorded for one artifact."""
+        prior = self._prior
+        if prior is None:
+            raise RuntimeError("no prior generation is configured to read.")
+        entry = prior.artifacts.get(artifact)
+        if entry is None:
+            raise ValueError(
+                f"generation {self._layout.from_generation!r} records no "
+                f"{artifact} in its manifest, so it cannot be appended onto."
+            )
+        return entry
 
     @property
-    def delta_map_path(self) -> str:
+    def item_to_sid_path(self) -> str:
+        """Where this generation's item_to_sid rows are written."""
+        return self._layout.write_path(ITEM_TO_SID_ARTIFACT)
+
+    @property
+    def delta_item_to_sid_path(self) -> str:
         """Where this generation's added item rows are written."""
-        return self._layout.write_path(DELTA_MAP_ARTIFACT)
+        return self._layout.write_path(DELTA_ITEM_TO_SID_ARTIFACT)
 
     @property
-    def groups_path(self) -> str:
-        """Where this generation's SID groups are written."""
-        return self._layout.write_path(GROUPS_ARTIFACT)
+    def sid_to_items_path(self) -> str:
+        """Where this generation's sid_to_items rows are written."""
+        return self._layout.write_path(SID_TO_ITEMS_ARTIFACT)
 
     @property
-    def delta_groups_path(self) -> str:
+    def delta_sid_to_items_path(self) -> str:
         """Where this generation's touched buckets are written."""
-        return self._layout.write_path(DELTA_GROUPS_ARTIFACT)
+        return self._layout.write_path(DELTA_SID_TO_ITEMS_ARTIFACT)
 
     @property
-    def prior_map_path(self) -> str:
-        """Where the appended-onto generation holds its item map."""
-        return self._layout.read_path(MAP_ARTIFACT)
+    def prior_item_to_sid_path(self) -> str:
+        """Where the appended-onto generation holds its item_to_sid rows."""
+        save_type = self._prior_entry(ITEM_TO_SID_ARTIFACT).save_type
+        return self._layout.read_path(ITEM_TO_SID_ARTIFACT, save_type)
 
     @property
-    def prior_groups_path(self) -> str:
-        """Where the appended-onto generation holds its SID groups."""
-        return self._layout.read_path(GROUPS_ARTIFACT)
+    def prior_sid_to_items_path(self) -> str:
+        """Where the appended-onto generation holds its sid_to_items rows."""
+        return self._layout.read_path(SID_TO_ITEMS_ARTIFACT, "parquet")
 
     def prior_locations(self) -> List[Tuple[str, str]]:
-        """Every published location an append reads, labelled for errors."""
-        wanted = [
-            (GROUPS_ARTIFACT, self.prior_groups_path),
-            ("manifest", self._layout.prior_manifest_path()),
+        """Every published artifact an append reads, labelled for errors.
+
+        The manifest is not among them: resolving these paths is what reads it,
+        so its absence has already raised by the time this returns.
+        """
+        return [
+            (SID_TO_ITEMS_ARTIFACT, self.prior_sid_to_items_path),
+            (ITEM_TO_SID_ARTIFACT, self.prior_item_to_sid_path),
         ]
-        if self._layout.map_root is not None:
-            wanted.append((MAP_ARTIFACT, self.prior_map_path))
-        return wanted
 
-    def record_map(self, rows: int) -> None:
-        """Record how many rows the merged item map holds."""
-        self._rows[MAP_ARTIFACT] = rows
+    def check_prior_compatible(self, codebook: List[int], capacity: int) -> None:
+        """Reject an append whose SID space differs from the published corpus.
 
-    def record_delta_map(self, rows: int) -> None:
-        """Record how many rows this run added to the item map."""
-        self._rows[DELTA_MAP_ARTIFACT] = rows
+        The codebook fixes how a SID packs into a bucket key and how its layers
+        shift into one vocabulary, so appending under a different one re-keys
+        every published SID and rewrites its ``offset_codebook``.
 
-    def record_groups(self, rows: int) -> None:
-        """Record how many buckets the merged SID groups hold."""
-        self._rows[GROUPS_ARTIFACT] = rows
+        Raises:
+            ValueError: If the codebook differs from the published generation's.
+        """
+        prior = self._prior
+        if prior is None:
+            return
+        if codebook != prior.codebook:
+            raise ValueError(
+                f"--codebook {codebook} differs from the {prior.codebook} "
+                f"published at generation {self._layout.from_generation!r}; "
+                "appending would re-key every published SID and rewrite its "
+                "offset_codebook. Append with the codebook the corpus was "
+                "built with."
+            )
+        if capacity != prior.capacity:
+            logger.warning(
+                "capacity is %d but generation %s was published with %d; already "
+                "published buckets keep the occupancy they have",
+                capacity,
+                self._layout.from_generation,
+                prior.capacity,
+            )
 
-    def record_delta_groups(self, rows: int) -> None:
+    def record_item_to_sid(self, rows: int) -> None:
+        """Record how many rows the merged item_to_sid holds."""
+        self._rows[ITEM_TO_SID_ARTIFACT] = rows
+
+    def record_delta_item_to_sid(self, rows: int) -> None:
+        """Record how many rows this run added to item_to_sid."""
+        self._rows[DELTA_ITEM_TO_SID_ARTIFACT] = rows
+
+    def record_sid_to_items(self, rows: int) -> None:
+        """Record how many buckets the merged sid_to_items holds."""
+        self._rows[SID_TO_ITEMS_ARTIFACT] = rows
+
+    def record_delta_sid_to_items(self, rows: int) -> None:
         """Record how many buckets this run touched."""
-        self._rows[DELTA_GROUPS_ARTIFACT] = rows
+        self._rows[DELTA_SID_TO_ITEMS_ARTIFACT] = rows
 
     def publish(
         self,
@@ -313,11 +386,7 @@ class Bundle:
         sees the buckets it touched, so the published ceiling is the larger of
         this run's and the one it appended onto.
         """
-        prior = (
-            read_manifest(self._layout.prior_manifest_path())
-            if self._layout.from_partition is not None
-            else None
-        )
+        prior = self._prior
         if prior is not None:
             observed = max(observed, prior.max_observed_items_per_sid)
         manifest = BundleManifest(

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -71,16 +71,14 @@ def manifest_path(bundle_root: str, partition: str) -> str:
 class ArtifactEntry:
     """Where one artifact landed and what it holds.
 
-    ``save_type`` selects how to open it and which location fields are set:
-    ``odps`` fills ``table`` and ``partition``, ``parquet`` and ``csv`` fill
-    ``path``.
+    ``location`` is the address in the form this repository's readers take, so
+    an ODPS artifact carries its full ``odps://`` URL rather than a split table
+    and partition; ``save_type`` says how to open it.
     """
 
     save_type: str
     rows: int
-    path: Optional[str] = None
-    table: Optional[str] = None
-    partition: Optional[str] = None
+    location: str
 
 
 @dataclass
@@ -93,16 +91,11 @@ class BundleManifest:
     max_observed_items_per_sid: int
     artifacts: Dict[str, ArtifactEntry] = field(default_factory=dict)
     since_bundle_uuid: Optional[str] = None
-    source_model: Optional[str] = None
     item_id_type: Optional[str] = None
 
     def to_json(self) -> str:
         """Serialize, dropping keys that carry no value."""
         payload: Dict[str, Any] = asdict(self)
-        payload["artifacts"] = {
-            name: {k: v for k, v in entry.items() if v is not None}
-            for name, entry in payload["artifacts"].items()
-        }
         return json.dumps({k: v for k, v in payload.items() if v is not None}, indent=2)
 
     @classmethod
@@ -134,22 +127,6 @@ class BundleManifest:
                     "is always parquet, so this bundle cannot be opened."
                 )
         return cls(artifacts=entries, **payload)
-
-
-def artifact_entry(
-    root: str, artifact: str, partition: str, save_type: str, rows: int
-) -> ArtifactEntry:
-    """Describe where one artifact landed, in the shape the manifest records."""
-    location = artifact_location(root, artifact, partition)
-    if is_odps_path(root):
-        table = root.rstrip("/").rpartition("/tables/")[2]
-        return ArtifactEntry(
-            save_type="odps",
-            rows=rows,
-            table=table,
-            partition=f"artifact={artifact}/generation={partition}",
-        )
-    return ArtifactEntry(save_type=save_type, rows=rows, path=location)
 
 
 def write_manifest(path: str, manifest: BundleManifest) -> None:
@@ -188,7 +165,7 @@ class BundleLayout:
     bundle_root: Optional[str]
     partition: Optional[str]
     from_partition: Optional[str]
-    map_read_suffix: str
+    reader_type: Optional[str] = None
 
     def root_for(self, artifact: str) -> str:
         """Return the root that owns one artifact's family."""
@@ -207,17 +184,19 @@ class BundleLayout:
         """Return where the appended-onto generation holds one artifact."""
         if self.from_partition is None:
             raise RuntimeError("no from_partition is configured to read.")
-        suffix = "parquet" if artifact in GROUPS_ARTIFACTS else self.map_read_suffix
+        is_csv_map = artifact in MAP_ARTIFACTS and self.reader_type == "CsvReader"
+        suffix = "csv" if is_csv_map else "parquet"
         return artifact_read_pattern(
             self.root_for(artifact), artifact, self.from_partition, suffix
         )
 
-    def entry(self, artifact: str, save_type: str, rows: int) -> ArtifactEntry:
+    def entry(self, artifact: str, file_save_type: str, rows: int) -> ArtifactEntry:
         """Describe where one artifact landed, for the manifest."""
-        if self.partition is None:
-            raise RuntimeError("no partition is configured to write.")
-        return artifact_entry(
-            self.root_for(artifact), artifact, self.partition, save_type, rows
+        odps = is_odps_path(self.root_for(artifact))
+        return ArtifactEntry(
+            save_type="odps" if odps else file_save_type,
+            rows=rows,
+            location=self.write_path(artifact),
         )
 
     def write_manifest(self, manifest: "BundleManifest") -> str:
@@ -233,24 +212,3 @@ class BundleLayout:
         if self.bundle_root is None or self.from_partition is None:
             raise RuntimeError("no prior manifest location is configured.")
         return manifest_path(self.bundle_root, self.from_partition)
-
-    def read_prior_manifest(self) -> "BundleManifest":
-        """Read the manifest of the generation being appended onto."""
-        return read_manifest(self.prior_manifest_path())
-
-
-def resolve_layout(
-    map_root: Optional[str],
-    bundle_root: Optional[str],
-    partition: Optional[str],
-    from_partition: Optional[str],
-    reader_type: Optional[str],
-) -> BundleLayout:
-    """Resolve every location this run needs from the roots it was given."""
-    return BundleLayout(
-        map_root=map_root,
-        bundle_root=bundle_root,
-        partition=partition,
-        from_partition=from_partition,
-        map_read_suffix="csv" if reader_type == "CsvReader" else "parquet",
-    )

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -55,7 +55,7 @@ def artifact_location(root: str, generation: str, artifact: str) -> str:
 
 
 def artifact_read_pattern(
-    root: str, generation: str, artifact: str, suffix: str
+    root: str, generation: str, artifact: str, save_type: str
 ) -> str:
     """Return the reader path for one artifact of one generation.
 
@@ -65,7 +65,7 @@ def artifact_read_pattern(
     location = artifact_location(root, generation, artifact)
     if is_odps_path(root):
         return location
-    return os.path.join(location, f"part-*.{suffix}")
+    return os.path.join(location, f"part-*.{save_type}")
 
 
 def manifest_path(output_path: str, generation: str) -> str:
@@ -203,17 +203,17 @@ class BundleLayout:
             raise RuntimeError("no generation is configured to write.")
         return artifact_location(self.root_for(artifact), self.generation, artifact)
 
-    def read_path(self, artifact: str, suffix: str) -> str:
+    def read_path(self, artifact: str, save_type: str) -> str:
         """Return where the appended-onto generation holds one artifact.
 
-        ``suffix`` comes from what that generation recorded it wrote, not from
+        ``save_type`` comes from what that generation recorded it wrote, not from
         this run's flags, so a chain does not depend on the reader type being
         repeated.
         """
         if self.from_generation is None:
             raise RuntimeError("no from_generation is configured to read.")
         return artifact_read_pattern(
-            self.root_for(artifact), self.from_generation, artifact, suffix
+            self.root_for(artifact), self.from_generation, artifact, save_type
         )
 
     def entry(
@@ -221,9 +221,10 @@ class BundleLayout:
     ) -> ArtifactEntry:
         """Describe where one artifact landed, for the manifest.
 
-        ``save_type`` is read off the address, so it cannot contradict
+        An ODPS root fixes ``save_type`` to ``odps``, so it cannot contradict
         ``location``; the serving set can only be parquet because a root that
-        would make it otherwise is refused at construction.
+        would make it otherwise is refused at construction, and the
+        item-to-SID set follows ``writer_type``.
         """
         if is_odps_path(self.root_for(artifact)):
             save_type = "odps"
@@ -332,6 +333,9 @@ class Bundle:
         The codebook fixes how a SID packs into a bucket key and how its layers
         shift into one vocabulary, so appending under a different one re-keys
         every published SID and rewrites its ``offset_codebook``.
+
+        A differing ``capacity`` is only warned about: published buckets keep
+        the occupancy they were published with.
 
         Raises:
             ValueError: If the codebook differs from the published generation's.

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Locations and manifest for one generation of the SID bundle.
+
+A bundle is the set of artifacts one resolve run publishes, plus a manifest that
+identifies them, locates them and describes the SID space they encode. The
+manifest is written last, so its presence is the completion marker.
+
+Artifacts fall into two families with different storage. The serving set --
+``sid_to_item_groups``, ``delta_sid_to_item_groups`` and the manifest -- is
+always parquet and JSON beneath ``bundle_root``. The map set -- ``item_to_sid_map``
+and ``delta_item_to_sid_map`` -- follows the caller's writer type beneath
+``map_root``, which may be an ODPS table. On ODPS the artifact name is a
+partition key rather than a path segment, because MaxCompute requires every
+partition to be ``key=value``.
+"""
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+MAP_ARTIFACT = "item_to_sid_map"
+DELTA_MAP_ARTIFACT = "delta_item_to_sid_map"
+GROUPS_ARTIFACT = "sid_to_item_groups"
+DELTA_GROUPS_ARTIFACT = "delta_sid_to_item_groups"
+
+MAP_ARTIFACTS = (MAP_ARTIFACT, DELTA_MAP_ARTIFACT)
+GROUPS_ARTIFACTS = (GROUPS_ARTIFACT, DELTA_GROUPS_ARTIFACT)
+
+_WRITER_TYPE_SUFFIX = {"ParquetWriter": "parquet", "CsvWriter": "csv"}
+
+
+def is_odps_path(path: str) -> bool:
+    """Whether a root addresses ODPS rather than a filesystem."""
+    return path.startswith("odps://")
+
+
+def artifact_location(root: str, artifact: str, partition: str) -> str:
+    """Return where one artifact's partition lives under ``root``."""
+    if is_odps_path(root):
+        return f"{root.rstrip('/')}/artifact={artifact}/generation={partition}"
+    return os.path.join(root, artifact, partition)
+
+
+def artifact_read_pattern(root: str, artifact: str, partition: str, suffix: str) -> str:
+    """Return the reader path for one artifact's partition.
+
+    A bare directory only globs to itself, so a derived read path needs the
+    ``part-*`` pattern the writers emit. An ODPS partition selects itself.
+    """
+    location = artifact_location(root, artifact, partition)
+    if is_odps_path(root):
+        return location
+    return os.path.join(location, f"part-*.{suffix}")
+
+
+def writer_suffix(writer_type: str) -> str:
+    """Return the file extension a file writer emits."""
+    if writer_type not in _WRITER_TYPE_SUFFIX:
+        raise ValueError(f"{writer_type} does not write files.")
+    return _WRITER_TYPE_SUFFIX[writer_type]
+
+
+def manifest_path(bundle_root: str, partition: str) -> str:
+    """Return the manifest location for one generation."""
+    return os.path.join(bundle_root, "manifest", f"{partition}.json")
+
+
+@dataclass
+class ArtifactEntry:
+    """Where one artifact landed and what it holds."""
+
+    type: str
+    rows: int
+    schema: Dict[str, str]
+    path: Optional[str] = None
+    table: Optional[str] = None
+    partition: Optional[str] = None
+
+
+@dataclass
+class BundleManifest:
+    """Identity and shape of one published generation."""
+
+    bundle_uuid: str
+    codebook: List[int]
+    capacity: int
+    max_observed_items_per_sid: int
+    artifacts: Dict[str, ArtifactEntry] = field(default_factory=dict)
+    since_bundle_uuid: Optional[str] = None
+    source_model: Optional[str] = None
+    item_id_type: Optional[str] = None
+
+    def to_json(self) -> str:
+        """Serialize, dropping keys that carry no value."""
+        payload: Dict[str, Any] = asdict(self)
+        payload["artifacts"] = {
+            name: {k: v for k, v in entry.items() if v is not None}
+            for name, entry in payload["artifacts"].items()
+        }
+        return json.dumps({k: v for k, v in payload.items() if v is not None}, indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "BundleManifest":
+        """Parse a manifest, rejecting one this tool could not have written."""
+        payload = json.loads(text)
+        missing = [
+            key
+            for key in ("bundle_uuid", "codebook", "capacity", "artifacts")
+            if key not in payload
+        ]
+        if missing:
+            raise ValueError(f"manifest is missing required keys {missing}.")
+        entries = {
+            name: ArtifactEntry(**entry)
+            for name, entry in payload.pop("artifacts").items()
+        }
+        for name in GROUPS_ARTIFACTS:
+            entry = entries.get(name)
+            if entry is not None and entry.type != "parquet":
+                raise ValueError(
+                    f"manifest declares {name} as {entry.type!r}; the serving set "
+                    "is always parquet, so this bundle cannot be opened."
+                )
+        payload.setdefault("max_observed_items_per_sid", payload["capacity"])
+        return cls(artifacts=entries, **payload)
+
+
+def write_manifest(path: str, manifest: BundleManifest) -> None:
+    """Write the manifest, creating its directory."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as handle:
+        handle.write(manifest.to_json())
+
+
+def read_manifest(path: str) -> BundleManifest:
+    """Read a published manifest.
+
+    Raises:
+        FileNotFoundError: If the manifest is absent, which means the run that
+            should have written it did not finish.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"no manifest at {path!r}; the manifest is written last, so its "
+            "absence means that generation did not finish."
+        )
+    with open(path) as handle:
+        return BundleManifest.from_json(handle.read())

--- a/tzrec/utils/sid/bundle.py
+++ b/tzrec/utils/sid/bundle.py
@@ -26,8 +26,11 @@ partition to be ``key=value``.
 
 import json
 import os
+import uuid
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+from tzrec.utils.path_util import is_odps_path
 
 MAP_ARTIFACT = "item_to_sid_map"
 DELTA_MAP_ARTIFACT = "delta_item_to_sid_map"
@@ -36,11 +39,6 @@ DELTA_GROUPS_ARTIFACT = "delta_sid_to_item_groups"
 
 MAP_ARTIFACTS = (MAP_ARTIFACT, DELTA_MAP_ARTIFACT)
 GROUPS_ARTIFACTS = (GROUPS_ARTIFACT, DELTA_GROUPS_ARTIFACT)
-
-
-def is_odps_path(path: str) -> bool:
-    """Whether a root addresses ODPS rather than a filesystem."""
-    return path.startswith("odps://")
 
 
 def artifact_location(root: str, artifact: str, partition: str) -> str:
@@ -167,6 +165,13 @@ class BundleLayout:
     from_partition: Optional[str]
     reader_type: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        if self.bundle_root is not None and is_odps_path(self.bundle_root):
+            raise ValueError(
+                "bundle_root holds the SID groups and the manifest, which are "
+                f"always files; got {self.bundle_root!r}."
+            )
+
     def root_for(self, artifact: str) -> str:
         """Return the root that owns one artifact's family."""
         root = self.bundle_root if artifact in GROUPS_ARTIFACTS else self.map_root
@@ -190,13 +195,23 @@ class BundleLayout:
             self.root_for(artifact), artifact, self.from_partition, suffix
         )
 
-    def entry(self, artifact: str, file_save_type: str, rows: int) -> ArtifactEntry:
-        """Describe where one artifact landed, for the manifest."""
-        odps = is_odps_path(self.root_for(artifact))
+    def entry(
+        self, artifact: str, rows: int, writer_type: Optional[str]
+    ) -> ArtifactEntry:
+        """Describe where one artifact landed, for the manifest.
+
+        ``save_type`` is read off the address, so it cannot contradict
+        ``location``; the serving set can only be parquet because a root that
+        would make it otherwise is refused at construction.
+        """
+        if is_odps_path(self.root_for(artifact)):
+            save_type = "odps"
+        elif artifact in GROUPS_ARTIFACTS:
+            save_type = "parquet"
+        else:
+            save_type = "csv" if writer_type == "CsvWriter" else "parquet"
         return ArtifactEntry(
-            save_type="odps" if odps else file_save_type,
-            rows=rows,
-            location=self.write_path(artifact),
+            save_type=save_type, rows=rows, location=self.write_path(artifact)
         )
 
     def write_manifest(self, manifest: "BundleManifest") -> str:
@@ -212,3 +227,109 @@ class BundleLayout:
         if self.bundle_root is None or self.from_partition is None:
             raise RuntimeError("no prior manifest location is configured.")
         return manifest_path(self.bundle_root, self.from_partition)
+
+
+class Bundle:
+    """The generation a run publishes: where each artifact goes, and its manifest.
+
+    Artifact names live here rather than at the call site, so a caller says
+    which artifact it wrote rather than naming it. Only artifacts it is told
+    about reach the manifest, which is how a full resolve records that it
+    published no delta.
+    """
+
+    def __init__(self, layout: BundleLayout) -> None:
+        self._layout = layout
+        self._rows: Dict[str, int] = {}
+        self.uuid = uuid.uuid4().hex
+
+    @property
+    def map_path(self) -> str:
+        """Where this generation's item map is written."""
+        return self._layout.write_path(MAP_ARTIFACT)
+
+    @property
+    def delta_map_path(self) -> str:
+        """Where this generation's added item rows are written."""
+        return self._layout.write_path(DELTA_MAP_ARTIFACT)
+
+    @property
+    def groups_path(self) -> str:
+        """Where this generation's SID groups are written."""
+        return self._layout.write_path(GROUPS_ARTIFACT)
+
+    @property
+    def delta_groups_path(self) -> str:
+        """Where this generation's touched buckets are written."""
+        return self._layout.write_path(DELTA_GROUPS_ARTIFACT)
+
+    @property
+    def prior_map_path(self) -> str:
+        """Where the appended-onto generation holds its item map."""
+        return self._layout.read_path(MAP_ARTIFACT)
+
+    @property
+    def prior_groups_path(self) -> str:
+        """Where the appended-onto generation holds its SID groups."""
+        return self._layout.read_path(GROUPS_ARTIFACT)
+
+    def prior_locations(self) -> List[Tuple[str, str]]:
+        """Every published location an append reads, labelled for errors."""
+        wanted = [
+            (GROUPS_ARTIFACT, self.prior_groups_path),
+            ("manifest", self._layout.prior_manifest_path()),
+        ]
+        if self._layout.map_root is not None:
+            wanted.append((MAP_ARTIFACT, self.prior_map_path))
+        return wanted
+
+    def record_map(self, rows: int) -> None:
+        """Record how many rows the merged item map holds."""
+        self._rows[MAP_ARTIFACT] = rows
+
+    def record_delta_map(self, rows: int) -> None:
+        """Record how many rows this run added to the item map."""
+        self._rows[DELTA_MAP_ARTIFACT] = rows
+
+    def record_groups(self, rows: int) -> None:
+        """Record how many buckets the merged SID groups hold."""
+        self._rows[GROUPS_ARTIFACT] = rows
+
+    def record_delta_groups(self, rows: int) -> None:
+        """Record how many buckets this run touched."""
+        self._rows[DELTA_GROUPS_ARTIFACT] = rows
+
+    def publish(
+        self,
+        codebook: List[int],
+        capacity: int,
+        observed: int,
+        item_id_type: Optional[str],
+        writer_type: Optional[str],
+    ) -> str:
+        """Write the manifest last and return where it landed.
+
+        ``observed`` is carried forward as a running maximum: an append only
+        sees the buckets it touched, so the published ceiling is the larger of
+        this run's and the one it appended onto.
+        """
+        prior = (
+            read_manifest(self._layout.prior_manifest_path())
+            if self._layout.from_partition is not None
+            else None
+        )
+        if prior is not None:
+            observed = max(observed, prior.max_observed_items_per_sid)
+        manifest = BundleManifest(
+            bundle_uuid=self.uuid,
+            since_bundle_uuid=prior.bundle_uuid if prior is not None else None,
+            codebook=codebook,
+            capacity=capacity,
+            max_observed_items_per_sid=observed,
+            item_id_type=item_id_type,
+            artifacts={
+                name: self._layout.entry(name, rows, writer_type)
+                for name, rows in self._rows.items()
+            },
+        )
+        return self._layout.write_manifest(manifest)

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+
+from tzrec.utils.sid import bundle
+from tzrec.utils.test_util import make_test_dir
+
+
+def _manifest(**kw):
+    base = dict(
+        bundle_uuid="uuid-v2",
+        codebook=[8, 8],
+        capacity=5,
+        max_observed_items_per_sid=3,
+        artifacts={
+            bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
+                type="parquet",
+                rows=4,
+                schema={"codebook": "list<int64>"},
+                path="./sid/sid_to_item_groups/v2",
+            )
+        },
+    )
+    base.update(kw)
+    return bundle.BundleManifest(**base)
+
+
+class BundleLocationTest(unittest.TestCase):
+    def test_file_root_puts_the_artifact_in_a_directory(self) -> None:
+        self.assertEqual(
+            bundle.artifact_location("./sid", bundle.GROUPS_ARTIFACT, "v2"),
+            "./sid/sid_to_item_groups/v2",
+        )
+
+    def test_odps_root_makes_the_artifact_a_partition_key(self) -> None:
+        self.assertEqual(
+            bundle.artifact_location(
+                "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2"
+            ),
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+        )
+
+    def test_odps_root_tolerates_a_trailing_slash(self) -> None:
+        self.assertEqual(
+            bundle.artifact_location(
+                "odps://prj/tables/sid/", bundle.MAP_ARTIFACT, "v1"
+            ),
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v1",
+        )
+
+    def test_file_read_pattern_globs_the_part_files(self) -> None:
+        self.assertEqual(
+            bundle.artifact_read_pattern("./sid", bundle.MAP_ARTIFACT, "v1", "parquet"),
+            "./sid/item_to_sid_map/v1/part-*.parquet",
+        )
+
+    def test_odps_read_pattern_is_the_partition_itself(self) -> None:
+        self.assertEqual(
+            bundle.artifact_read_pattern(
+                "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v1", "parquet"
+            ),
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v1",
+        )
+
+    def test_writer_suffix_rejects_a_non_file_writer(self) -> None:
+        self.assertEqual(bundle.writer_suffix("CsvWriter"), "csv")
+        with self.assertRaisesRegex(ValueError, "does not write files"):
+            bundle.writer_suffix("OdpsWriter")
+
+    def test_manifest_path_is_per_generation(self) -> None:
+        self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/manifest/v2.json")
+
+
+class BundleManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = make_test_dir()
+
+    def test_round_trip_preserves_every_field(self) -> None:
+        original = _manifest(
+            since_bundle_uuid="uuid-v1", source_model="rqvae", item_id_type="int64"
+        )
+        restored = bundle.BundleManifest.from_json(original.to_json())
+        self.assertEqual(restored, original)
+
+    def test_absent_optional_fields_are_omitted_not_null(self) -> None:
+        payload = json.loads(_manifest().to_json())
+        self.assertNotIn("since_bundle_uuid", payload)
+        self.assertNotIn("source_model", payload)
+        entry = payload["artifacts"][bundle.GROUPS_ARTIFACT]
+        self.assertNotIn("table", entry)
+        self.assertIn("path", entry)
+
+    def test_rejects_a_manifest_missing_required_keys(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing required keys"):
+            bundle.BundleManifest.from_json(json.dumps({"bundle_uuid": "x"}))
+
+    def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
+        payload = json.loads(_manifest().to_json())
+        payload["artifacts"][bundle.GROUPS_ARTIFACT]["type"] = "odps"
+        with self.assertRaisesRegex(ValueError, "serving set is always parquet"):
+            bundle.BundleManifest.from_json(json.dumps(payload))
+
+    def test_map_artifact_may_be_odps(self) -> None:
+        payload = json.loads(_manifest().to_json())
+        payload["artifacts"][bundle.MAP_ARTIFACT] = {
+            "type": "odps",
+            "rows": 9,
+            "schema": {"item_id": "int64"},
+            "table": "prj.sid",
+            "partition": "artifact=item_to_sid_map/generation=v2",
+        }
+        restored = bundle.BundleManifest.from_json(json.dumps(payload))
+        self.assertEqual(restored.artifacts[bundle.MAP_ARTIFACT].table, "prj.sid")
+
+    def test_write_then_read_from_disk(self) -> None:
+        path = bundle.manifest_path(self.test_dir, "v2")
+        bundle.write_manifest(path, _manifest())
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(bundle.read_manifest(path).bundle_uuid, "uuid-v2")
+
+    def test_absent_manifest_reports_an_unfinished_run(self) -> None:
+        with self.assertRaisesRegex(FileNotFoundError, "did not finish"):
+            bundle.read_manifest(bundle.manifest_path(self.test_dir, "missing"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -36,26 +36,12 @@ def _manifest(**kw):
 
 
 class BundleLocationTest(unittest.TestCase):
-    def test_file_root_puts_the_artifact_in_a_directory(self) -> None:
-        self.assertEqual(
-            bundle.artifact_location("./sid", "v2", bundle.SID_TO_ITEMS_ARTIFACT),
-            "./sid/v2/sid_to_items",
-        )
-
     def test_odps_root_tolerates_a_trailing_slash(self) -> None:
         self.assertEqual(
             bundle.artifact_location(
                 "odps://prj/tables/sid/", "v1", bundle.ITEM_TO_SID_ARTIFACT
             ),
             "odps://prj/tables/sid/generation=v1/artifact=item_to_sid",
-        )
-
-    def test_file_read_pattern_globs_the_part_files(self) -> None:
-        self.assertEqual(
-            bundle.artifact_read_pattern(
-                "./sid", "v1", bundle.ITEM_TO_SID_ARTIFACT, "parquet"
-            ),
-            "./sid/v1/item_to_sid/part-*.parquet",
         )
 
     def test_odps_read_pattern_is_the_partition_itself(self) -> None:
@@ -65,9 +51,6 @@ class BundleLocationTest(unittest.TestCase):
             ),
             "odps://prj/tables/sid/generation=v1/artifact=item_to_sid",
         )
-
-    def test_manifest_sits_inside_its_generation(self) -> None:
-        self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/v2/manifest.json")
 
 
 class BundleLayoutTest(unittest.TestCase):

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -27,7 +27,6 @@ def _manifest(**kw):
             bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
                 save_type="parquet",
                 rows=4,
-                schema={"codebook": "list<int64>"},
                 path="./sid/sid_to_item_groups/v2",
             )
         },
@@ -77,6 +76,81 @@ class BundleLocationTest(unittest.TestCase):
         self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/manifest/v2.json")
 
 
+class BundleLayoutTest(unittest.TestCase):
+    def _layout(self, **kw):
+        base = dict(
+            map_root="./map",
+            bundle_root="./sid",
+            partition="v2",
+            from_partition="v1",
+            reader_type=None,
+        )
+        base.update(kw)
+        return bundle.resolve_layout(**base)
+
+    def test_each_family_resolves_under_its_own_root(self) -> None:
+        layout = self._layout()
+        self.assertEqual(
+            layout.write_path(bundle.MAP_ARTIFACT), "./map/item_to_sid_map/v2"
+        )
+        self.assertEqual(
+            layout.write_path(bundle.DELTA_MAP_ARTIFACT),
+            "./map/delta_item_to_sid_map/v2",
+        )
+        self.assertEqual(
+            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+        )
+        self.assertEqual(
+            layout.write_path(bundle.DELTA_GROUPS_ARTIFACT),
+            "./sid/delta_sid_to_item_groups/v2",
+        )
+
+    def test_reads_come_from_the_appended_onto_partition(self) -> None:
+        layout = self._layout()
+        self.assertEqual(
+            layout.read_path(bundle.MAP_ARTIFACT),
+            "./map/item_to_sid_map/v1/part-*.parquet",
+        )
+        self.assertEqual(
+            layout.read_path(bundle.GROUPS_ARTIFACT),
+            "./sid/sid_to_item_groups/v1/part-*.parquet",
+        )
+
+    def test_reader_type_selects_the_map_suffix_but_never_the_groups(self) -> None:
+        layout = self._layout(reader_type="CsvReader")
+        self.assertTrue(layout.read_path(bundle.MAP_ARTIFACT).endswith("part-*.csv"))
+        self.assertTrue(
+            layout.read_path(bundle.GROUPS_ARTIFACT).endswith("part-*.parquet")
+        )
+
+    def test_an_odps_map_root_leaves_the_serving_set_on_files(self) -> None:
+        layout = self._layout(map_root="odps://prj/tables/sid")
+        self.assertEqual(
+            layout.write_path(bundle.MAP_ARTIFACT),
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+        )
+        self.assertEqual(
+            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+        )
+
+    def test_manifest_locations_track_the_two_partitions(self) -> None:
+        layout = self._layout()
+        self.assertEqual(layout.prior_manifest_path(), "./sid/manifest/v1.json")
+
+    def test_a_missing_root_is_reported_against_its_artifact(self) -> None:
+        layout = self._layout(map_root=None)
+        with self.assertRaisesRegex(RuntimeError, "item_to_sid_map"):
+            layout.write_path(bundle.MAP_ARTIFACT)
+        self.assertEqual(
+            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+        )
+
+    def test_a_full_resolve_has_nothing_to_read(self) -> None:
+        layout = self._layout(from_partition=None)
+        with self.assertRaisesRegex(RuntimeError, "from_partition"):
+            layout.read_path(bundle.GROUPS_ARTIFACT)
+
+
 class BundleManifestTest(unittest.TestCase):
     def setUp(self) -> None:
         self.test_dir = make_test_dir()
@@ -108,7 +182,7 @@ class BundleManifestTest(unittest.TestCase):
 
     def test_artifact_entry_records_an_odps_table_and_partition(self) -> None:
         entry = bundle.artifact_entry(
-            "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2", "parquet", 9, {}
+            "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2", "parquet", 9
         )
         self.assertEqual(entry.save_type, "odps")
         self.assertEqual(entry.table, "sid")
@@ -117,7 +191,7 @@ class BundleManifestTest(unittest.TestCase):
 
     def test_artifact_entry_records_a_file_path(self) -> None:
         entry = bundle.artifact_entry(
-            "./sid", bundle.GROUPS_ARTIFACT, "v2", "parquet", 4, {}
+            "./sid", bundle.GROUPS_ARTIFACT, "v2", "parquet", 4
         )
         self.assertEqual(entry.save_type, "parquet")
         self.assertEqual(entry.path, "./sid/sid_to_item_groups/v2")
@@ -134,7 +208,6 @@ class BundleManifestTest(unittest.TestCase):
         payload["artifacts"][bundle.MAP_ARTIFACT] = {
             "save_type": "odps",
             "rows": 9,
-            "schema": {"item_id": "int64"},
             "table": "prj.sid",
             "partition": "artifact=item_to_sid_map/generation=v2",
         }

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -145,6 +145,17 @@ class BundleLayoutTest(unittest.TestCase):
             layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
         )
 
+    def test_an_odps_bundle_root_is_refused(self) -> None:
+        # the serving set is always files, so a root that would make it
+        # otherwise cannot be built rather than being written and rejected later
+        with self.assertRaisesRegex(ValueError, "always files"):
+            bundle.BundleLayout(
+                map_root="./map",
+                bundle_root="odps://prj/tables/g",
+                partition="v2",
+                from_partition=None,
+            )
+
     def test_a_full_resolve_has_nothing_to_read(self) -> None:
         layout = self._layout(from_partition=None)
         with self.assertRaisesRegex(RuntimeError, "from_partition"):
@@ -182,7 +193,7 @@ class BundleManifestTest(unittest.TestCase):
             partition="v2",
             from_partition=None,
         )
-        entry = layout.entry(bundle.MAP_ARTIFACT, "parquet", 9)
+        entry = layout.entry(bundle.MAP_ARTIFACT, 9, "ParquetWriter")
         self.assertEqual(entry.save_type, "odps")
         self.assertEqual(
             entry.location,
@@ -193,9 +204,17 @@ class BundleManifestTest(unittest.TestCase):
         layout = bundle.BundleLayout(
             map_root="./map", bundle_root="./sid", partition="v2", from_partition=None
         )
-        entry = layout.entry(bundle.MAP_ARTIFACT, "csv", 4)
+        entry = layout.entry(bundle.MAP_ARTIFACT, 4, "CsvWriter")
         self.assertEqual(entry.save_type, "csv")
         self.assertEqual(entry.location, "./map/item_to_sid_map/v2")
+
+    def test_a_csv_writer_never_makes_the_serving_set_csv(self) -> None:
+        layout = bundle.BundleLayout(
+            map_root="./map", bundle_root="./sid", partition="v2", from_partition=None
+        )
+        self.assertEqual(
+            layout.entry(bundle.GROUPS_ARTIFACT, 4, "CsvWriter").save_type, "parquet"
+        )
 
     def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
         payload = json.loads(_manifest().to_json())

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -24,10 +24,10 @@ def _manifest(**kw):
         capacity=5,
         max_observed_items_per_sid=3,
         artifacts={
-            bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
+            bundle.SID_TO_ITEMS_ARTIFACT: bundle.ArtifactEntry(
                 save_type="parquet",
                 rows=4,
-                location="./sid/sid_to_item_groups/v2",
+                location="./sid/v2/sid_to_items",
             )
         },
     )
@@ -38,52 +38,45 @@ def _manifest(**kw):
 class BundleLocationTest(unittest.TestCase):
     def test_file_root_puts_the_artifact_in_a_directory(self) -> None:
         self.assertEqual(
-            bundle.artifact_location("./sid", bundle.GROUPS_ARTIFACT, "v2"),
-            "./sid/sid_to_item_groups/v2",
-        )
-
-    def test_odps_root_makes_the_artifact_a_partition_key(self) -> None:
-        self.assertEqual(
-            bundle.artifact_location(
-                "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2"
-            ),
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+            bundle.artifact_location("./sid", "v2", bundle.SID_TO_ITEMS_ARTIFACT),
+            "./sid/v2/sid_to_items",
         )
 
     def test_odps_root_tolerates_a_trailing_slash(self) -> None:
         self.assertEqual(
             bundle.artifact_location(
-                "odps://prj/tables/sid/", bundle.MAP_ARTIFACT, "v1"
+                "odps://prj/tables/sid/", "v1", bundle.ITEM_TO_SID_ARTIFACT
             ),
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v1",
+            "odps://prj/tables/sid/generation=v1/artifact=item_to_sid",
         )
 
     def test_file_read_pattern_globs_the_part_files(self) -> None:
         self.assertEqual(
-            bundle.artifact_read_pattern("./sid", bundle.MAP_ARTIFACT, "v1", "parquet"),
-            "./sid/item_to_sid_map/v1/part-*.parquet",
+            bundle.artifact_read_pattern(
+                "./sid", "v1", bundle.ITEM_TO_SID_ARTIFACT, "parquet"
+            ),
+            "./sid/v1/item_to_sid/part-*.parquet",
         )
 
     def test_odps_read_pattern_is_the_partition_itself(self) -> None:
         self.assertEqual(
             bundle.artifact_read_pattern(
-                "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v1", "parquet"
+                "odps://prj/tables/sid", "v1", bundle.ITEM_TO_SID_ARTIFACT, "parquet"
             ),
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v1",
+            "odps://prj/tables/sid/generation=v1/artifact=item_to_sid",
         )
 
-    def test_manifest_path_is_per_generation(self) -> None:
-        self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/manifest/v2.json")
+    def test_manifest_sits_inside_its_generation(self) -> None:
+        self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/v2/manifest.json")
 
 
 class BundleLayoutTest(unittest.TestCase):
     def _layout(self, **kw):
         base = dict(
-            map_root="./map",
-            bundle_root="./sid",
-            partition="v2",
-            from_partition="v1",
-            reader_type=None,
+            output_path="./sid",
+            item_to_sid_root="./map",
+            generation="v2",
+            from_generation="v1",
         )
         base.update(kw)
         return bundle.BundleLayout(**base)
@@ -91,75 +84,70 @@ class BundleLayoutTest(unittest.TestCase):
     def test_each_family_resolves_under_its_own_root(self) -> None:
         layout = self._layout()
         self.assertEqual(
-            layout.write_path(bundle.MAP_ARTIFACT), "./map/item_to_sid_map/v2"
+            layout.write_path(bundle.ITEM_TO_SID_ARTIFACT), "./map/v2/item_to_sid"
         )
         self.assertEqual(
-            layout.write_path(bundle.DELTA_MAP_ARTIFACT),
-            "./map/delta_item_to_sid_map/v2",
+            layout.write_path(bundle.DELTA_ITEM_TO_SID_ARTIFACT),
+            "./map/v2/delta_item_to_sid",
         )
         self.assertEqual(
-            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+            layout.write_path(bundle.SID_TO_ITEMS_ARTIFACT), "./sid/v2/sid_to_items"
         )
         self.assertEqual(
-            layout.write_path(bundle.DELTA_GROUPS_ARTIFACT),
-            "./sid/delta_sid_to_item_groups/v2",
+            layout.write_path(bundle.DELTA_SID_TO_ITEMS_ARTIFACT),
+            "./sid/v2/delta_sid_to_items",
         )
 
-    def test_reads_come_from_the_appended_onto_partition(self) -> None:
+    def test_reads_come_from_the_appended_onto_generation(self) -> None:
         layout = self._layout()
         self.assertEqual(
-            layout.read_path(bundle.MAP_ARTIFACT),
-            "./map/item_to_sid_map/v1/part-*.parquet",
+            layout.read_path(bundle.ITEM_TO_SID_ARTIFACT, "parquet"),
+            "./map/v1/item_to_sid/part-*.parquet",
         )
         self.assertEqual(
-            layout.read_path(bundle.GROUPS_ARTIFACT),
-            "./sid/sid_to_item_groups/v1/part-*.parquet",
-        )
-
-    def test_reader_type_selects_the_map_suffix_but_never_the_groups(self) -> None:
-        layout = self._layout(reader_type="CsvReader")
-        self.assertTrue(layout.read_path(bundle.MAP_ARTIFACT).endswith("part-*.csv"))
-        self.assertTrue(
-            layout.read_path(bundle.GROUPS_ARTIFACT).endswith("part-*.parquet")
-        )
-
-    def test_an_odps_map_root_leaves_the_serving_set_on_files(self) -> None:
-        layout = self._layout(map_root="odps://prj/tables/sid")
-        self.assertEqual(
-            layout.write_path(bundle.MAP_ARTIFACT),
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+            layout.read_path(bundle.SID_TO_ITEMS_ARTIFACT, "parquet"),
+            "./sid/v1/sid_to_items/part-*.parquet",
         )
         self.assertEqual(
-            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+            layout.read_path(bundle.ITEM_TO_SID_ARTIFACT, "csv"),
+            "./map/v1/item_to_sid/part-*.csv",
         )
 
-    def test_manifest_locations_track_the_two_partitions(self) -> None:
+    def test_an_odps_item_to_sid_root_leaves_the_serving_set_on_files(self) -> None:
+        layout = self._layout(item_to_sid_root="odps://prj/tables/sid")
+        self.assertEqual(
+            layout.write_path(bundle.ITEM_TO_SID_ARTIFACT),
+            "odps://prj/tables/sid/generation=v2/artifact=item_to_sid",
+        )
+        self.assertEqual(
+            layout.write_path(bundle.SID_TO_ITEMS_ARTIFACT), "./sid/v2/sid_to_items"
+        )
+
+    def test_manifest_locations_track_the_two_generations(self) -> None:
         layout = self._layout()
-        self.assertEqual(layout.prior_manifest_path(), "./sid/manifest/v1.json")
+        self.assertEqual(layout.prior_manifest_path(), "./sid/v1/manifest.json")
 
     def test_a_missing_root_is_reported_against_its_artifact(self) -> None:
-        layout = self._layout(map_root=None)
-        with self.assertRaisesRegex(RuntimeError, "item_to_sid_map"):
-            layout.write_path(bundle.MAP_ARTIFACT)
+        layout = self._layout(item_to_sid_root=None)
+        with self.assertRaisesRegex(RuntimeError, "item_to_sid"):
+            layout.write_path(bundle.ITEM_TO_SID_ARTIFACT)
         self.assertEqual(
-            layout.write_path(bundle.GROUPS_ARTIFACT), "./sid/sid_to_item_groups/v2"
+            layout.write_path(bundle.SID_TO_ITEMS_ARTIFACT), "./sid/v2/sid_to_items"
         )
 
-    def test_an_odps_bundle_root_is_refused(self) -> None:
-        # the serving set is always files, so a root that would make it
-        # otherwise cannot be built rather than being written and rejected later
+    def test_an_odps_output_path_is_refused(self) -> None:
         with self.assertRaisesRegex(ValueError, "always files"):
             bundle.BundleLayout(
-                map_root="./map",
-                bundle_root="odps://prj/tables/g",
-                partition="v2",
-                from_partition=None,
+                output_path="odps://prj/tables/g",
+                item_to_sid_root="./map",
+                generation="v2",
+                from_generation=None,
             )
 
     def test_a_full_resolve_has_nothing_to_read(self) -> None:
-        layout = self._layout(from_partition=None)
-        with self.assertRaisesRegex(RuntimeError, "from_partition"):
-            layout.read_path(bundle.GROUPS_ARTIFACT)
+        layout = self._layout(from_generation=None)
+        with self.assertRaisesRegex(RuntimeError, "from_generation"):
+            layout.read_path(bundle.SID_TO_ITEMS_ARTIFACT, "parquet")
 
 
 class BundleManifestTest(unittest.TestCase):
@@ -174,7 +162,7 @@ class BundleManifestTest(unittest.TestCase):
     def test_absent_optional_fields_are_omitted_not_null(self) -> None:
         payload = json.loads(_manifest().to_json())
         self.assertNotIn("since_bundle_uuid", payload)
-        self.assertIn("location", payload["artifacts"][bundle.GROUPS_ARTIFACT])
+        self.assertIn("location", payload["artifacts"][bundle.SID_TO_ITEMS_ARTIFACT])
 
     def test_rejects_a_manifest_missing_required_keys(self) -> None:
         with self.assertRaisesRegex(ValueError, "missing required keys"):
@@ -188,51 +176,58 @@ class BundleManifestTest(unittest.TestCase):
 
     def test_an_odps_entry_keeps_the_url_its_readers_take(self) -> None:
         layout = bundle.BundleLayout(
-            map_root="odps://prj/tables/sid",
-            bundle_root="./sid",
-            partition="v2",
-            from_partition=None,
+            output_path="./sid",
+            item_to_sid_root="odps://prj/tables/sid",
+            generation="v2",
+            from_generation=None,
         )
-        entry = layout.entry(bundle.MAP_ARTIFACT, 9, "ParquetWriter")
+        entry = layout.entry(bundle.ITEM_TO_SID_ARTIFACT, 9, "ParquetWriter")
         self.assertEqual(entry.save_type, "odps")
         self.assertEqual(
             entry.location,
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+            "odps://prj/tables/sid/generation=v2/artifact=item_to_sid",
         )
 
     def test_a_file_entry_keeps_the_writer_format(self) -> None:
         layout = bundle.BundleLayout(
-            map_root="./map", bundle_root="./sid", partition="v2", from_partition=None
+            output_path="./sid",
+            item_to_sid_root="./map",
+            generation="v2",
+            from_generation=None,
         )
-        entry = layout.entry(bundle.MAP_ARTIFACT, 4, "CsvWriter")
+        entry = layout.entry(bundle.ITEM_TO_SID_ARTIFACT, 4, "CsvWriter")
         self.assertEqual(entry.save_type, "csv")
-        self.assertEqual(entry.location, "./map/item_to_sid_map/v2")
+        self.assertEqual(entry.location, "./map/v2/item_to_sid")
 
     def test_a_csv_writer_never_makes_the_serving_set_csv(self) -> None:
         layout = bundle.BundleLayout(
-            map_root="./map", bundle_root="./sid", partition="v2", from_partition=None
+            output_path="./sid",
+            item_to_sid_root="./map",
+            generation="v2",
+            from_generation=None,
         )
         self.assertEqual(
-            layout.entry(bundle.GROUPS_ARTIFACT, 4, "CsvWriter").save_type, "parquet"
+            layout.entry(bundle.SID_TO_ITEMS_ARTIFACT, 4, "CsvWriter").save_type,
+            "parquet",
         )
 
     def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
         payload = json.loads(_manifest().to_json())
-        payload["artifacts"][bundle.GROUPS_ARTIFACT]["save_type"] = "odps"
+        payload["artifacts"][bundle.SID_TO_ITEMS_ARTIFACT]["save_type"] = "odps"
         with self.assertRaisesRegex(ValueError, "serving set is always parquet"):
             bundle.BundleManifest.from_json(json.dumps(payload))
 
-    def test_map_artifact_may_be_odps(self) -> None:
+    def test_item_to_sid_artifact_may_be_odps(self) -> None:
         payload = json.loads(_manifest().to_json())
-        payload["artifacts"][bundle.MAP_ARTIFACT] = {
+        payload["artifacts"][bundle.ITEM_TO_SID_ARTIFACT] = {
             "save_type": "odps",
             "rows": 9,
-            "location": "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+            "location": "odps://prj/tables/sid/generation=v2/artifact=item_to_sid",
         }
         restored = bundle.BundleManifest.from_json(json.dumps(payload))
         self.assertEqual(
-            restored.artifacts[bundle.MAP_ARTIFACT].location,
-            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+            restored.artifacts[bundle.ITEM_TO_SID_ARTIFACT].location,
+            "odps://prj/tables/sid/generation=v2/artifact=item_to_sid",
         )
 
     def test_write_then_read_from_disk(self) -> None:

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -73,11 +73,6 @@ class BundleLocationTest(unittest.TestCase):
             "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v1",
         )
 
-    def test_writer_suffix_rejects_a_non_file_writer(self) -> None:
-        self.assertEqual(bundle.writer_suffix("CsvWriter"), "csv")
-        with self.assertRaisesRegex(ValueError, "does not write files"):
-            bundle.writer_suffix("OdpsWriter")
-
     def test_manifest_path_is_per_generation(self) -> None:
         self.assertEqual(bundle.manifest_path("./sid", "v2"), "./sid/manifest/v2.json")
 
@@ -104,6 +99,29 @@ class BundleManifestTest(unittest.TestCase):
     def test_rejects_a_manifest_missing_required_keys(self) -> None:
         with self.assertRaisesRegex(ValueError, "missing required keys"):
             bundle.BundleManifest.from_json(json.dumps({"bundle_uuid": "x"}))
+
+    def test_rejects_a_manifest_without_the_observed_ceiling(self) -> None:
+        payload = json.loads(_manifest().to_json())
+        del payload["max_observed_items_per_sid"]
+        with self.assertRaisesRegex(ValueError, "max_observed_items_per_sid"):
+            bundle.BundleManifest.from_json(json.dumps(payload))
+
+    def test_artifact_entry_records_an_odps_table_and_partition(self) -> None:
+        entry = bundle.artifact_entry(
+            "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2", "parquet", 9, {}
+        )
+        self.assertEqual(entry.type, "odps")
+        self.assertEqual(entry.table, "sid")
+        self.assertEqual(entry.partition, "artifact=item_to_sid_map/generation=v2")
+        self.assertIsNone(entry.path)
+
+    def test_artifact_entry_records_a_file_path(self) -> None:
+        entry = bundle.artifact_entry(
+            "./sid", bundle.GROUPS_ARTIFACT, "v2", "parquet", 4, {}
+        )
+        self.assertEqual(entry.type, "parquet")
+        self.assertEqual(entry.path, "./sid/sid_to_item_groups/v2")
+        self.assertIsNone(entry.table)
 
     def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
         payload = json.loads(_manifest().to_json())

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -27,7 +27,7 @@ def _manifest(**kw):
             bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
                 save_type="parquet",
                 rows=4,
-                path="./sid/sid_to_item_groups/v2",
+                location="./sid/sid_to_item_groups/v2",
             )
         },
     )
@@ -86,7 +86,7 @@ class BundleLayoutTest(unittest.TestCase):
             reader_type=None,
         )
         base.update(kw)
-        return bundle.resolve_layout(**base)
+        return bundle.BundleLayout(**base)
 
     def test_each_family_resolves_under_its_own_root(self) -> None:
         layout = self._layout()
@@ -156,19 +156,14 @@ class BundleManifestTest(unittest.TestCase):
         self.test_dir = make_test_dir()
 
     def test_round_trip_preserves_every_field(self) -> None:
-        original = _manifest(
-            since_bundle_uuid="uuid-v1", source_model="rqvae", item_id_type="int64"
-        )
+        original = _manifest(since_bundle_uuid="uuid-v1", item_id_type="int64")
         restored = bundle.BundleManifest.from_json(original.to_json())
         self.assertEqual(restored, original)
 
     def test_absent_optional_fields_are_omitted_not_null(self) -> None:
         payload = json.loads(_manifest().to_json())
         self.assertNotIn("since_bundle_uuid", payload)
-        self.assertNotIn("source_model", payload)
-        entry = payload["artifacts"][bundle.GROUPS_ARTIFACT]
-        self.assertNotIn("table", entry)
-        self.assertIn("path", entry)
+        self.assertIn("location", payload["artifacts"][bundle.GROUPS_ARTIFACT])
 
     def test_rejects_a_manifest_missing_required_keys(self) -> None:
         with self.assertRaisesRegex(ValueError, "missing required keys"):
@@ -180,22 +175,27 @@ class BundleManifestTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "max_observed_items_per_sid"):
             bundle.BundleManifest.from_json(json.dumps(payload))
 
-    def test_artifact_entry_records_an_odps_table_and_partition(self) -> None:
-        entry = bundle.artifact_entry(
-            "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2", "parquet", 9
+    def test_an_odps_entry_keeps_the_url_its_readers_take(self) -> None:
+        layout = bundle.BundleLayout(
+            map_root="odps://prj/tables/sid",
+            bundle_root="./sid",
+            partition="v2",
+            from_partition=None,
         )
+        entry = layout.entry(bundle.MAP_ARTIFACT, "parquet", 9)
         self.assertEqual(entry.save_type, "odps")
-        self.assertEqual(entry.table, "sid")
-        self.assertEqual(entry.partition, "artifact=item_to_sid_map/generation=v2")
-        self.assertIsNone(entry.path)
-
-    def test_artifact_entry_records_a_file_path(self) -> None:
-        entry = bundle.artifact_entry(
-            "./sid", bundle.GROUPS_ARTIFACT, "v2", "parquet", 4
+        self.assertEqual(
+            entry.location,
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
         )
-        self.assertEqual(entry.save_type, "parquet")
-        self.assertEqual(entry.path, "./sid/sid_to_item_groups/v2")
-        self.assertIsNone(entry.table)
+
+    def test_a_file_entry_keeps_the_writer_format(self) -> None:
+        layout = bundle.BundleLayout(
+            map_root="./map", bundle_root="./sid", partition="v2", from_partition=None
+        )
+        entry = layout.entry(bundle.MAP_ARTIFACT, "csv", 4)
+        self.assertEqual(entry.save_type, "csv")
+        self.assertEqual(entry.location, "./map/item_to_sid_map/v2")
 
     def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
         payload = json.loads(_manifest().to_json())
@@ -208,11 +208,13 @@ class BundleManifestTest(unittest.TestCase):
         payload["artifacts"][bundle.MAP_ARTIFACT] = {
             "save_type": "odps",
             "rows": 9,
-            "table": "prj.sid",
-            "partition": "artifact=item_to_sid_map/generation=v2",
+            "location": "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
         }
         restored = bundle.BundleManifest.from_json(json.dumps(payload))
-        self.assertEqual(restored.artifacts[bundle.MAP_ARTIFACT].table, "prj.sid")
+        self.assertEqual(
+            restored.artifacts[bundle.MAP_ARTIFACT].location,
+            "odps://prj/tables/sid/artifact=item_to_sid_map/generation=v2",
+        )
 
     def test_write_then_read_from_disk(self) -> None:
         path = bundle.manifest_path(self.test_dir, "v2")

--- a/tzrec/utils/sid/bundle_test.py
+++ b/tzrec/utils/sid/bundle_test.py
@@ -25,7 +25,7 @@ def _manifest(**kw):
         max_observed_items_per_sid=3,
         artifacts={
             bundle.GROUPS_ARTIFACT: bundle.ArtifactEntry(
-                type="parquet",
+                save_type="parquet",
                 rows=4,
                 schema={"codebook": "list<int64>"},
                 path="./sid/sid_to_item_groups/v2",
@@ -110,7 +110,7 @@ class BundleManifestTest(unittest.TestCase):
         entry = bundle.artifact_entry(
             "odps://prj/tables/sid", bundle.MAP_ARTIFACT, "v2", "parquet", 9, {}
         )
-        self.assertEqual(entry.type, "odps")
+        self.assertEqual(entry.save_type, "odps")
         self.assertEqual(entry.table, "sid")
         self.assertEqual(entry.partition, "artifact=item_to_sid_map/generation=v2")
         self.assertIsNone(entry.path)
@@ -119,20 +119,20 @@ class BundleManifestTest(unittest.TestCase):
         entry = bundle.artifact_entry(
             "./sid", bundle.GROUPS_ARTIFACT, "v2", "parquet", 4, {}
         )
-        self.assertEqual(entry.type, "parquet")
+        self.assertEqual(entry.save_type, "parquet")
         self.assertEqual(entry.path, "./sid/sid_to_item_groups/v2")
         self.assertIsNone(entry.table)
 
     def test_rejects_a_serving_artifact_that_is_not_parquet(self) -> None:
         payload = json.loads(_manifest().to_json())
-        payload["artifacts"][bundle.GROUPS_ARTIFACT]["type"] = "odps"
+        payload["artifacts"][bundle.GROUPS_ARTIFACT]["save_type"] = "odps"
         with self.assertRaisesRegex(ValueError, "serving set is always parquet"):
             bundle.BundleManifest.from_json(json.dumps(payload))
 
     def test_map_artifact_may_be_odps(self) -> None:
         payload = json.loads(_manifest().to_json())
         payload["artifacts"][bundle.MAP_ARTIFACT] = {
-            "type": "odps",
+            "save_type": "odps",
             "rows": 9,
             "schema": {"item_id": "int64"},
             "table": "prj.sid",

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cached_property
 from typing import Iterable, Optional
 
@@ -80,7 +80,12 @@ def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
 def lookup_sorted(
     sorted_keys: np.ndarray, keys: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Locate ``keys`` inside a strictly ascending ``sorted_keys``."""
+    """Locate ``keys`` inside an ascending ``sorted_keys``.
+
+    Returns the insertion positions and a mask of exact hits; a position is
+    meaningful only where the mask is set, and repeated keys resolve to their
+    first occurrence.
+    """
     positions = np.searchsorted(sorted_keys, keys)
     found = positions < sorted_keys.shape[0]
     found[found] = sorted_keys[positions[found]] == keys[found]
@@ -89,7 +94,13 @@ def lookup_sorted(
 
 @dataclass(frozen=True)
 class PriorOccupancy:
-    """Per-bucket occupancy of an already-published corpus."""
+    """Per-bucket occupancy of an already-published corpus.
+
+    Args:
+        bucket_keys: Occupied bucket keys, int64, strictly ascending.
+        bucket_counts: Published item count of each key, aligned with
+            ``bucket_keys``.
+    """
 
     bucket_keys: np.ndarray
     bucket_counts: np.ndarray
@@ -144,14 +155,16 @@ class CollisionPlan:
             *within* ``bucket_keys`` / ``bucket_counts`` (a row->bucket
             index in ``[0, num_buckets)``, not a key value), int64 shape
             ``(item_count,)`` in original row order.
-        initial_slot_indices: One-based rank of each row within its origin
-            bucket in deterministic (hash) order, int64 shape ``(item_count,)``
-            in original row order.
+        initial_slot_indices: One-based slot of each row within its origin
+            bucket in deterministic (hash) order, continuing the published
+            occupancy when appending; int64 shape ``(item_count,)`` in
+            original row order.
         bucket_keys: Flattened SID key ``prefix_key * last_size + last_code``
             for every occupied bucket, int64 shape ``(num_buckets,)`` indexed by
             bucket index (the values in ``origin_bucket_indices``) and ascending.
-        bucket_counts: Item count of every bucket before capacity capping,
-            int64 shape ``(num_buckets,)`` aligned with ``bucket_keys``.
+        bucket_counts: Number of this plan's rows in every bucket before
+            capacity capping, int64 shape ``(num_buckets,)`` aligned with
+            ``bucket_keys``; add ``prior_bucket_counts`` for the corpus total.
         overflow_rows: Original row indices ranked at or beyond ``capacity``
             within their bucket (the rows to relocate), int64 in deterministic
             processing order.
@@ -168,6 +181,10 @@ class CollisionPlan:
             resolve; for an append it must cover at least every bucket of every
             band touched by the planned rows, because relocation can read any
             bucket inside those bands.
+        prior_bucket_counts: Published occupancy of every bucket in
+            ``bucket_keys``, int64 aligned with it and zero where the bucket
+            is new; ``prior_bucket_counts + bucket_counts`` is a bucket's
+            uncapped total over the published corpus and these rows.
     """
 
     item_count: int
@@ -181,10 +198,8 @@ class CollisionPlan:
     overflow_bucket_key_prefixes: np.ndarray
     overflow_origin_last_codes: np.ndarray
     config: CollisionResolutionConfig
-    prior: PriorOccupancy = field(default_factory=PriorOccupancy.empty)
-    prior_bucket_counts: np.ndarray = field(
-        default_factory=lambda: np.empty(0, dtype=np.int64)
-    )
+    prior: PriorOccupancy
+    prior_bucket_counts: np.ndarray
 
 
 @dataclass(frozen=True)
@@ -365,7 +380,9 @@ class CollisionResolver(ABC):
 
         Args:
             plan: Collision plan defining original bucket keys and capacity.
-            initial_counts: Original bucket counts capped at capacity.
+            initial_counts: Corpus bucket counts before relocation -- published
+                plus new, capped at capacity but never below the prior
+                occupancy.
             in_overflow_band: Mask selecting buckets affected by relocation.
             slot_counts: Final counts for buckets in affected bands.
             collect_grouping: Whether to build sorted final bucket arrays.
@@ -934,9 +951,10 @@ def build_original_item_grouping(plan: CollisionPlan) -> CodebookItemGrouping:
 def build_resolved_item_grouping(
     plan: CollisionPlan, result: CollisionResolutionResult
 ) -> CodebookItemGrouping:
-    """Group all rows by emitted SID and final one-based slot index.
+    """Group this plan's rows by emitted SID and bucket-local slot index.
 
-    The grouping uses a linear scatter from final one-based slot indices.
+    Only buckets that gained rows appear, and slot indices have the prior
+    occupancy subtracted, so the grouping covers only this plan's rows.
 
     Args:
         plan: Grouping and overflow plan from :func:`prepare_collision_plan`.

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -62,15 +62,7 @@ class CollisionResolutionConfig:
 def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
     """Concatenate ``arange(start, start + length)`` for every aligned pair.
 
-    A vectorized replacement for a Python loop over ragged ranges. Pairs with a
-    non-positive length contribute nothing.
-
-    Args:
-        starts: First value of each range.
-        lengths: Number of values in each range, aligned with ``starts``.
-
-    Returns:
-        The concatenated ranges as one int64 array.
+    Pairs with a non-positive length contribute nothing.
     """
     starts = np.asarray(starts, dtype=np.int64)
     lengths = np.asarray(lengths, dtype=np.int64)
@@ -80,8 +72,8 @@ def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
     total = int(lengths.sum())
     if total == 0:
         return np.empty(0, dtype=np.int64)
-    # Build the result as a cumulative sum of per-position steps: 1 inside a
-    # range, and the jump to the next range's start at each boundary.
+    # Cumulative sum of per-position steps: 1 inside a range, and the jump to
+    # the next range's start at each boundary.
     steps = np.ones(total, dtype=np.int64)
     steps[0] = starts[0]
     if starts.shape[0] > 1:
@@ -95,35 +87,18 @@ def lookup_sorted(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Locate ``keys`` inside a strictly ascending ``sorted_keys``.
 
-    Args:
-        sorted_keys: Strictly ascending lookup domain.
-        keys: Keys to locate.
-
-    Returns:
-        Insertion positions aligned with ``keys``, and a boolean mask of the
-        keys actually present. Positions are only meaningful where the mask is
-        set; elsewhere they may be out of bounds.
+    Returns insertion positions and a mask of the keys actually present.
+    Positions are only meaningful where the mask is set.
     """
     positions = np.searchsorted(sorted_keys, keys)
     found = positions < sorted_keys.shape[0]
-    # Self-masking keeps the equality test to the in-bounds positions only.
+    # Self-masking keeps the equality test to in-bounds positions only.
     found[found] = sorted_keys[positions[found]] == keys[found]
     return positions, found
 
 
 def bands_of_bucket_keys(bucket_keys: np.ndarray, last_size: int) -> np.ndarray:
-    """Return the band identifier of every flattened bucket key.
-
-    Inverse of the ``band * last_size + last_code`` packing that
-    :func:`sid_bucket_keys` applies, so callers never open-code the division.
-
-    Args:
-        bucket_keys: Flattened SID keys.
-        last_size: Cardinality of the last SID layer.
-
-    Returns:
-        An int64 band identifier per key.
-    """
+    """Return the band of every bucket key, inverting :func:`sid_bucket_keys`."""
     return np.asarray(bucket_keys, dtype=np.int64) // last_size
 
 
@@ -132,17 +107,8 @@ def in_sorted_bands(
 ) -> np.ndarray:
     """Return a mask of the keys whose band appears in ``bands``.
 
-    ``bands`` must already be ascending and unique -- typically straight from
-    ``np.unique`` -- so membership is a binary search rather than the sort that
-    ``np.isin`` would perform against the whole band set on every call.
-
-    Args:
-        bucket_keys: Flattened SID keys to test.
-        bands: Ascending, unique band identifiers to keep.
-        last_size: Cardinality of the last SID layer.
-
-    Returns:
-        A boolean mask aligned with ``bucket_keys``.
+    ``bands`` must be ascending and unique, so membership is a binary search
+    rather than the whole-set sort ``np.isin`` would do on every call.
     """
     _, found = lookup_sorted(bands, bands_of_bucket_keys(bucket_keys, last_size))
     return found
@@ -152,19 +118,15 @@ def in_sorted_bands(
 class PriorOccupancy:
     """Per-bucket occupancy of an already-published corpus.
 
-    Append runs seed collision resolution with this instead of starting every
-    bucket empty, so new items continue an existing bucket's slot numbering
-    rather than colliding with published items.
+    Append seeds collision resolution with this instead of starting every
+    bucket empty, so new items continue a bucket's slot numbering.
 
     Args:
-        bucket_keys: Flattened SID keys ``prefix_key * last_size + last_code``
-            of occupied buckets, int64. Must be strictly ascending and unique;
-            the producer validates that while streaming, and ``counts_for`` and
-            ``restrict_to_bands`` both rely on it.
-        bucket_counts: Item count of every bucket, int64 and at least one,
-            aligned with ``bucket_keys``. Counts may legitimately exceed
-            capacity when a previous run left unresolved rows on their origin
-            SID.
+        bucket_keys: Occupied bucket keys, int64, strictly ascending and
+            unique. The producer validates that while streaming; both methods
+            here rely on it.
+        bucket_counts: Item count per bucket, aligned with ``bucket_keys``.
+            May exceed capacity where a previous run left unresolved rows.
     """
 
     bucket_keys: np.ndarray
@@ -186,14 +148,7 @@ class PriorOccupancy:
         return int(self.bucket_counts.sum())
 
     def counts_for(self, bucket_keys: np.ndarray) -> np.ndarray:
-        """Return prior counts aligned with ``bucket_keys``, zero when absent.
-
-        Args:
-            bucket_keys: Flattened SID keys to look up.
-
-        Returns:
-            An int64 array aligned with ``bucket_keys``.
-        """
+        """Return prior counts aligned with ``bucket_keys``, zero when absent."""
         keys = np.asarray(bucket_keys, dtype=np.int64)
         counts = np.zeros(keys.shape[0], dtype=np.int64)
         positions, found = lookup_sorted(self.bucket_keys, keys)
@@ -205,16 +160,8 @@ class PriorOccupancy:
     ) -> "PriorOccupancy":
         """Return the sub-occupancy of buckets lying in the given bands.
 
-        Every bucket of one band occupies the contiguous key range
-        ``[band * last_size, (band + 1) * last_size)``, so the selection is a
-        range gather rather than a membership test over every prior key.
-
-        Args:
-            band_ids: Band identifiers to keep; need not be sorted or unique.
-            last_size: Cardinality of the last SID layer.
-
-        Returns:
-            A new occupancy holding only buckets in ``band_ids``.
+        One band owns the contiguous key range ``[band * S, (band + 1) * S)``,
+        so this is a range gather, not a membership test over every prior key.
         """
         bands = np.unique(np.asarray(band_ids, dtype=np.int64))
         if self.is_empty or bands.size == 0:
@@ -427,8 +374,6 @@ class CollisionResolver(ABC):
         Returns:
             A collision result that preserves the original assignments.
         """
-        # Without overflow every planned bucket simply gains its new rows, so
-        # the final occupancy is the prior plus this plan's counts.
         final_counts = plan.prior_bucket_counts + plan.bucket_counts
         final_bucket_keys = (
             plan.bucket_keys.copy() if collect_grouping else np.empty(0, dtype=np.int64)
@@ -536,10 +481,8 @@ class CollisionResolver(ABC):
         last_size = plan.config.layer_sizes[-1]
         capacity = plan.config.capacity
         prior_counts = plan.prior_bucket_counts
-        # Occupancy after this plan's overflow rows are logically removed. The
-        # outer maximum keeps a bucket that a previous run already left over
-        # capacity at its true count -- capping it there would re-issue slot
-        # indices that published items already hold.
+        # The outer maximum matters: a bucket a previous run left over capacity
+        # keeps its true count, else it would re-issue published slot indices.
         initial_counts = np.maximum(
             prior_counts, np.minimum(prior_counts + plan.bucket_counts, capacity)
         )
@@ -549,9 +492,8 @@ class CollisionResolver(ABC):
         in_overflow_band = in_sorted_bands(
             plan.bucket_keys, overflow_band_ids, last_size
         )
-        # Seed prior-only buckets first: placement treats a missing key as an
-        # empty bucket, so an existing bucket that received no new row must be
-        # visible or it would be overfilled past capacity.
+        # Placement treats a missing key as an empty bucket, so a prior-only
+        # bucket must be seeded or it would be overfilled past capacity.
         band_prior = plan.prior.restrict_to_bands(overflow_band_ids, last_size)
         slot_counts = dict(
             zip(band_prior.bucket_keys.tolist(), band_prior.bucket_counts.tolist())
@@ -811,31 +753,12 @@ def _band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
 
 
 def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
-    """Return the mixed-radix prefix key of every SID row.
-
-    Args:
-        codes: Integer SID matrix with shape ``(N, len(layer_sizes))``.
-        layer_sizes: Cardinality of each SID layer.
-
-    Returns:
-        An int64 band identifier per row; all zeros for a single-layer SID.
-    """
+    """Return the mixed-radix prefix key of every SID row (zeros if one layer)."""
     return _band_ids(np.asarray(codes), layer_sizes)
 
 
 def sid_bucket_keys(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
-    """Return the flattened bucket key of every SID row.
-
-    The key is ``band_id * layer_sizes[-1] + last_code``, matching the keys
-    stored in :class:`CollisionPlan` and :class:`PriorOccupancy`.
-
-    Args:
-        codes: Integer SID matrix with shape ``(N, len(layer_sizes))``.
-        layer_sizes: Cardinality of each SID layer.
-
-    Returns:
-        An int64 bucket key per row.
-    """
+    """Return ``band_id * layer_sizes[-1] + last_code`` for every SID row."""
     codes = np.asarray(codes)
     return _band_ids(codes, layer_sizes) * layer_sizes[-1] + codes[:, -1].astype(
         np.int64, copy=False
@@ -965,13 +888,10 @@ def prepare_collision_plan(
         band_ids[representative_rows] * last_size
         + original_last_codes[representative_rows]
     )
-    # A row overflows once the items already in its bucket -- published plus
-    # better-ranked rows of this plan -- reach capacity.
     row_prior_counts = prior.counts_for(bucket_keys)[origin_bucket_indices]
     overflow_rows = sorted_rows[
         (row_prior_counts + bucket_ranks)[sorted_rows] >= config.capacity
     ]
-    # Turn 0-based ranks into 1-based slots that continue past the prior items.
     bucket_ranks += row_prior_counts + 1
     overflow_bucket_key_prefixes = band_ids[overflow_rows] * last_size
 
@@ -1085,9 +1005,6 @@ def build_resolved_item_grouping(
             "with collect_grouping=True."
         )
 
-    # ``result`` carries corpus-wide occupancy. Subtracting the prior turns it
-    # back into this plan's own rows: buckets that gained nothing drop out, and
-    # global slot indices become dense 1..count within each remaining bucket.
     final_prior_counts = plan.prior.counts_for(result.final_bucket_keys)
     delta_counts = result.final_bucket_counts - final_prior_counts
     gained = delta_counts > 0

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -436,9 +436,8 @@ class CollisionResolver(ABC):
         last_size = plan.config.layer_sizes[-1]
         capacity = plan.config.capacity
         prior_counts = plan.prior_bucket_counts
-        initial_counts = np.maximum(
-            prior_counts, np.minimum(prior_counts + plan.bucket_counts, capacity)
-        )
+        combined_counts = prior_counts + plan.bucket_counts
+        initial_counts = np.maximum(prior_counts, np.minimum(combined_counts, capacity))
         # Relocation only reads or writes buckets in a band with an overflow
         # row. Every other bucket keeps its capped initial count untouched.
         overflow_band_ids = np.unique(plan.overflow_bucket_key_prefixes // last_size)
@@ -512,9 +511,7 @@ class CollisionResolver(ABC):
         unresolved_array = np.asarray(unresolved_rows, dtype=np.int64)
         stats = CollisionResolutionStats(
             total_items=plan.item_count,
-            raw_collision_buckets=int(
-                ((prior_counts + plan.bucket_counts) > capacity).sum()
-            ),
+            raw_collision_buckets=int((combined_counts > capacity).sum()),
             final_collision_buckets=final_collision_buckets,
             relocated_count=relocated_count,
             unresolved_count=len(unresolved_rows),
@@ -842,11 +839,10 @@ def prepare_collision_plan(
         band_ids[representative_rows] * last_size
         + original_last_codes[representative_rows]
     )
-    row_prior_counts = prior.counts_for(bucket_keys)[origin_bucket_indices]
-    overflow_rows = sorted_rows[
-        (row_prior_counts + bucket_ranks)[sorted_rows] >= config.capacity
-    ]
-    bucket_ranks += row_prior_counts + 1
+    if not prior.is_empty:
+        bucket_ranks += prior.counts_for(bucket_keys)[origin_bucket_indices]
+    overflow_rows = sorted_rows[bucket_ranks[sorted_rows] >= config.capacity]
+    bucket_ranks += 1
     overflow_bucket_key_prefixes = band_ids[overflow_rows] * last_size
 
     return CollisionPlan(

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -728,6 +728,19 @@ def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
     return keys
 
 
+def sid_offset_codes(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
+    """Shift each layer's codes into one contiguous vocabulary.
+
+    Layer ``i`` is offset by ``sum(layer_sizes[:i])``, so codes from different
+    layers never collide: ``[1, 2, 3]`` under ``(64, 64, 64)`` becomes
+    ``[1, 66, 131]``.
+    """
+    starts = np.concatenate(
+        ([0], np.cumsum(np.asarray(layer_sizes[:-1], dtype=np.int64)))
+    )
+    return np.asarray(codes) + starts
+
+
 def sid_bucket_keys(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
     """Return ``band_id * layer_sizes[-1] + last_code`` for every SID row."""
     codes = np.asarray(codes)

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -182,11 +182,9 @@ class CollisionPlan:
     overflow_origin_last_codes: np.ndarray
     config: CollisionResolutionConfig
     prior: PriorOccupancy = field(default_factory=PriorOccupancy.empty)
-
-    @cached_property
-    def prior_bucket_counts(self) -> np.ndarray:
-        """Prior occupancy of every planned bucket, aligned with bucket_keys."""
-        return self.prior.counts_for(self.bucket_keys)
+    prior_bucket_counts: np.ndarray = field(
+        default_factory=lambda: np.empty(0, dtype=np.int64)
+    )
 
 
 @dataclass(frozen=True)
@@ -839,8 +837,9 @@ def prepare_collision_plan(
         band_ids[representative_rows] * last_size
         + original_last_codes[representative_rows]
     )
+    prior_bucket_counts = prior.counts_for(bucket_keys)
     if not prior.is_empty:
-        bucket_ranks += prior.counts_for(bucket_keys)[origin_bucket_indices]
+        bucket_ranks += prior_bucket_counts[origin_bucket_indices]
     overflow_rows = sorted_rows[bucket_ranks[sorted_rows] >= config.capacity]
     bucket_ranks += 1
     overflow_bucket_key_prefixes = band_ids[overflow_rows] * last_size
@@ -858,6 +857,7 @@ def prepare_collision_plan(
         overflow_origin_last_codes=original_last_codes[overflow_rows],
         config=config,
         prior=prior,
+        prior_bucket_counts=prior_bucket_counts,
     )
 
 
@@ -965,17 +965,17 @@ def build_resolved_item_grouping(
     def row_chunks() -> Iterable[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         for start in range(0, plan.item_count, _ROW_CHUNK_SIZE):
             end = min(start + _ROW_CHUNK_SIZE, plan.item_count)
-            rows = np.arange(start, end, dtype=np.int64)
-            emitted_sid_keys = plan.bucket_keys[plan.origin_bucket_indices[rows]]
-            emitted_sid_keys -= plan.original_last_codes[rows]
-            emitted_sid_keys += result.resolved_last_codes[rows]
+            chunk = slice(start, end)
+            emitted_sid_keys = plan.bucket_keys[plan.origin_bucket_indices[chunk]]
+            emitted_sid_keys -= plan.original_last_codes[chunk]
+            emitted_sid_keys += result.resolved_last_codes[chunk]
             bucket_ids, found = lookup_sorted(sid_keys, emitted_sid_keys)
             if not np.all(found):
                 raise RuntimeError("final bucket keys do not cover every emitted SID.")
             yield (
-                rows,
+                np.arange(start, end, dtype=np.int64),
                 bucket_ids,
-                result.slot_indices[rows] - prior_counts[bucket_ids],
+                result.slot_indices[chunk] - prior_counts[bucket_ids],
             )
 
     return _scatter_item_grouping(sid_keys, counts, plan.item_count, row_chunks())

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -104,11 +104,6 @@ class PriorOccupancy:
         """Whether no bucket is occupied."""
         return self.bucket_keys.shape[0] == 0
 
-    @cached_property
-    def total_items(self) -> int:
-        """Total number of already-published items."""
-        return int(self.bucket_counts.sum())
-
     def counts_for(self, bucket_keys: np.ndarray) -> np.ndarray:
         """Return prior counts aligned with ``bucket_keys``, zero when absent."""
         keys = np.asarray(bucket_keys, dtype=np.int64)

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -60,10 +60,7 @@ class CollisionResolutionConfig:
 
 
 def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
-    """Concatenate ``arange(start, start + length)`` for every aligned pair.
-
-    Pairs with a non-positive length contribute nothing.
-    """
+    """Concatenate ``arange(start, start + length)`` for every aligned pair."""
     starts = np.asarray(starts, dtype=np.int64)
     lengths = np.asarray(lengths, dtype=np.int64)
     keep = lengths > 0
@@ -83,11 +80,7 @@ def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
 def lookup_sorted(
     sorted_keys: np.ndarray, keys: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Locate ``keys`` inside a strictly ascending ``sorted_keys``.
-
-    Returns insertion positions and a mask of the keys actually present.
-    Positions are only meaningful where the mask is set.
-    """
+    """Locate ``keys`` inside a strictly ascending ``sorted_keys``."""
     positions = np.searchsorted(sorted_keys, keys)
     found = positions < sorted_keys.shape[0]
     found[found] = sorted_keys[positions[found]] == keys[found]
@@ -96,18 +89,7 @@ def lookup_sorted(
 
 @dataclass(frozen=True)
 class PriorOccupancy:
-    """Per-bucket occupancy of an already-published corpus.
-
-    Append seeds collision resolution with this instead of starting every
-    bucket empty, so new items continue a bucket's slot numbering.
-
-    Args:
-        bucket_keys: Occupied bucket keys, int64, strictly ascending and
-            unique. The producer validates that while streaming; both methods
-            here rely on it.
-        bucket_counts: Item count per bucket, aligned with ``bucket_keys``.
-            May exceed capacity where a previous run left unresolved rows.
-    """
+    """Per-bucket occupancy of an already-published corpus."""
 
     bucket_keys: np.ndarray
     bucket_counts: np.ndarray
@@ -144,8 +126,6 @@ class PriorOccupancy:
         so this is a range gather, not a membership test over every prior key.
         """
         bands = np.unique(np.asarray(band_ids, dtype=np.int64))
-        if self.is_empty or bands.size == 0:
-            return PriorOccupancy.empty()
         starts = np.searchsorted(self.bucket_keys, bands * last_size, side="left")
         stops = np.searchsorted(self.bucket_keys, (bands + 1) * last_size, side="left")
         selected = concat_ranges(starts, stops - starts)
@@ -359,7 +339,7 @@ class CollisionResolver(ABC):
             plan.bucket_keys.copy() if collect_grouping else np.empty(0, dtype=np.int64)
         )
         final_bucket_counts = (
-            final_counts.copy() if collect_grouping else np.empty(0, dtype=np.int64)
+            final_counts if collect_grouping else np.empty(0, dtype=np.int64)
         )
         max_final_bucket_size = int(final_counts.max()) if final_counts.size else 0
         stats = CollisionResolutionStats(
@@ -729,12 +709,7 @@ def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
 
 
 def sid_offset_codes(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
-    """Shift each layer's codes into one contiguous vocabulary.
-
-    Layer ``i`` is offset by ``sum(layer_sizes[:i])``, so codes from different
-    layers never collide: ``[1, 2, 3]`` under ``(64, 64, 64)`` becomes
-    ``[1, 66, 131]``.
-    """
+    """Shift each layer's codes into one contiguous vocabulary."""
     starts = np.concatenate(
         ([0], np.cumsum(np.asarray(layer_sizes[:-1], dtype=np.int64)))
     )

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -72,8 +72,6 @@ def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
     total = int(lengths.sum())
     if total == 0:
         return np.empty(0, dtype=np.int64)
-    # Cumulative sum of per-position steps: 1 inside a range, and the jump to
-    # the next range's start at each boundary.
     steps = np.ones(total, dtype=np.int64)
     steps[0] = starts[0]
     if starts.shape[0] > 1:
@@ -92,26 +90,8 @@ def lookup_sorted(
     """
     positions = np.searchsorted(sorted_keys, keys)
     found = positions < sorted_keys.shape[0]
-    # Self-masking keeps the equality test to in-bounds positions only.
     found[found] = sorted_keys[positions[found]] == keys[found]
     return positions, found
-
-
-def bands_of_bucket_keys(bucket_keys: np.ndarray, last_size: int) -> np.ndarray:
-    """Return the band of every bucket key, inverting :func:`sid_bucket_keys`."""
-    return np.asarray(bucket_keys, dtype=np.int64) // last_size
-
-
-def in_sorted_bands(
-    bucket_keys: np.ndarray, bands: np.ndarray, last_size: int
-) -> np.ndarray:
-    """Return a mask of the keys whose band appears in ``bands``.
-
-    ``bands`` must be ascending and unique, so membership is a binary search
-    rather than the whole-set sort ``np.isin`` would do on every call.
-    """
-    _, found = lookup_sorted(bands, bands_of_bucket_keys(bucket_keys, last_size))
-    return found
 
 
 @dataclass(frozen=True)
@@ -481,19 +461,15 @@ class CollisionResolver(ABC):
         last_size = plan.config.layer_sizes[-1]
         capacity = plan.config.capacity
         prior_counts = plan.prior_bucket_counts
-        # The outer maximum matters: a bucket a previous run left over capacity
-        # keeps its true count, else it would re-issue published slot indices.
         initial_counts = np.maximum(
             prior_counts, np.minimum(prior_counts + plan.bucket_counts, capacity)
         )
         # Relocation only reads or writes buckets in a band with an overflow
         # row. Every other bucket keeps its capped initial count untouched.
         overflow_band_ids = np.unique(plan.overflow_bucket_key_prefixes // last_size)
-        in_overflow_band = in_sorted_bands(
-            plan.bucket_keys, overflow_band_ids, last_size
+        _, in_overflow_band = lookup_sorted(
+            overflow_band_ids, plan.bucket_keys // last_size
         )
-        # Placement treats a missing key as an empty bucket, so a prior-only
-        # bucket must be seeded or it would be overfilled past capacity.
         band_prior = plan.prior.restrict_to_bands(overflow_band_ids, last_size)
         slot_counts = dict(
             zip(band_prior.bucket_keys.tolist(), band_prior.bucket_counts.tolist())
@@ -740,8 +716,8 @@ def stable_order_hash(item_ids: np.ndarray) -> np.ndarray:
     return _splitmix64(base)
 
 
-def _band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
-    """Return the mixed-radix prefix key for each row."""
+def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
+    """Return the mixed-radix prefix key of every SID row (zeros if one layer)."""
     row_count, layer_count = codes.shape
     if layer_count == 1:
         return np.zeros(row_count, dtype=np.int64)
@@ -752,15 +728,10 @@ def _band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
     return keys
 
 
-def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
-    """Return the mixed-radix prefix key of every SID row (zeros if one layer)."""
-    return _band_ids(np.asarray(codes), layer_sizes)
-
-
 def sid_bucket_keys(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
     """Return ``band_id * layer_sizes[-1] + last_code`` for every SID row."""
     codes = np.asarray(codes)
-    return _band_ids(codes, layer_sizes) * layer_sizes[-1] + codes[:, -1].astype(
+    return sid_band_ids(codes, layer_sizes) * layer_sizes[-1] + codes[:, -1].astype(
         np.int64, copy=False
     )
 
@@ -873,7 +844,7 @@ def prepare_collision_plan(
             )
 
     original_last_codes = codes[:, -1].astype(np.int64, copy=False)
-    band_ids = _band_ids(codes, config.layer_sizes)
+    band_ids = sid_band_ids(codes, config.layer_sizes)
     order_hashes = stable_order_hash(item_ids)
     (
         bucket_ranks,

--- a/tzrec/utils/sid/collision.py
+++ b/tzrec/utils/sid/collision.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Iterable, Optional
 
@@ -59,6 +59,172 @@ class CollisionResolutionConfig:
             )
 
 
+def concat_ranges(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
+    """Concatenate ``arange(start, start + length)`` for every aligned pair.
+
+    A vectorized replacement for a Python loop over ragged ranges. Pairs with a
+    non-positive length contribute nothing.
+
+    Args:
+        starts: First value of each range.
+        lengths: Number of values in each range, aligned with ``starts``.
+
+    Returns:
+        The concatenated ranges as one int64 array.
+    """
+    starts = np.asarray(starts, dtype=np.int64)
+    lengths = np.asarray(lengths, dtype=np.int64)
+    keep = lengths > 0
+    starts = starts[keep]
+    lengths = lengths[keep]
+    total = int(lengths.sum())
+    if total == 0:
+        return np.empty(0, dtype=np.int64)
+    # Build the result as a cumulative sum of per-position steps: 1 inside a
+    # range, and the jump to the next range's start at each boundary.
+    steps = np.ones(total, dtype=np.int64)
+    steps[0] = starts[0]
+    if starts.shape[0] > 1:
+        boundaries = np.cumsum(lengths)[:-1]
+        steps[boundaries] = starts[1:] - (starts[:-1] + lengths[:-1]) + 1
+    return np.cumsum(steps)
+
+
+def lookup_sorted(
+    sorted_keys: np.ndarray, keys: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Locate ``keys`` inside a strictly ascending ``sorted_keys``.
+
+    Args:
+        sorted_keys: Strictly ascending lookup domain.
+        keys: Keys to locate.
+
+    Returns:
+        Insertion positions aligned with ``keys``, and a boolean mask of the
+        keys actually present. Positions are only meaningful where the mask is
+        set; elsewhere they may be out of bounds.
+    """
+    positions = np.searchsorted(sorted_keys, keys)
+    found = positions < sorted_keys.shape[0]
+    # Self-masking keeps the equality test to the in-bounds positions only.
+    found[found] = sorted_keys[positions[found]] == keys[found]
+    return positions, found
+
+
+def bands_of_bucket_keys(bucket_keys: np.ndarray, last_size: int) -> np.ndarray:
+    """Return the band identifier of every flattened bucket key.
+
+    Inverse of the ``band * last_size + last_code`` packing that
+    :func:`sid_bucket_keys` applies, so callers never open-code the division.
+
+    Args:
+        bucket_keys: Flattened SID keys.
+        last_size: Cardinality of the last SID layer.
+
+    Returns:
+        An int64 band identifier per key.
+    """
+    return np.asarray(bucket_keys, dtype=np.int64) // last_size
+
+
+def in_sorted_bands(
+    bucket_keys: np.ndarray, bands: np.ndarray, last_size: int
+) -> np.ndarray:
+    """Return a mask of the keys whose band appears in ``bands``.
+
+    ``bands`` must already be ascending and unique -- typically straight from
+    ``np.unique`` -- so membership is a binary search rather than the sort that
+    ``np.isin`` would perform against the whole band set on every call.
+
+    Args:
+        bucket_keys: Flattened SID keys to test.
+        bands: Ascending, unique band identifiers to keep.
+        last_size: Cardinality of the last SID layer.
+
+    Returns:
+        A boolean mask aligned with ``bucket_keys``.
+    """
+    _, found = lookup_sorted(bands, bands_of_bucket_keys(bucket_keys, last_size))
+    return found
+
+
+@dataclass(frozen=True)
+class PriorOccupancy:
+    """Per-bucket occupancy of an already-published corpus.
+
+    Append runs seed collision resolution with this instead of starting every
+    bucket empty, so new items continue an existing bucket's slot numbering
+    rather than colliding with published items.
+
+    Args:
+        bucket_keys: Flattened SID keys ``prefix_key * last_size + last_code``
+            of occupied buckets, int64. Must be strictly ascending and unique;
+            the producer validates that while streaming, and ``counts_for`` and
+            ``restrict_to_bands`` both rely on it.
+        bucket_counts: Item count of every bucket, int64 and at least one,
+            aligned with ``bucket_keys``. Counts may legitimately exceed
+            capacity when a previous run left unresolved rows on their origin
+            SID.
+    """
+
+    bucket_keys: np.ndarray
+    bucket_counts: np.ndarray
+
+    @classmethod
+    def empty(cls) -> "PriorOccupancy":
+        """Return the occupancy of a corpus with no published items."""
+        return cls(np.empty(0, dtype=np.int64), np.empty(0, dtype=np.int64))
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether no bucket is occupied."""
+        return self.bucket_keys.shape[0] == 0
+
+    @cached_property
+    def total_items(self) -> int:
+        """Total number of already-published items."""
+        return int(self.bucket_counts.sum())
+
+    def counts_for(self, bucket_keys: np.ndarray) -> np.ndarray:
+        """Return prior counts aligned with ``bucket_keys``, zero when absent.
+
+        Args:
+            bucket_keys: Flattened SID keys to look up.
+
+        Returns:
+            An int64 array aligned with ``bucket_keys``.
+        """
+        keys = np.asarray(bucket_keys, dtype=np.int64)
+        counts = np.zeros(keys.shape[0], dtype=np.int64)
+        positions, found = lookup_sorted(self.bucket_keys, keys)
+        counts[found] = self.bucket_counts[positions[found]]
+        return counts
+
+    def restrict_to_bands(
+        self, band_ids: np.ndarray, last_size: int
+    ) -> "PriorOccupancy":
+        """Return the sub-occupancy of buckets lying in the given bands.
+
+        Every bucket of one band occupies the contiguous key range
+        ``[band * last_size, (band + 1) * last_size)``, so the selection is a
+        range gather rather than a membership test over every prior key.
+
+        Args:
+            band_ids: Band identifiers to keep; need not be sorted or unique.
+            last_size: Cardinality of the last SID layer.
+
+        Returns:
+            A new occupancy holding only buckets in ``band_ids``.
+        """
+        bands = np.unique(np.asarray(band_ids, dtype=np.int64))
+        if self.is_empty or bands.size == 0:
+            return PriorOccupancy.empty()
+        starts = np.searchsorted(self.bucket_keys, bands * last_size, side="left")
+        stops = np.searchsorted(self.bucket_keys, (bands + 1) * last_size, side="left")
+        selected = concat_ranges(starts, stops - starts)
+        return PriorOccupancy(self.bucket_keys[selected], self.bucket_counts[selected])
+
+
 @dataclass(frozen=True)
 class CollisionPlan:
     """Compact grouping plan consumed by collision resolution.
@@ -96,6 +262,10 @@ class CollisionPlan:
             (used to skip a candidate equal to the origin), int64 aligned with
             ``overflow_rows``.
         config: Collision capacity and SID shape configuration.
+        prior: Occupancy of the already-published corpus. Empty for a full
+            resolve; for an append it must cover at least every bucket of every
+            band touched by the planned rows, because relocation can read any
+            bucket inside those bands.
     """
 
     item_count: int
@@ -109,6 +279,12 @@ class CollisionPlan:
     overflow_bucket_key_prefixes: np.ndarray
     overflow_origin_last_codes: np.ndarray
     config: CollisionResolutionConfig
+    prior: PriorOccupancy = field(default_factory=PriorOccupancy.empty)
+
+    @cached_property
+    def prior_bucket_counts(self) -> np.ndarray:
+        """Prior occupancy of every planned bucket, aligned with bucket_keys."""
+        return self.prior.counts_for(self.bucket_keys)
 
 
 @dataclass(frozen=True)
@@ -251,17 +427,16 @@ class CollisionResolver(ABC):
         Returns:
             A collision result that preserves the original assignments.
         """
+        # Without overflow every planned bucket simply gains its new rows, so
+        # the final occupancy is the prior plus this plan's counts.
+        final_counts = plan.prior_bucket_counts + plan.bucket_counts
         final_bucket_keys = (
             plan.bucket_keys.copy() if collect_grouping else np.empty(0, dtype=np.int64)
         )
         final_bucket_counts = (
-            plan.bucket_counts.copy()
-            if collect_grouping
-            else np.empty(0, dtype=np.int64)
+            final_counts.copy() if collect_grouping else np.empty(0, dtype=np.int64)
         )
-        max_final_bucket_size = (
-            int(plan.bucket_counts.max()) if plan.bucket_counts.size else 0
-        )
+        max_final_bucket_size = int(final_counts.max()) if final_counts.size else 0
         stats = CollisionResolutionStats(
             total_items=plan.item_count,
             raw_collision_buckets=0,
@@ -360,12 +535,28 @@ class CollisionResolver(ABC):
 
         last_size = plan.config.layer_sizes[-1]
         capacity = plan.config.capacity
-        initial_counts = np.minimum(plan.bucket_counts, capacity)
+        prior_counts = plan.prior_bucket_counts
+        # Occupancy after this plan's overflow rows are logically removed. The
+        # outer maximum keeps a bucket that a previous run already left over
+        # capacity at its true count -- capping it there would re-issue slot
+        # indices that published items already hold.
+        initial_counts = np.maximum(
+            prior_counts, np.minimum(prior_counts + plan.bucket_counts, capacity)
+        )
         # Relocation only reads or writes buckets in a band with an overflow
         # row. Every other bucket keeps its capped initial count untouched.
-        overflow_band_ids = plan.overflow_bucket_key_prefixes // last_size
-        in_overflow_band = np.isin(plan.bucket_keys // last_size, overflow_band_ids)
+        overflow_band_ids = np.unique(plan.overflow_bucket_key_prefixes // last_size)
+        in_overflow_band = in_sorted_bands(
+            plan.bucket_keys, overflow_band_ids, last_size
+        )
+        # Seed prior-only buckets first: placement treats a missing key as an
+        # empty bucket, so an existing bucket that received no new row must be
+        # visible or it would be overfilled past capacity.
+        band_prior = plan.prior.restrict_to_bands(overflow_band_ids, last_size)
         slot_counts = dict(
+            zip(band_prior.bucket_keys.tolist(), band_prior.bucket_counts.tolist())
+        )
+        slot_counts.update(
             zip(
                 plan.bucket_keys[in_overflow_band].tolist(),
                 initial_counts[in_overflow_band].tolist(),
@@ -428,7 +619,9 @@ class CollisionResolver(ABC):
         unresolved_array = np.asarray(unresolved_rows, dtype=np.int64)
         stats = CollisionResolutionStats(
             total_items=plan.item_count,
-            raw_collision_buckets=int((plan.bucket_counts > capacity).sum()),
+            raw_collision_buckets=int(
+                ((prior_counts + plan.bucket_counts) > capacity).sum()
+            ),
             final_collision_buckets=final_collision_buckets,
             relocated_count=relocated_count,
             unresolved_count=len(unresolved_rows),
@@ -617,6 +810,38 @@ def _band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
     return keys
 
 
+def sid_band_ids(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
+    """Return the mixed-radix prefix key of every SID row.
+
+    Args:
+        codes: Integer SID matrix with shape ``(N, len(layer_sizes))``.
+        layer_sizes: Cardinality of each SID layer.
+
+    Returns:
+        An int64 band identifier per row; all zeros for a single-layer SID.
+    """
+    return _band_ids(np.asarray(codes), layer_sizes)
+
+
+def sid_bucket_keys(codes: np.ndarray, layer_sizes: tuple[int, ...]) -> np.ndarray:
+    """Return the flattened bucket key of every SID row.
+
+    The key is ``band_id * layer_sizes[-1] + last_code``, matching the keys
+    stored in :class:`CollisionPlan` and :class:`PriorOccupancy`.
+
+    Args:
+        codes: Integer SID matrix with shape ``(N, len(layer_sizes))``.
+        layer_sizes: Cardinality of each SID layer.
+
+    Returns:
+        An int64 bucket key per row.
+    """
+    codes = np.asarray(codes)
+    return _band_ids(codes, layer_sizes) * layer_sizes[-1] + codes[:, -1].astype(
+        np.int64, copy=False
+    )
+
+
 def _within_bucket_rank(
     band_ids: np.ndarray, last_codes: np.ndarray, order_hashes: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -662,20 +887,33 @@ def prepare_collision_plan(
     item_ids: np.ndarray,
     codes: np.ndarray,
     config: CollisionResolutionConfig,
+    prior: Optional[PriorOccupancy] = None,
 ) -> CollisionPlan:
     """Group SID buckets and identify overflow rows in stable processing order.
+
+    With a ``prior``, the rows are treated as an append onto an existing
+    corpus: a bucket already holding ``P`` items admits only ``capacity - P``
+    more, and retained rows are numbered from ``P + 1`` so they continue the
+    published slot sequence instead of restarting at one. Published items are
+    never rows here, which is what makes them impossible to move.
 
     Args:
         item_ids: One-dimensional item IDs aligned with ``codes``.
         codes: Integer SID matrix with shape ``(N, number_of_layers)``.
         config: Collision capacity and SID shape configuration.
+        prior: Occupancy of the already-published corpus, or ``None`` for a
+            full resolve. It must cover every bucket of every band these rows
+            touch, because relocation can address any bucket inside a band.
 
     Returns:
         A compact plan for candidate loading and collision resolution.
 
     Raises:
-        ValueError: If input dimensions, row counts, or layer counts disagree.
+        ValueError: If input dimensions, row counts, or layer counts disagree,
+            or if prior bucket keys fall outside the configured key space.
     """
+    if prior is None:
+        prior = PriorOccupancy.empty()
     item_ids = np.asarray(item_ids)
     codes = np.asarray(codes)
     if item_ids.ndim != 1:
@@ -702,6 +940,15 @@ def prepare_collision_plan(
             "produced the SID table."
         )
 
+    if not prior.is_empty:
+        key_space = math.prod(config.layer_sizes)
+        if int(prior.bucket_keys[0]) < 0 or int(prior.bucket_keys[-1]) >= key_space:
+            raise ValueError(
+                "prior bucket keys fall outside the key space of layer_sizes "
+                f"{config.layer_sizes}; check that --codebook matches the run "
+                "that produced the existing SID artifacts."
+            )
+
     original_last_codes = codes[:, -1].astype(np.int64, copy=False)
     band_ids = _band_ids(codes, config.layer_sizes)
     order_hashes = stable_order_hash(item_ids)
@@ -713,13 +960,19 @@ def prepare_collision_plan(
         bucket_counts,
     ) = _within_bucket_rank(band_ids, original_last_codes, order_hashes)
 
-    overflow_rows = sorted_rows[bucket_ranks[sorted_rows] >= config.capacity]
-    bucket_ranks += 1
     last_size = config.layer_sizes[-1]
     bucket_keys = (
         band_ids[representative_rows] * last_size
         + original_last_codes[representative_rows]
     )
+    # A row overflows once the items already in its bucket -- published plus
+    # better-ranked rows of this plan -- reach capacity.
+    row_prior_counts = prior.counts_for(bucket_keys)[origin_bucket_indices]
+    overflow_rows = sorted_rows[
+        (row_prior_counts + bucket_ranks)[sorted_rows] >= config.capacity
+    ]
+    # Turn 0-based ranks into 1-based slots that continue past the prior items.
+    bucket_ranks += row_prior_counts + 1
     overflow_bucket_key_prefixes = band_ids[overflow_rows] * last_size
 
     return CollisionPlan(
@@ -734,6 +987,7 @@ def prepare_collision_plan(
         overflow_bucket_key_prefixes=overflow_bucket_key_prefixes,
         overflow_origin_last_codes=original_last_codes[overflow_rows],
         config=config,
+        prior=prior,
     )
 
 
@@ -778,20 +1032,25 @@ def _scatter_item_grouping(
 def build_original_item_grouping(plan: CollisionPlan) -> CodebookItemGrouping:
     """Group all original rows by SID and initial one-based slot index.
 
+    Slot indices are made bucket-local by subtracting the prior occupancy, so
+    the grouping covers only this plan's rows even when appending to a corpus.
+
     Args:
         plan: Grouping and overflow plan from :func:`prepare_collision_plan`.
 
     Returns:
         Sorted original SID keys, bucket counts, and grouped original row order.
     """
+    prior_bucket_counts = plan.prior_bucket_counts
 
     def row_chunks() -> Iterable[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         for start in range(0, plan.item_count, _ROW_CHUNK_SIZE):
             end = min(start + _ROW_CHUNK_SIZE, plan.item_count)
+            bucket_ids = plan.origin_bucket_indices[start:end]
             yield (
                 np.arange(start, end, dtype=np.int64),
-                plan.origin_bucket_indices[start:end],
-                plan.initial_slot_indices[start:end],
+                bucket_ids,
+                plan.initial_slot_indices[start:end] - prior_bucket_counts[bucket_ids],
             )
 
     return _scatter_item_grouping(
@@ -826,6 +1085,16 @@ def build_resolved_item_grouping(
             "with collect_grouping=True."
         )
 
+    # ``result`` carries corpus-wide occupancy. Subtracting the prior turns it
+    # back into this plan's own rows: buckets that gained nothing drop out, and
+    # global slot indices become dense 1..count within each remaining bucket.
+    final_prior_counts = plan.prior.counts_for(result.final_bucket_keys)
+    delta_counts = result.final_bucket_counts - final_prior_counts
+    gained = delta_counts > 0
+    sid_keys = result.final_bucket_keys[gained]
+    counts = delta_counts[gained]
+    prior_counts = final_prior_counts[gained]
+
     def row_chunks() -> Iterable[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         for start in range(0, plan.item_count, _ROW_CHUNK_SIZE):
             end = min(start + _ROW_CHUNK_SIZE, plan.item_count)
@@ -833,17 +1102,13 @@ def build_resolved_item_grouping(
             emitted_sid_keys = plan.bucket_keys[plan.origin_bucket_indices[rows]]
             emitted_sid_keys -= plan.original_last_codes[rows]
             emitted_sid_keys += result.resolved_last_codes[rows]
-            bucket_ids = np.searchsorted(result.final_bucket_keys, emitted_sid_keys)
-            in_bounds = bucket_ids < result.final_bucket_keys.shape[0]
-            if not np.all(in_bounds) or not np.all(
-                result.final_bucket_keys[bucket_ids] == emitted_sid_keys
-            ):
+            bucket_ids, found = lookup_sorted(sid_keys, emitted_sid_keys)
+            if not np.all(found):
                 raise RuntimeError("final bucket keys do not cover every emitted SID.")
-            yield rows, bucket_ids, result.slot_indices[rows]
+            yield (
+                rows,
+                bucket_ids,
+                result.slot_indices[rows] - prior_counts[bucket_ids],
+            )
 
-    return _scatter_item_grouping(
-        result.final_bucket_keys,
-        result.final_bucket_counts,
-        plan.item_count,
-        row_chunks(),
-    )
+    return _scatter_item_grouping(sid_keys, counts, plan.item_count, row_chunks())

--- a/tzrec/utils/sid/collision_test.py
+++ b/tzrec/utils/sid/collision_test.py
@@ -27,6 +27,7 @@ from tzrec.utils.sid.collision import (
     concat_ranges,
     prepare_collision_plan,
     sid_bucket_keys,
+    sid_offset_codes,
 )
 from tzrec.utils.test_util import parameterized_name_func
 
@@ -515,6 +516,38 @@ class ConcatRangesTest(unittest.TestCase):
         np.testing.assert_array_equal(concat_ranges([5, 10, 20], [2, 0, 1]), [5, 6, 20])
         self.assertEqual(concat_ranges([3], [0]).shape, (0,))
         self.assertEqual(concat_ranges([], []).shape, (0,))
+
+
+class SidOffsetCodesTest(unittest.TestCase):
+    def test_shifts_each_layer_by_the_preceding_sizes(self) -> None:
+        np.testing.assert_array_equal(
+            sid_offset_codes(np.asarray([[1, 2, 3]]), (64, 64, 64)), [[1, 66, 131]]
+        )
+
+    def test_supports_non_uniform_codebooks(self) -> None:
+        # offsets are 0, 4, 4 + 8
+        np.testing.assert_array_equal(
+            sid_offset_codes(np.asarray([[1, 2, 3]]), (4, 8, 16)), [[1, 6, 15]]
+        )
+
+    def test_single_layer_is_unchanged(self) -> None:
+        np.testing.assert_array_equal(
+            sid_offset_codes(np.asarray([[7], [0]]), (64,)), [[7], [0]]
+        )
+
+    def test_layers_occupy_disjoint_ranges(self) -> None:
+        layer_sizes = (4, 8, 16)
+        codes = np.stack(
+            np.meshgrid(*[np.arange(size) for size in layer_sizes], indexing="ij"),
+            axis=-1,
+        ).reshape(-1, len(layer_sizes))
+        offset = sid_offset_codes(codes, layer_sizes)
+        for layer, size in enumerate(layer_sizes):
+            start = sum(layer_sizes[:layer])
+            column = offset[:, layer]
+            self.assertEqual(int(column.min()), start)
+            self.assertEqual(int(column.max()), start + size - 1)
+        self.assertEqual(int(offset.max()), sum(layer_sizes) - 1)
 
 
 class PriorOccupancyTest(unittest.TestCase):

--- a/tzrec/utils/sid/collision_test.py
+++ b/tzrec/utils/sid/collision_test.py
@@ -140,7 +140,6 @@ class CollisionTest(unittest.TestCase):
         np.testing.assert_array_equal(result.final_bucket_keys, [0, 1, 2, 3, 4, 5])
         np.testing.assert_array_equal(result.final_bucket_counts, [2, 2, 2, 1, 2, 1])
         self.assertTrue(result.grouping_collected)
-        self.assertEqual(result.stats.total_items, 10)
         self.assertEqual(result.stats.raw_collision_buckets, 2)
         self.assertEqual(result.stats.final_collision_buckets, 0)
         self.assertEqual(result.stats.relocated_count, 3)
@@ -554,7 +553,6 @@ class PriorOccupancyTest(unittest.TestCase):
     def test_empty_has_no_items(self) -> None:
         prior = PriorOccupancy.empty()
         self.assertTrue(prior.is_empty)
-        self.assertEqual(prior.total_items, 0)
         np.testing.assert_array_equal(prior.counts_for(np.asarray([3, 7])), [0, 0])
 
     def test_counts_for_returns_zero_for_absent_buckets(self) -> None:
@@ -562,7 +560,6 @@ class PriorOccupancyTest(unittest.TestCase):
         np.testing.assert_array_equal(
             prior.counts_for(np.asarray([9, 0, 5, 100, 2])), [2, 0, 4, 0, 1]
         )
-        self.assertEqual(prior.total_items, 7)
 
     def test_restrict_to_bands_keeps_only_requested_bands(self) -> None:
         # last_size 4 -> band 0 spans keys 0..3, band 2 spans keys 8..11.

--- a/tzrec/utils/sid/collision_test.py
+++ b/tzrec/utils/sid/collision_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import unittest
 from unittest import mock
 
@@ -19,19 +20,29 @@ from tzrec.utils.sid import collision
 from tzrec.utils.sid.collision import (
     CollisionResolutionConfig,
     KnnCollisionResolver,
+    PriorOccupancy,
     RandomCollisionResolver,
     build_original_item_grouping,
     build_resolved_item_grouping,
+    concat_ranges,
     prepare_collision_plan,
+    sid_bucket_keys,
 )
 from tzrec.utils.test_util import parameterized_name_func
 
 
-def _plan(layer_sizes, capacity, item_ids, codes):
+def _plan(layer_sizes, capacity, item_ids, codes, prior=None):
     return prepare_collision_plan(
         np.asarray(item_ids, dtype=np.int64),
         np.asarray(codes, dtype=np.int64),
         CollisionResolutionConfig(layer_sizes, capacity),
+        prior=prior,
+    )
+
+
+def _prior(keys, counts):
+    return PriorOccupancy(
+        np.asarray(keys, dtype=np.int64), np.asarray(counts, dtype=np.int64)
     )
 
 
@@ -492,6 +503,121 @@ class CollisionTest(unittest.TestCase):
         self.assertEqual(grouped.stats.max_final_bucket_size, 2)
         _assert_same_assignments(self, rate_only, grouped)
         self.assertFalse(rate_only.grouping_collected)
+
+
+class ConcatRangesTest(unittest.TestCase):
+    def test_concatenates_ragged_ranges(self) -> None:
+        np.testing.assert_array_equal(
+            concat_ranges([5, 10], [2, 3]), [5, 6, 10, 11, 12]
+        )
+
+    def test_skips_empty_ranges(self) -> None:
+        np.testing.assert_array_equal(concat_ranges([5, 10, 20], [2, 0, 1]), [5, 6, 20])
+        self.assertEqual(concat_ranges([3], [0]).shape, (0,))
+        self.assertEqual(concat_ranges([], []).shape, (0,))
+
+
+class PriorOccupancyTest(unittest.TestCase):
+    def test_empty_has_no_items(self) -> None:
+        prior = PriorOccupancy.empty()
+        self.assertTrue(prior.is_empty)
+        self.assertEqual(prior.total_items, 0)
+        np.testing.assert_array_equal(prior.counts_for(np.asarray([3, 7])), [0, 0])
+
+    def test_counts_for_returns_zero_for_absent_buckets(self) -> None:
+        prior = _prior([2, 5, 9], [1, 4, 2])
+        np.testing.assert_array_equal(
+            prior.counts_for(np.asarray([9, 0, 5, 100, 2])), [2, 0, 4, 0, 1]
+        )
+        self.assertEqual(prior.total_items, 7)
+
+    def test_restrict_to_bands_keeps_only_requested_bands(self) -> None:
+        # last_size 4 -> band 0 spans keys 0..3, band 2 spans keys 8..11.
+        prior = _prior([0, 3, 5, 9, 11, 12], [1, 2, 3, 4, 5, 6])
+        restricted = prior.restrict_to_bands(np.asarray([2, 0]), 4)
+        np.testing.assert_array_equal(restricted.bucket_keys, [0, 3, 9, 11])
+        np.testing.assert_array_equal(restricted.bucket_counts, [1, 2, 4, 5])
+        self.assertTrue(prior.restrict_to_bands(np.asarray([7]), 4).is_empty)
+
+
+class AppendPlanTest(unittest.TestCase):
+    def test_zero_prior_matches_full_resolve(self) -> None:
+        codes = [[0, 0], [0, 0], [1, 3], [0, 2]]
+        without = _plan((2, 4), 2, range(4), codes)
+        with_empty = _plan((2, 4), 2, range(4), codes, prior=PriorOccupancy.empty())
+        # Enumerate the array fields so a newly added one is covered too.
+        for field in dataclasses.fields(without):
+            if field.name in ("item_count", "config", "prior"):
+                continue
+            np.testing.assert_array_equal(
+                getattr(without, field.name),
+                getattr(with_empty, field.name),
+                err_msg=field.name,
+            )
+        self.assertEqual(without.item_count, with_empty.item_count)
+
+    def test_prior_consumes_capacity_and_continues_slots(self) -> None:
+        # Bucket (0, 0) is key 0 and already holds one published item, so with
+        # capacity 2 only one of the two new rows can be retained there.
+        plan = _plan((2, 4), 2, [10, 11], [[0, 0], [0, 0]], prior=_prior([0], [1]))
+        np.testing.assert_array_equal(plan.prior_bucket_counts, [1])
+        self.assertEqual(plan.overflow_rows.size, 1)
+        retained = int(np.setdiff1d(np.arange(2), plan.overflow_rows)[0])
+        # The retained row continues the published slot sequence at 2, not 1.
+        self.assertEqual(int(plan.initial_slot_indices[retained]), 2)
+
+    def test_full_prior_bucket_overflows_every_new_row(self) -> None:
+        plan = _plan((2, 4), 2, [10, 11], [[0, 0], [0, 0]], prior=_prior([0], [2]))
+        np.testing.assert_array_equal(np.sort(plan.overflow_rows), [0, 1])
+
+    def test_prior_over_capacity_never_reissues_a_published_slot(self) -> None:
+        # A previous run left three items on key 0 at capacity 1 (unresolved
+        # overflow). The new row cannot relocate, so it must land at slot 4.
+        plan = _plan((2, 4), 1, [10], [[0, 0]], prior=_prior([0], [3]))
+        result = KnnCollisionResolver().resolve(plan, np.asarray([[0]], dtype=np.int64))
+        self.assertEqual(result.stats.unresolved_count, 1)
+        self.assertEqual(int(result.slot_indices[0]), 4)
+
+    def test_relocation_sees_prior_only_buckets_in_the_band(self) -> None:
+        # Key 0 is full, and key 1 -- in the same band but holding no new row --
+        # is already full too. The only free candidate is key 2.
+        plan = _plan((1, 4), 1, [10], [[0, 0]], prior=_prior([0, 1], [1, 1]))
+        result = KnnCollisionResolver().resolve(
+            plan, np.asarray([[1, 2]], dtype=np.int64)
+        )
+        self.assertEqual(result.stats.relocated_count, 1)
+        self.assertEqual(int(result.resolved_last_codes[0]), 2)
+        self.assertEqual(int(result.slot_indices[0]), 1)
+
+    def test_final_counts_are_corpus_totals(self) -> None:
+        plan = _plan((2, 4), 3, [10], [[0, 0]], prior=_prior([0], [2]))
+        result = KnnCollisionResolver().resolve(plan, None)
+        self.assertEqual(plan.overflow_rows.size, 0)
+        np.testing.assert_array_equal(result.final_bucket_keys, [0])
+        np.testing.assert_array_equal(result.final_bucket_counts, [3])
+        self.assertEqual(result.stats.max_final_bucket_size, 3)
+
+    def test_groupings_cover_only_the_appended_rows(self) -> None:
+        prior = _prior([0], [1])
+        plan = _plan((2, 4), 3, [10, 11], [[0, 0], [0, 1]], prior=prior)
+        result = KnnCollisionResolver().resolve(plan, None)
+
+        resolved = build_resolved_item_grouping(plan, result)
+        np.testing.assert_array_equal(np.sort(resolved.row_order), [0, 1])
+        self.assertEqual(int(resolved.counts.sum()), 2)
+        # Key 0 already held one item, so the delta grouping keeps one row there
+        # and the local slot restarts at 1 even though the global slot is 2.
+        keys = sid_bucket_keys(np.asarray([[0, 0], [0, 1]]), (2, 4))
+        np.testing.assert_array_equal(resolved.sid_keys, np.sort(keys))
+        self.assertEqual(int(result.slot_indices[0]), 2)
+
+        original = build_original_item_grouping(plan)
+        np.testing.assert_array_equal(np.sort(original.row_order), [0, 1])
+        self.assertEqual(int(original.counts.sum()), 2)
+
+    def test_rejects_prior_outside_the_key_space(self) -> None:
+        with self.assertRaisesRegex(ValueError, "outside the key space"):
+            _plan((2, 4), 2, [10], [[0, 0]], prior=_prior([8], [1]))
 
 
 if __name__ == "__main__":

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"


### PR DESCRIPTION
## What this adds

**1. Appending newly-arrived items to a published SID map**, without moving any
published SID.

**2. An `offset_codebook` column** on both output artifacts — the same SID with
each layer shifted into one contiguous vocabulary, so layer `i` is offset by
`sum(codebook[:i])`:

```
--codebook 64,64,64      SID [1, 2, 3]  ->  offset [1, 66, 131]
```

Layers then occupy disjoint id ranges, which is what a shared embedding table or
tokenizer needs. It is computed from the *emitted* SID, so a relocated item's
offset SID follows where it landed rather than what the model predicted.

**3. A bundle**: the artifacts a run publishes plus a manifest that identifies
them, locates them and describes the SID space they encode. A SID map is not
self-describing — a consumer holding one cannot tell which codebook produced it
or which generation it belongs to, so every consumer is configured out of band
and a mismatch surfaces as a slightly worse model rather than an error.

## The command line changes

Against master this removes three flags and adds four, and `--output_path` keeps
its name while changing meaning.

| removed | replaced by |
| ------- | ----------- |
| `--resolved_sid_groups_output_path` | `{output_path}/{generation}/sid_to_items` |
| `--original_sid_groups_output_path` | nothing — the artifact is dropped |
| `--writer_type`                     | `--item_to_sid_writer_type` |

Added: `--generation`, required; `--from_generation`, whose presence selects
append mode; `--item_to_sid_root`, optional; `--item_to_sid_writer_type`.

```bash
# full resolve
python -m tzrec.tools.sid.resolve_sid_collisions \
    --input_path 'sid_predict_output/*.parquet' \
    --codebook 8192,8192,8192 --max_items_per_codebook 5 \
    --output_path sid --generation v1

# append
python -m tzrec.tools.sid.resolve_sid_collisions \
    --input_path 'sid_predict_new/*.parquet' \
    --codebook 8192,8192,8192 --max_items_per_codebook 5 \
    --output_path sid --generation v2 --from_generation v1
```

One generation is one self-contained directory:

```
sid/v2/
  item_to_sid/  delta_item_to_sid/  sid_to_items/  delta_sid_to_items/
  manifest.json
```

**`--output_path` changes meaning**: it named the map file and now names the
bundle root. Every stale command line fails loudly at argparse, because the
group-path flags it must have carried no longer exist.

`--item_to_sid_root` exists for the one family whose storage is a choice — an
ODPS table, typically. It defaults to `--output_path`; pointing it at the same
place is ignored with a warning, since the flag then does nothing.

## Design

**Storage is a property of the artifact family, not of the bundle.** The serving
set — `sid_to_items`, `delta_sid_to_items`, the manifest — is parquet and JSON
under `--output_path`, always, which is why that root may never be an ODPS
table. Only the item-to-SID family has a choice, so
`--item_to_sid_writer_type` scopes to it alone. The whole serving-side contract
is files, so a serving runtime needs no ODPS client.

**Layout is uniform: `{root}/{generation}/{artifact}`.** On ODPS the two levels
are partition keys rather than path segments — `generation=…/artifact=…` —
because MaxCompute requires every partition to be `key=value`. Putting
`generation` first makes it the first-level partition there, so a generation is
one lifecycle unit on ODPS as well as on disk.

**The manifest is written last**, so its presence marks a generation complete.
It carries `bundle_uuid`, `since_bundle_uuid` (identity, not a counter: applying
a delta is checkable), the codebook, capacity, and
`max_observed_items_per_sid` as a *running maximum* — an append only ever sees
the buckets it touches, so publishing this run's value directly would let a small
append onto a large corpus report a ceiling far below the true one.

**The manifest is also the authority on the format it published.** An append
reads the prior `item_to_sid` in whatever `save_type` that generation recorded,
so a chain does not depend on `--reader_type` being repeated run after run.
`--reader_type` is therefore only about `--input_path`.

**Append is the general case; a full resolve is the empty-prior instance.** There
is no `if append:` branch in `tzrec/utils/sid/collision.py`. `PriorOccupancy`
carries per-bucket occupancy of the published corpus and is the only channel.
Published items are never rows in the plan, so they cannot be re-ranked — the
freeze guarantee is structural rather than a check.

Occupancy comes from the groups artifact, where list position *is* the slot, so a
non-dense index set is unrepresentable there. The map is checked on total row
count against total grouped item IDs, which catches a truncated shard anywhere in
the key space and a mismatched generation pair.

**An append refuses a SID space it did not inherit.** Before any published byte
is read, `--codebook` is compared against the prior manifest. Otherwise the
failure is silent: a changed codebook re-keys every published SID and rewrites
its `offset_codebook`, while leaving every code in range, so no range check can
see it. A changed `capacity` is allowed but warned about — published buckets keep
the occupancy they already have.

## Changes to existing outputs

| | before | after |
|---|---|---|
| map columns | `item_id, origin_codebook, codebook, index` | `… codebook, **offset_codebook**, index` |
| groups columns | `codebook, itemids` | `codebook, **offset_codebook**, itemids` |
| groups storage | followed `--writer_type` | **always parquet** |
| layout | caller-named paths | `{root}/{generation}/{artifact}` |

Fixing the serving set to parquet makes the CSV encoding of `itemids`
unreachable, so it is removed along with the flags that could reach it.
`--item_to_sid_writer_type CsvWriter` still applies to the item-to-SID family,
whose SID columns keep their comma-separated encoding.

## Test Plan

In the diff: `collision_test.py` 49 · `resolve_sid_collisions_test.py` 53 ·
`bundle_test.py` 20. `pre-commit run -a` and `scripts/pyre_check.py` clean.

Run outside the diff, as manual validation:

- A randomised property harness: 400 four-generation append chains over random
  layer sizes / capacity / topk, asserting published indices stay exactly
  `1..count`; plus 20 cases confirming a zero-prior plan is field-identical to a
  stock one.
- An end-to-end chain over Parquet at a tiny batch size to force multi-batch
  merges, asserting every published row is byte-identical across generations.
- Mutation sweeps over the append path, the offset arithmetic, the size check and
  the layout: each correctness-relevant mutation fails at least one test in the
  diff.
- Validated against a 255M-item corpus (`8192^3`, capacity 5): schemas, ascending
  group order, `position == index - 1`, and the `prior > capacity` case all
  confirmed on real data.

Known gap, stated rather than papered over: the `--item_to_sid_root` handling
and the append-time codebook guard are verified by probe, not by a test in the
diff.

## Open question

How an ODPS table that already exists acquires the `artifact` partition column.
`OdpsWriter._create_table` declares one `STRING` column per partition level, but
only for a table it creates. With `generation` as the first level this matches
how such tables are usually already partitioned, but adding a second partition
column to an existing table is still a recreate.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
