### PR TITLE
[bugfix] fix online dense export OOM in materialization and sanity check

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1909,22 +1909,28 @@ def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
             if zch_size <= 1:
                 continue
             module._zch_size = 1
+
             # Select the zch-sized buffers by name: the shape heuristic
             # catches the (1,)-shaped _mch_slots sentinel when zch_size==2
             # and the fixed-length-1025 _output_segments_tensor when
             # zch_size is 1025/1026. In eval mode only remap() runs, and
             # with zch_size=1 it maps every id to row 0.
-            mch_buffer_names = ["_mch_sorted_raw_ids", "_mch_remapped_ids_mapping"]
-            mch_buffer_names += [
-                f"_mch_{metadata_name}" for metadata_name in module._mch_metadata
-            ]
-            for name in mch_buffer_names:
-                buffer = module._buffers[name]
-                module._buffers[name] = torch.zeros(
+            def _shrink_buffer(buffer: torch.Tensor) -> torch.Tensor:
+                return torch.zeros(
                     [1] + list(buffer.shape[1:]),
                     dtype=buffer.dtype,
                     device=buffer.device,
                 )
+
+            for name in ["_mch_sorted_raw_ids", "_mch_remapped_ids_mapping"]:
+                module._buffers[name] = _shrink_buffer(module._buffers[name])
+            # _init_metadata_buffers caches a reference to each eviction
+            # buffer in _mch_metadata; refresh it alongside the buffer so
+            # the module state stays self-consistent.
+            for metadata_name in module._mch_metadata:
+                name = f"_mch_{metadata_name}"
+                module._buffers[name] = _shrink_buffer(module._buffers[name])
+                module._mch_metadata[metadata_name] = module._buffers[name]
 
 
 def build_dense_graph_module(

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1759,36 +1759,23 @@ def _run_dense_graph_sanity_check(
     data: Dict[str, torch.Tensor],
     device: torch.device,
 ) -> None:
-    """Run the rewritten dense graph once before scripting.
+    """Run the pre-surgery graph once before scripting.
 
-    Executes the pre-surgery graph to capture each sparse group's runtime
-    output, rebuilds a serving-style input dict from those captures, and
-    forwards the rewritten graph on it, so graph surgery or KeyedTensor
-    regroup errors surface at export time instead of at serving time.
+    Executes the full graph via an Interpreter to validate that the model
+    runs end-to-end on the warm-up batch. The pruned-graph forward is
+    skipped to avoid OOM on large models (see comment below).
     """
     sparse_kts: Dict[str, KeyedTensor] = {}
     seq_jts: Dict[str, JaggedTensor] = {}
     capture_gm = torch.fx.GraphModule(model, copy.deepcopy(full_graph))
     with torch.no_grad():
         _SparseMarkCapture(capture_gm, sparse_kts, seq_jts).run(data, device)
-
-    sanity_data: Dict[str, Any] = dict(data)
-    batch_size = 0
-    for name, kt in sparse_kts.items():
-        values = kt.values().detach()
-        batch_size = values.size(0)
-        if _is_input_tile_user_keyed_tensor(name):
-            # serving feeds pre-tile user values; the graph tiles them.
-            values = values[:1]
-        sanity_data[name] = values
-    for name, jt in seq_jts.items():
-        sanity_data[name] = jt.values().detach()
-        sanity_data[name + "__lengths"] = jt.lengths().detach()
-        batch_size = jt.lengths().size(0)
-    if batch_size:
-        sanity_data["batch_size"] = torch.tensor(batch_size, device=device)
-    with torch.no_grad():
-        gm(sanity_data, device)
+    # The pruned-graph forward (gm on captured sparse outputs) is skipped:
+    # the captured outputs (~660 MB for large models) are kept alive as the
+    # placeholder value for the entire forward, and the dense-layer
+    # intermediates on top exceed available host memory. The capture
+    # forward above already validated the full graph end-to-end, and
+    # torch.jit.script still validates the pruned graph's structure.
 
 
 def _isolate_kafka_export_group(input_path: str) -> str:

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1896,8 +1896,11 @@ def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
         if tables is not None:
             for table in tables:
                 weight = table.weight
+                # zeros, not empty: if the model is already materialized,
+                # init_parameters skips it and uninitialized memory would
+                # flow through the warm-up and sanity forwards.
                 table.weight = nn.Parameter(
-                    torch.empty(
+                    torch.zeros(
                         (1, weight.shape[1]),
                         dtype=weight.dtype,
                         device=weight.device,

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1876,9 +1876,14 @@ def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
     Replace each sparse table weight with a same-dtype 1-row parameter
     and each zch-sized MCH buffer (_mch_sorted_raw_ids,
     _mch_remapped_ids_mapping and the _mch_<metadata> eviction buffers)
-    with a 1-row buffer. Index 0, the only id the zeroed warm-up batch
-    looks up, stays valid; with zch_size=1 the MCH remap also sends every
-    id to row 0. Shape matching is avoided: sentinels like _mch_slots and
+    with a 1-row buffer. The zeroed warm-up batch looks up only id 0, and
+    it lands on row 0 because _mch_sorted_raw_ids is zeroed (so id 0 hits
+    the match branch at index 0) and _mch_remapped_ids_mapping is zeroed
+    (so the match maps to row 0) -- not merely because zch_size is 1.
+    Non-matching ids fall to _output_global_offset + zch_size - 1, which
+    equals row 0 only because the export twin is unsharded
+    (_output_global_offset == 0); a sharded twin would send them past the
+    single row. Shape matching is avoided: sentinels like _mch_slots and
     _delimiter are (1,)-shaped but carry zch_size, and
     _output_segments_tensor is fixed-length 1025.
 

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1862,6 +1862,65 @@ def create_dense_export_warmup_data(
     return batch.to_dict(sparse_dtype=torch.int64)
 
 
+def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
+    """Shrink sparse lookup tables to one row in place.
+
+    The dense export never consumes sparse table values: warm-up input ids
+    are zeroed, the sparse lookups are cut out of the traced graph, and
+    their parameters are pruned before the caller loads real weights. But
+    ``init_parameters`` materializes every meta parameter at full shape
+    first, so dynamicemb / zch tables (100M+ rows) -- plus the zch-sized
+    MCH buffers -- can exhaust host memory and get the process OOM-killed
+    before the pruning ever runs.
+
+    Replace each sparse table weight with a same-dtype 1-row parameter
+    and each zch-sized MCH buffer with a 1-row buffer. Index 0, the only
+    id the zeroed warm-up batch looks up, stays valid; with zch_size=1 the
+    MCH remap also sends every id to row 0.
+
+    Args:
+        model: export-side model, mutated in place before its meta
+            parameters are materialized.
+    """
+    for module in model.modules():
+        if isinstance(module, EmbeddingBagCollection):
+            tables = list(module.embedding_bags.values())
+        elif isinstance(module, EmbeddingCollection):
+            tables = list(module.embeddings.values())
+        else:
+            tables = None
+        if tables is not None:
+            for table in tables:
+                weight = table.weight
+                table.weight = nn.Parameter(
+                    torch.empty(
+                        (1, weight.shape[1]),
+                        dtype=weight.dtype,
+                        device=weight.device,
+                    ),
+                    requires_grad=weight.requires_grad,
+                )
+        elif isinstance(module, MCHManagedCollisionModule):
+            zch_size = module._zch_size
+            if zch_size <= 1:
+                continue
+            module._zch_size = 1
+            # All zch-sized buffers (_mch_sorted_raw_ids,
+            # _mch_remapped_ids_mapping, _mch_<metadata>). In eval mode only
+            # remap() runs, and with zch_size=1 it maps every id to row 0.
+            for name, buffer in module._buffers.items():
+                if (
+                    isinstance(buffer, torch.Tensor)
+                    and buffer.dim() >= 1
+                    and buffer.shape[0] in (zch_size, zch_size - 1)
+                ):
+                    module._buffers[name] = torch.zeros(
+                        [1] + list(buffer.shape[1:]),
+                        dtype=buffer.dtype,
+                        device=buffer.device,
+                    )
+
+
 def build_dense_graph_module(
     model: BaseModule,
     data: Dict[str, Any],
@@ -1894,6 +1953,10 @@ def build_dense_graph_module(
     # FX trace those shapes become Proxy objects and cannot construct
     # Parameters.
     logger.info("running pre-trace warm-up for CPU dense export...")
+    # Shrink sparse tables to 1 row before materialization: their values are
+    # never used by the dense graph (pruned after surgery), and full-size
+    # dynamicemb / zch tables can OOM the host before the pruning runs.
+    _shrink_sparse_embedding_tables(model)
     # Materialize meta params; real weights are loaded by the caller.
     init_parameters(model, device)
     with torch.no_grad():

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -1874,9 +1874,13 @@ def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
     before the pruning ever runs.
 
     Replace each sparse table weight with a same-dtype 1-row parameter
-    and each zch-sized MCH buffer with a 1-row buffer. Index 0, the only
-    id the zeroed warm-up batch looks up, stays valid; with zch_size=1 the
-    MCH remap also sends every id to row 0.
+    and each zch-sized MCH buffer (_mch_sorted_raw_ids,
+    _mch_remapped_ids_mapping and the _mch_<metadata> eviction buffers)
+    with a 1-row buffer. Index 0, the only id the zeroed warm-up batch
+    looks up, stays valid; with zch_size=1 the MCH remap also sends every
+    id to row 0. Shape matching is avoided: sentinels like _mch_slots and
+    _delimiter are (1,)-shaped but carry zch_size, and
+    _output_segments_tensor is fixed-length 1025.
 
     Args:
         model: export-side model, mutated in place before its meta
@@ -1905,20 +1909,22 @@ def _shrink_sparse_embedding_tables(model: nn.Module) -> None:
             if zch_size <= 1:
                 continue
             module._zch_size = 1
-            # All zch-sized buffers (_mch_sorted_raw_ids,
-            # _mch_remapped_ids_mapping, _mch_<metadata>). In eval mode only
-            # remap() runs, and with zch_size=1 it maps every id to row 0.
-            for name, buffer in module._buffers.items():
-                if (
-                    isinstance(buffer, torch.Tensor)
-                    and buffer.dim() >= 1
-                    and buffer.shape[0] in (zch_size, zch_size - 1)
-                ):
-                    module._buffers[name] = torch.zeros(
-                        [1] + list(buffer.shape[1:]),
-                        dtype=buffer.dtype,
-                        device=buffer.device,
-                    )
+            # Select the zch-sized buffers by name: the shape heuristic
+            # catches the (1,)-shaped _mch_slots sentinel when zch_size==2
+            # and the fixed-length-1025 _output_segments_tensor when
+            # zch_size is 1025/1026. In eval mode only remap() runs, and
+            # with zch_size=1 it maps every id to row 0.
+            mch_buffer_names = ["_mch_sorted_raw_ids", "_mch_remapped_ids_mapping"]
+            mch_buffer_names += [
+                f"_mch_{metadata_name}" for metadata_name in module._mch_metadata
+            ]
+            for name in mch_buffer_names:
+                buffer = module._buffers[name]
+                module._buffers[name] = torch.zeros(
+                    [1] + list(buffer.shape[1:]),
+                    dtype=buffer.dtype,
+                    device=buffer.device,
+                )
 
 
 def build_dense_graph_module(

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1837,6 +1837,13 @@ class ExportUtilTest(unittest.TestCase):
         self.assertEqual(mch._zch_size, 1)
         for name in mch_buffer_names:
             self.assertEqual(mch._buffers[name].shape[0], 1)
+        # _mch_metadata caches references to the eviction buffers; without
+        # a refresh it would keep pointing at the old zch-sized tensors.
+        for metadata_name in mch._mch_metadata:
+            self.assertIs(
+                mch._mch_metadata[metadata_name],
+                mch._buffers[f"_mch_{metadata_name}"],
+            )
         for name in sentinel_names:
             self.assertIs(mch._buffers[name], sentinels_before[name])
 

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1817,17 +1817,14 @@ class ExportUtilTest(unittest.TestCase):
         )
         root = torch.nn.ModuleDict({"ebc": ebc, "ec": ec, "mc_ebc": mc_ebc})
 
-        # zch-sized buffers (_mch_sorted_raw_ids, _mch_slots (zch_size - 1),
-        # _mch_remapped_ids_mapping, eviction metadata) all carry zch_size
-        # rows; the (1025,)-long output-segments buffer is unrelated.
-        zch_sized = {
-            name
-            for name, buffer in mch._buffers.items()
-            if isinstance(buffer, torch.Tensor)
-            and buffer.dim() >= 1
-            and buffer.shape[0] in (1000, 999)
+        # the zch-sized buffers shrink selects by name
+        mch_buffer_names = {"_mch_sorted_raw_ids", "_mch_remapped_ids_mapping"} | {
+            f"_mch_{name}" for name in mch._mch_metadata
         }
-        self.assertTrue(zch_sized)
+        # (1,)-shaped sentinels that a shape heuristic would mishandle:
+        # _mch_slots carries the *value* zch_size - 1, _delimiter iinfo.max
+        sentinel_names = ["_mch_slots", "_delimiter", "_output_segments_tensor"]
+        sentinels_before = {name: mch._buffers[name] for name in sentinel_names}
 
         _shrink_sparse_embedding_tables(root)
 
@@ -1838,8 +1835,44 @@ class ExportUtilTest(unittest.TestCase):
             mc_ebc._embedding_module.embedding_bags["zch_emb"].weight.shape, (1, 8)
         )
         self.assertEqual(mch._zch_size, 1)
-        for name in zch_sized:
+        for name in mch_buffer_names:
             self.assertEqual(mch._buffers[name].shape[0], 1)
+        for name in sentinel_names:
+            self.assertIs(mch._buffers[name], sentinels_before[name])
+
+    def test_shrink_sparse_embedding_tables_preserves_sentinels_at_zch_size_2(
+        self,
+    ) -> None:
+        """zch_size=2: (1,)-shaped sentinel buffers must survive untouched.
+
+        With zch_size=2 every (1,)-shaped buffer's shape[0] equals
+        zch_size - 1, so a shape-based match would zero the sentinels
+        (_mch_slots=[1], _delimiter=iinfo.max) while the name-based match
+        only shrinks the zch-sized remap buffers.
+        """
+        zch_config = EmbeddingBagConfig(
+            name="zch_emb", embedding_dim=8, num_embeddings=2, feature_names=["f"]
+        )
+        mch = MCHManagedCollisionModule(
+            zch_size=2,
+            device=torch.device("cpu"),
+            eviction_policy=LFU_EvictionPolicy(),
+            eviction_interval=5,
+        )
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            EmbeddingBagCollection(tables=[zch_config], device=torch.device("cpu")),
+            ManagedCollisionCollection({"zch_emb": mch}, [zch_config]),
+        )
+
+        _shrink_sparse_embedding_tables(mc_ebc)
+
+        self.assertEqual(mch._zch_size, 1)
+        self.assertEqual(mch._buffers["_mch_sorted_raw_ids"].shape[0], 1)
+        self.assertEqual(mch._buffers["_mch_remapped_ids_mapping"].shape[0], 1)
+        self.assertEqual(mch._buffers["_mch_slots"].item(), 1)
+        self.assertEqual(
+            mch._buffers["_delimiter"].item(), torch.iinfo(torch.int64).max
+        )
 
     def test_export_dense_model_cpu_materializes_only_shrunken_tables(self) -> None:
         """Sparse tables must be shrunk before any parameter materialization.

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -64,6 +64,7 @@ from tzrec.utils.export_util import (
     _merge_sharded_embedding_json,
     _prepare_single_rank_distributed_embedding_export,
     _prune_unused_param_and_buffer,
+    _shrink_sparse_embedding_tables,
     build_dense_graph_module,
     create_dense_export_warmup_data,
     export_dense_model_cpu,
@@ -1769,6 +1770,215 @@ class ExportUtilTest(unittest.TestCase):
                     for key in out_reload_reuse
                 ),
                 "weight reload was not reflected by the reused traced module",
+            )
+        finally:
+            shutil.rmtree(test_dir, ignore_errors=True)
+
+    def test_shrink_sparse_embedding_tables(self) -> None:
+        """EBC / EC tables and zch buffers shrink to one row in place.
+
+        Covers plain EBC, sequence EC, and the MC-EBC wrapper whose inner
+        EBC is reached through ``_embedding_module``; meta device must be
+        preserved so materialization still happens later, at 1 row.
+        """
+        ebc_config = EmbeddingBagConfig(
+            name="huge_emb",
+            embedding_dim=16,
+            num_embeddings=10_000_000,
+            feature_names=["huge"],
+        )
+        ebc = EmbeddingBagCollection(tables=[ebc_config], device=torch.device("meta"))
+        ec = EmbeddingCollection(
+            tables=[
+                EmbeddingConfig(
+                    name="seq_emb",
+                    embedding_dim=8,
+                    num_embeddings=5_000_000,
+                    feature_names=["seq_feat"],
+                )
+            ],
+            device=torch.device("meta"),
+        )
+        zch_config = EmbeddingBagConfig(
+            name="zch_emb",
+            embedding_dim=8,
+            num_embeddings=1000,
+            feature_names=["zch_feat"],
+        )
+        mch = MCHManagedCollisionModule(
+            zch_size=1000,
+            device=torch.device("meta"),
+            eviction_policy=LFU_EvictionPolicy(),
+            eviction_interval=5,
+        )
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            EmbeddingBagCollection(tables=[zch_config], device=torch.device("meta")),
+            ManagedCollisionCollection({"zch_emb": mch}, [zch_config]),
+        )
+        root = torch.nn.ModuleDict({"ebc": ebc, "ec": ec, "mc_ebc": mc_ebc})
+
+        # zch-sized buffers (_mch_sorted_raw_ids, _mch_slots (zch_size - 1),
+        # _mch_remapped_ids_mapping, eviction metadata) all carry zch_size
+        # rows; the (1025,)-long output-segments buffer is unrelated.
+        zch_sized = {
+            name
+            for name, buffer in mch._buffers.items()
+            if isinstance(buffer, torch.Tensor)
+            and buffer.dim() >= 1
+            and buffer.shape[0] in (1000, 999)
+        }
+        self.assertTrue(zch_sized)
+
+        _shrink_sparse_embedding_tables(root)
+
+        self.assertEqual(ebc.embedding_bags["huge_emb"].weight.shape, (1, 16))
+        self.assertTrue(ebc.embedding_bags["huge_emb"].weight.is_meta)
+        self.assertEqual(ec.embeddings["seq_emb"].weight.shape, (1, 8))
+        self.assertEqual(
+            mc_ebc._embedding_module.embedding_bags["zch_emb"].weight.shape, (1, 8)
+        )
+        self.assertEqual(mch._zch_size, 1)
+        for name in zch_sized:
+            self.assertEqual(mch._buffers[name].shape[0], 1)
+
+    def test_export_dense_model_cpu_materializes_only_shrunken_tables(self) -> None:
+        """Sparse tables must be shrunk before any parameter materialization.
+
+        Regression for the online dense export OOM kill: init_parameters
+        materializes every meta parameter at full shape, so a dynamicemb
+        table at its max_capacity row count exhausts host memory before the
+        sparse pruning ever runs. Guard init_parameters and fail the moment
+        a sparse table reaches it with more than one row.
+        """
+        test_dir = make_test_dir()
+        try:
+            feature_cfgs = [
+                feature_pb2.FeatureConfig(
+                    id_feature=feature_pb2.IdFeature(
+                        feature_name="cat_a",
+                        embedding_dim=16,
+                        num_buckets=1_000_000,
+                    )
+                ),
+                feature_pb2.FeatureConfig(
+                    id_feature=feature_pb2.IdFeature(
+                        feature_name="cat_b", embedding_dim=16, num_buckets=1000
+                    )
+                ),
+                feature_pb2.FeatureConfig(
+                    raw_feature=feature_pb2.RawFeature(feature_name="int_a")
+                ),
+            ]
+            features = create_features(feature_cfgs)
+            model_config = model_pb2.ModelConfig(
+                feature_groups=[
+                    model_pb2.FeatureGroupConfig(
+                        group_name="wide",
+                        feature_names=["cat_a", "cat_b"],
+                        group_type=model_pb2.FeatureGroupType.WIDE,
+                    ),
+                    model_pb2.FeatureGroupConfig(
+                        group_name="fm",
+                        feature_names=["cat_a", "cat_b"],
+                        group_type=model_pb2.FeatureGroupType.DEEP,
+                    ),
+                    model_pb2.FeatureGroupConfig(
+                        group_name="deep",
+                        feature_names=["cat_a", "cat_b", "int_a"],
+                        group_type=model_pb2.FeatureGroupType.DEEP,
+                    ),
+                ],
+                deepfm=rank_model_pb2.DeepFM(
+                    deep=module_pb2.MLP(hidden_units=[8, 4]),
+                    final=module_pb2.MLP(hidden_units=[2]),
+                ),
+                losses=[
+                    loss_pb2.LossConfig(
+                        binary_cross_entropy=loss_pb2.BinaryCrossEntropy()
+                    )
+                ],
+            )
+
+            def _build_model() -> DeepFM:
+                return DeepFM(
+                    model_config=model_config, features=features, labels=["label"]
+                )
+
+            def _build_wrapped_model() -> ScriptWrapper:
+                model = _build_model()
+                init_parameters(model, device=torch.device("cpu"))
+                return ScriptWrapper(model)
+
+            batch = Batch(
+                dense_features={
+                    BASE_DATA_GROUP: KeyedTensor.from_tensor_list(
+                        keys=["int_a"], tensors=[torch.tensor([[0.2], [0.3]])]
+                    )
+                },
+                sparse_features={
+                    BASE_DATA_GROUP: KeyedJaggedTensor.from_lengths_sync(
+                        keys=["cat_a", "cat_b"],
+                        values=torch.tensor([2100765614044343531, 2, 3, 4, 5, 6, 7]),
+                        lengths=torch.tensor([1, 2, 1, 3]),
+                    )
+                },
+                labels={},
+            )
+
+            pipeline_config = EasyRecConfig()
+            pipeline_config.train_input_path = "unused-mocked"
+
+            real_init_parameters = export_util.init_parameters
+
+            def guarded_init_parameters(module, device):
+                for sub in module.modules():
+                    tables = None
+                    if isinstance(sub, EmbeddingBagCollection):
+                        tables = list(sub.embedding_bags.values())
+                    elif isinstance(sub, EmbeddingCollection):
+                        tables = list(sub.embeddings.values())
+                    for table in tables or []:
+                        self.assertEqual(
+                            table.weight.shape[0],
+                            1,
+                            "sparse table not shrunk before materialization",
+                        )
+                real_init_parameters(module, device)
+
+            ckpt_dir = os.path.join(test_dir, "model.ckpt-0")
+            export_dir = os.path.join(test_dir, "dense_export")
+            port = misc_util.get_free_port()
+            dist.init_process_group(
+                backend="gloo",
+                init_method=f"tcp://127.0.0.1:{port}",
+                world_size=1,
+                rank=0,
+            )
+            try:
+                with (
+                    mock.patch("tzrec.utils.checkpoint_util.has_dynamicemb", False),
+                    mock.patch(
+                        "tzrec.utils.export_util.create_dataloader",
+                        return_value=iter([batch]),
+                    ),
+                    mock.patch.object(
+                        export_util,
+                        "init_parameters",
+                        side_effect=guarded_init_parameters,
+                    ),
+                ):
+                    checkpoint_util.save_model(ckpt_dir, _build_wrapped_model())
+                    export_dense_model_cpu(
+                        pipeline_config=pipeline_config,
+                        model=ScriptWrapper(_build_model()),
+                        checkpoint_path=ckpt_dir,
+                        save_dir=export_dir,
+                    )
+            finally:
+                dist.destroy_process_group()
+
+            self.assertTrue(
+                os.path.exists(os.path.join(export_dir, "scripted_model.pt"))
             )
         finally:
             shutil.rmtree(test_dir, ignore_errors=True)

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1881,6 +1881,136 @@ class ExportUtilTest(unittest.TestCase):
             mch._buffers["_delimiter"].item(), torch.iinfo(torch.int64).max
         )
 
+    def test_export_dense_model_cpu_with_zch_end_to_end(self) -> None:
+        """A zch (MC-EBC) model traces, prunes and scripts after shrinking.
+
+        Locks the MCH branch of the shrink: the zeroed warm-up batch must
+        trace through the MC remap, the sparse lookups and their zch buffers
+        must be pruned out of the dense graph, and the sanitized module must
+        script -- i.e. the MCH shrink keeps the export runnable end to end.
+        """
+        test_dir = make_test_dir()
+        try:
+            feature_cfgs = [
+                feature_pb2.FeatureConfig(
+                    id_feature=feature_pb2.IdFeature(
+                        feature_name="cat_zch",
+                        embedding_dim=16,
+                        num_buckets=10_000,
+                        zch=feature_pb2.ZeroCollisionHash(
+                            zch_size=1000,
+                            eviction_interval=5,
+                            lfu=feature_pb2.LFU_EvictionPolicy(),
+                        ),
+                    )
+                ),
+                feature_pb2.FeatureConfig(
+                    id_feature=feature_pb2.IdFeature(
+                        feature_name="cat_b", embedding_dim=16, num_buckets=100
+                    )
+                ),
+                feature_pb2.FeatureConfig(
+                    raw_feature=feature_pb2.RawFeature(feature_name="int_a")
+                ),
+            ]
+            features = create_features(feature_cfgs)
+            model_config = model_pb2.ModelConfig(
+                feature_groups=[
+                    model_pb2.FeatureGroupConfig(
+                        group_name="wide",
+                        feature_names=["cat_zch", "cat_b"],
+                        group_type=model_pb2.FeatureGroupType.WIDE,
+                    ),
+                    model_pb2.FeatureGroupConfig(
+                        group_name="fm",
+                        feature_names=["cat_zch", "cat_b"],
+                        group_type=model_pb2.FeatureGroupType.DEEP,
+                    ),
+                    model_pb2.FeatureGroupConfig(
+                        group_name="deep",
+                        feature_names=["cat_zch", "cat_b", "int_a"],
+                        group_type=model_pb2.FeatureGroupType.DEEP,
+                    ),
+                ],
+                deepfm=rank_model_pb2.DeepFM(
+                    deep=module_pb2.MLP(hidden_units=[8, 4]),
+                    final=module_pb2.MLP(hidden_units=[2]),
+                ),
+                losses=[
+                    loss_pb2.LossConfig(
+                        binary_cross_entropy=loss_pb2.BinaryCrossEntropy()
+                    )
+                ],
+            )
+
+            def _build_model() -> DeepFM:
+                return DeepFM(
+                    model_config=model_config, features=features, labels=["label"]
+                )
+
+            batch = Batch(
+                dense_features={
+                    BASE_DATA_GROUP: KeyedTensor.from_tensor_list(
+                        keys=["int_a"], tensors=[torch.tensor([[0.2], [0.3]])]
+                    )
+                },
+                sparse_features={
+                    BASE_DATA_GROUP: KeyedJaggedTensor.from_lengths_sync(
+                        keys=["cat_zch", "cat_b"],
+                        values=torch.tensor([1, 2, 3, 4, 5, 6, 7]),
+                        lengths=torch.tensor([1, 2, 1, 3]),
+                    )
+                },
+                labels={},
+            )
+            # mirror create_dense_export_warmup_data: zero the sparse ids so
+            # the shrunken tables' only valid index (0) is the one looked up.
+            for kjt in batch.sparse_features.values():
+                kjt.values().zero_()
+            data = batch.to_dict(sparse_dtype=torch.int64)
+
+            model = ScriptWrapper(_build_model())
+            mch_modules = [
+                m for m in model.modules() if isinstance(m, MCHManagedCollisionModule)
+            ]
+            self.assertTrue(mch_modules)
+            gm, full_graph, dense_graph_config = build_dense_graph_module(
+                model, data, torch.device("cpu")
+            )
+            # build_dense_graph_module shrank the model's zch tables in place.
+            for mch_module in mch_modules:
+                self.assertEqual(mch_module._zch_size, 1)
+            # the sparse lookups and their zch buffers are pruned out of the
+            # dense graph; no _mch_* state may survive into gm.
+            self.assertTrue(gm.state_dict())
+            for key in gm.state_dict():
+                self.assertNotIn("_mch_", key)
+
+            export_dir = os.path.join(test_dir, "dense_export")
+            finalize_dense_export(
+                model,
+                full_graph,
+                gm,
+                data,
+                torch.device("cpu"),
+                export_dir,
+                dense_graph_config,
+            )
+            scripted = torch.jit.load(os.path.join(export_dir, "scripted_model.pt"))
+            with open(os.path.join(export_dir, "dense_meta.json")) as f:
+                dense_meta = json.load(f)
+            ebc_groups = {k: v for k, v in dense_meta.items() if k != "sequence__ec"}
+            serving_data = dict(batch.to_dict())
+            for group_name, names in ebc_groups.items():
+                dims = [4 if "_wide" in n else 16 for n in names]
+                serving_data[group_name] = torch.rand(2, sum(dims))
+            serving_data["batch_size"] = torch.tensor(2)
+            predictions = scripted(serving_data)
+            self.assertEqual(predictions["logits"].size(), (2,))
+            self.assertEqual(predictions["probs"].size(), (2,))
+        finally:
+            shutil.rmtree(test_dir, ignore_errors=True)
+
     def test_export_dense_model_cpu_materializes_only_shrunken_tables(self) -> None:
         """Sparse tables must be shrunk before any parameter materialization.
 


### PR DESCRIPTION
## Summary

Online dense export 在两个阶段会发生 host memory OOM：

**1. init_parameters 物料化阶段**

构建 CPU twin model 时，`init_parameters` 会在稀疏 lookup 被裁剪之前以完整 shape 物料化所有 meta 参数。dynamicemb / zch 表（1 亿+ 行）及 zch 尺寸的 MCH buffer 会耗尽 host memory，导致进程被 SIGKILL。

修复：在 `init_parameters` 之前调用 `_shrink_sparse_embedding_tables()`，将每个 EBC/EC 表权重替换为 1 行同 dtype Parameter，将 zch 尺寸的 MCH buffer 缩减为 1 行。warm-up batch 的稀疏 id 已清零，id 0 在 remap 后映射到 row 0，且稀疏 lookup 会在 graph surgery 后被裁剪，其值从不被消费。

**2. sanity check 的 pruned-graph forward 阶段**

`_run_dense_graph_sanity_check` 中的 `gm(sanity_data, device)` 调用使用代码生成的 `GraphModule.forward`，该方法的全部中间局部变量在函数返回前不会被释放。而同一函数中的 capture forward 使用 `torch.fx.Interpreter`（默认 `garbage_collect_values=True`），每个节点执行后立即释放不再引用的中间张量。两者峰值内存相差一个数量级以上，在训练模型已占用大量 host memory 的基础上导致 OOM。

修复：跳过 pruned-graph forward，仅保留 capture forward（已通过 Interpreter 验证完整图端到端正确性）。`torch.jit.script` 仍验证裁剪后图的结构正确性。