### PR TITLE
[bugfix] bump HSTU op to fix TMA initialization

### DIFF
--- a/docs/source/models/dlrm_hstu.md
+++ b/docs/source/models/dlrm_hstu.md
@@ -168,7 +168,7 @@ model_config {
 - kernel: 算子实现，可选TRITON/PYTORCH/CUTLASS
 
   - TRITON: 基于Triton的实现，通常比PYTORCH快2-3x，节省2-3x显存
-  - CUTLASS: 基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（DEVICE可选cu126/cu129/cu130：`pip install fbgemm_gpu_hstu==0.1.0+20260626.9fd44403.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/${DEVICE}/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU
+  - CUTLASS: 基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.cu126 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU
   - PYTORCH: 纯PyTorch实现，兼容性最好
 
 ### MTGR Style 配置方式

--- a/docs/source/models/dlrm_hstu.md
+++ b/docs/source/models/dlrm_hstu.md
@@ -168,7 +168,7 @@ model_config {
 - kernel: 算子实现，可选TRITON/PYTORCH/CUTLASS
 
   - TRITON: 基于Triton的实现，通常比PYTORCH快2-3x，节省2-3x显存
-  - CUTLASS: 基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.cu126 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU
+  - CUTLASS: 基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（DEVICE可选cu126/cu129/cu130：`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/${DEVICE}/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU
   - PYTORCH: 纯PyTorch实现，兼容性最好
 
 ### MTGR Style 配置方式

--- a/docs/source/models/ultra_hstu.md
+++ b/docs/source/models/ultra_hstu.md
@@ -141,7 +141,7 @@ model_config {
 
 - **`hstu`**：`repeated HSTU`。≥ 2 个时每个 entry 必须设置唯一非空 `name`。各 channel 的 STU `embedding_dim` 不要求一致；item 侧 MLP 与 `FusionMTLTower` 的输入维度自动取所有 channel `embedding_dim` 之和。
 - **`HSTU.name`**：MoT 通道名。非空时通道名 *替换* 默认 `uih` 前缀，preprocessor 据此从 `grouped_features` 读取 `<name>.sequence` / `<name>_action.sequence` / `<name>_watchtime.sequence` / `<name>_timestamp.sequence`。
-- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。CUTLASS 为基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（DEVICE可选cu126/cu129/cu130：`pip install fbgemm_gpu_hstu==0.1.0+20260626.9fd44403.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/${DEVICE}/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU。
+- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。CUTLASS 为基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.cu126 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU。
 - **`HSTU.attn_truncation_split_layer` / `attn_truncation_tail_len`**：mid-stack truncation 的分裂 layer 索引与 UIH 尾部保留长度。两者都必须 `> 0` 才启用，单独设置其一会被拒绝。
 
 ### Embedding 表共享

--- a/docs/source/models/ultra_hstu.md
+++ b/docs/source/models/ultra_hstu.md
@@ -141,7 +141,7 @@ model_config {
 
 - **`hstu`**：`repeated HSTU`。≥ 2 个时每个 entry 必须设置唯一非空 `name`。各 channel 的 STU `embedding_dim` 不要求一致；item 侧 MLP 与 `FusionMTLTower` 的输入维度自动取所有 channel `embedding_dim` 之和。
 - **`HSTU.name`**：MoT 通道名。非空时通道名 *替换* 默认 `uih` 前缀，preprocessor 据此从 `grouped_features` 读取 `<name>.sequence` / `<name>_action.sequence` / `<name>_watchtime.sequence` / `<name>_timestamp.sequence`。
-- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。CUTLASS 为基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.cu126 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU。
+- **`HSTU.stu.sla_k1` / `sla_k2`**：SLA 的局部窗口长度与全局 prefix 长度。任一 `> 0` 即启用 SLA；要求 `kernel: CUTLASS`（或 `PYTORCH`）。CUTLASS 为基于CUTLASS的CUDA融合算子实现，需安装fbgemm_gpu_hstu包（DEVICE可选cu126/cu129/cu130：`pip install fbgemm_gpu_hstu==0.1.0+20260805.fece651b.${DEVICE} -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/${DEVICE}/repo.html`），要求`attention_dim`等于`hidden_dim`，支持Ampere/Ada/Hopper GPU。
 - **`HSTU.attn_truncation_split_layer` / `attn_truncation_tail_len`**：mid-stack truncation 的分裂 layer 索引与 UIH 尾部保留长度。两者都必须 `> 0` 才启用，单独设置其一会被拒绝。
 
 ### Embedding 表共享

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,7 +1,7 @@
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu130-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu130-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu130-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 torch_fx_tool @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/rtp/torch_fx_tool-0.0.1%2B20251201.8c109c4-py3-none-any.whl

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,7 +1,7 @@
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
 dynamicemb @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/dynamicemb/cu130/dynamicemb-0.1.0%2B20260630.5dc46a2.cu130-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260626.9fd44403.cu130-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260626.9fd44403.cu130-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
-fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu130/fbgemm_gpu_hstu-0.1.0%2B20260626.9fd44403.cu130-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
+fbgemm_gpu_hstu @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/hstu/cu126/fbgemm_gpu_hstu-0.1.0%2B20260805.fece651b.cu126-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 torch_fx_tool @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/rtp/torch_fx_tool-0.0.1%2B20251201.8c109c4-py3-none-any.whl


### PR DESCRIPTION
## Summary

- Update the Python 3.10-3.12 cu130 `fbgemm_gpu_hstu` wheels to `0.1.0+20260805.fece651b.cu130`.
- Update the DLRM-HSTU and ULTRA-HSTU installation documentation while retaining cu126, cu129, and cu130 as selectable `DEVICE` values.

## Root cause

The previous HSTU build initializes optional RAB and dRAB TMA descriptors from null pointers even when those paths are disabled, which older drivers reject. The `fece651b` build conditionally initializes those descriptors only when the corresponding RAB path is enabled.

The fix is consumed through the published wheel rather than duplicated in TorchEasyRec because the CUTLASS HSTU implementation is maintained in FBGEMM.

## Impact

This avoids TMA initialization failures for CUTLASS HSTU attention when RAB or dRAB is disabled. Runtime dependencies remain on CUDA 13.0, while the documentation retains the available CUDA device variants.

## Test Plan

- `conda run -n tzrec130 pre-commit run -a`
- Verified that the cu130 cp310, cp311, and cp312 wheel URLs return HTTP 200
- `git diff --check`