### PR TITLE
[feat] support unordered dataloader delivery

### DIFF
--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -335,6 +335,12 @@ pipeline.global-job-parameters: |
 - 每个`proc`上的读数据并发度，`nproc-per-node * num_workers`建议小于单机CPU核数
 - 如果`num_workers==0`，数据进程和训练进程将会在一个进程中，便于调试
 
+### in_order
+
+- 是否按dataloader任务提交顺序返回batch，默认为true；仅在`num_workers > 0`时生效
+- 设置为false时，先处理完的worker可以先返回batch，避免慢worker阻塞其他worker，但可能降低可复现性，并改变训练样本或预测结果的输出顺序
+- 对于样本分布不均衡的数据，设置为false可能使训练过程看到的数据分布产生偏差
+
 ### shuffle
 
 - 是否训练时打散数据，默认为false

--- a/tzrec/datasets/dataset.py
+++ b/tzrec/datasets/dataset.py
@@ -839,6 +839,7 @@ def create_dataloader(
         batch_size=None,
         pin_memory=data_config.pin_memory if mode != Mode.PREDICT else False,
         collate_fn=lambda x: x,
+        in_order=data_config.in_order,
         **kwargs,
     )
     # For PyTorch versions 2.6 and above, we initialize the data iterator before

--- a/tzrec/datasets/parquet_dataset_test.py
+++ b/tzrec/datasets/parquet_dataset_test.py
@@ -262,8 +262,10 @@ class ParquetDatasetTest(unittest.TestCase):
                 label_fields=["label"],
                 num_workers=2,
             )
+            self.assertTrue(data_config.in_order)
 
             dataloader1 = create_dataloader(data_config, features, input_path)
+            self.assertTrue(dataloader1.in_order)
             iterator1 = iter(dataloader1)
             checkpoint_state = {}
             for _ in range(4):
@@ -336,10 +338,12 @@ class ParquetDatasetTest(unittest.TestCase):
                 fg_mode=data_pb2.FgMode.FG_NONE,
                 label_fields=["label"],
                 num_workers=2,
+                in_order=False,
             )
 
             # full pass to learn the per-worker interval keys + total rows
             dataloader0 = create_dataloader(data_config, features, input_path)
+            self.assertFalse(dataloader0.in_order)
             full_state = {}
             num_total_rows = 0
             for batch in dataloader0.get_iterator():  # pyre-ignore[16]
@@ -359,6 +363,7 @@ class ParquetDatasetTest(unittest.TestCase):
             dataloader = create_dataloader(
                 data_config, features, input_path, checkpoint_state=tail_state
             )
+            self.assertFalse(dataloader.in_order)
             # first get_iterator() == the eager iterator -> resumed tail only
             num_tail_rows = _drain(dataloader.get_iterator())  # pyre-ignore[16]
             self.assertEqual(num_tail_rows, expected_tail_rows)

--- a/tzrec/protos/data.proto
+++ b/tzrec/protos/data.proto
@@ -153,6 +153,9 @@ message DataConfig {
     // type names follow ODPS conventions with aliases: BIGINT->INT64, INT->INT32
     optional string input_fields_str = 27;
 
+    // whether dataloader batches are returned in first-in, first-out order
+    optional bool in_order = 28 [default = true];
+
     // negative sampler
     oneof sampler {
         NegativeSampler negative_sampler = 101;


### PR DESCRIPTION
## Summary

Add an opt-in `data_config.in_order` setting and forward it to PyTorch `DataLoader`. The setting defaults to `true`, so existing pipelines keep ordered batch delivery, while users can set it to `false` to avoid head-of-line blocking from slower workers.

The data guide documents that unordered delivery only affects multi-process loading and may reduce reproducibility or change training and prediction output order. Existing checkpoint-resume coverage now validates both the ordered default and unordered eager-iterator behavior.

## User impact

Existing configurations are unchanged. Setting `in_order: false` allows ready batches to be returned without waiting for earlier worker tasks.

## Test Plan

- `bash scripts/gen_proto.sh`
- `PYTHONPATH=. python -m tzrec.datasets.parquet_dataset_test ParquetDatasetTest.test_create_dataloader_checkpoint_state_reaches_workers ParquetDatasetTest.test_create_dataloader_get_iterator_reuses_eager_iterator`
- `PYTHONPATH=. python -m tzrec.datasets.parquet_dataset_test` (10 tests)
- `pre-commit run -a`

`python scripts/pyre_check.py` was attempted, but the committed `.pyre_configuration` is invalid JSON because of an existing trailing comma. Temporarily correcting that exposed an existing Pyre backend failure; the configuration file was restored unchanged.