### PR TITLE
[feat] absorb upstream kafka schema changes in KafkaReader

### DIFF
--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -99,14 +99,7 @@ data_config {
 - 输入消息流的内容是序列化的ArrowRecordBatch，支持两种序列化格式:
 
   - schema-less格式 (`record_batch.serialize()`): 需设置`data_config.input_fields`或`data_config.input_fields_str`来指定数据的schema
-  - 带schema的格式 (Arrow IPC Stream): 无需设置`input_fields`，schema从消息中自动推断，但schema会占用消息体大小
-
-- 上游schema变更:
-
-  - 使用带schema的格式 (Arrow IPC Stream) 时，KafkaDataset按**列名**从消息中取数，因此上游新增列或调整列顺序无需重启训练即可自动适配：新增的列如果没有被任何特征、label等使用，会被自动忽略；列顺序变化不影响取数结果。schema变更时会打印一条INFO日志
-  - 训练用到的列（特征输入列、label_fields、sample_weight_fields等）如果在上游被删除或改名，会直接报错并中断训练，报错信息中会列出缺失的列名。这里不会用空值填充，否则上游故障会被静默地当作特征默认值训练进模型
-  - 训练用到的列在上游发生类型变更时同样直接报错，报错信息中会给出变更前后的类型
-  - schema-less格式的消息体中不包含schema，无法感知上游变更，因此不支持上述能力。上游schema会变更时请使用带schema的格式
+  - 带schema的格式 (Arrow IPC Stream): 无需设置`input_fields`，schema从消息中自动推断，上游新增列或调整列顺序无需重启训练即可自动适配，但schema会占用消息体大小
 
 - input_path: 按如下格式设置
 

--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -101,6 +101,13 @@ data_config {
   - schema-less格式 (`record_batch.serialize()`): 需设置`data_config.input_fields`或`data_config.input_fields_str`来指定数据的schema
   - 带schema的格式 (Arrow IPC Stream): 无需设置`input_fields`，schema从消息中自动推断，但schema会占用消息体大小
 
+- 上游schema变更:
+
+  - 使用带schema的格式 (Arrow IPC Stream) 时，KafkaDataset按**列名**从消息中取数，因此上游新增列或调整列顺序无需重启训练即可自动适配：新增的列如果没有被任何特征、label等使用，会被自动忽略；列顺序变化不影响取数结果。schema变更时会打印一条INFO日志
+  - 训练用到的列（特征输入列、label_fields、sample_weight_fields等）如果在上游被删除或改名，会直接报错并中断训练，报错信息中会列出缺失的列名。这里不会用空值填充，否则上游故障会被静默地当作特征默认值训练进模型
+  - 训练用到的列在上游发生类型变更时同样直接报错，报错信息中会给出变更前后的类型
+  - schema-less格式的消息体中不包含schema，无法感知上游变更，因此不支持上述能力。上游schema会变更时请使用带schema的格式
+
 - input_path: 按如下格式设置
 
   - `kafka://broker:9092/topic?group.id=consumer_group&auto.offset.reset=earliest`

--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -99,7 +99,7 @@ data_config {
 - 输入消息流的内容是序列化的ArrowRecordBatch，支持两种序列化格式:
 
   - schema-less格式 (`record_batch.serialize()`): 需设置`data_config.input_fields`或`data_config.input_fields_str`来指定数据的schema
-  - 带schema的格式 (Arrow IPC Stream): 无需设置`input_fields`，schema从消息中自动推断，上游新增列或调整列顺序无需重启训练即可自动适配，但schema会占用消息体大小
+  - 带schema的格式 (Arrow IPC Stream): 无需设置`input_fields`，schema从消息中自动推断，上游新增列或调整列顺序无需重启训练即可自动适配，上游删除或修改Reader所需列（列名/类型）时会报错，且schema会占用消息体大小
 
 - input_path: 按如下格式设置
 

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -32,6 +32,7 @@ from tzrec.datasets.utils import (
     DATA_TIMESTAMP,
     FIELD_TYPE_TO_PA,
     get_input_fields_proto,
+    remove_nullable,
 )
 from tzrec.features.feature import BaseFeature
 from tzrec.protos import data_pb2
@@ -94,6 +95,58 @@ def _parse_kafka_uri(uri: str) -> Tuple[str, Dict[str, Any], Optional[int]]:
     params["bootstrap.servers"] = broker
 
     return topic, params, start_timestamp_ms
+
+
+def _build_projection(
+    src_schema: pa.Schema, dst_schema: pa.Schema
+) -> Optional[List[int]]:
+    """Map every field of dst_schema onto a column index of src_schema.
+
+    Matching is by name, so an upstream producer may append new columns or reorder
+    existing ones without breaking the reader.  A column dst_schema needs but
+    src_schema does not have is an error: filling it with nulls would silently turn
+    a broken upstream into a model trained on default values.
+
+    Args:
+        src_schema (pa.Schema): schema of the incoming record batch.
+        dst_schema (pa.Schema): schema the reader is contracted to produce.
+
+    Returns:
+        list: src_schema column index per dst_schema field, or ``None`` when the two
+            schemas already line up and no projection is needed.
+
+    Raises:
+        ValueError: if a dst_schema column is missing from src_schema or has a
+            different type there.
+    """
+    indices = []
+    missing = []
+    mismatched = []
+    for field in dst_schema:
+        idx = src_schema.get_field_index(field.name)
+        if idx < 0:
+            missing.append(field.name)
+            continue
+        src_type = remove_nullable(src_schema.field(idx).type)
+        if src_type != remove_nullable(field.type):
+            mismatched.append(f"{field.name}: {field.type} -> {src_type}")
+        indices.append(idx)
+
+    if missing or mismatched:
+        reasons = []
+        if missing:
+            reasons.append(f"missing column(s) {missing}")
+        if mismatched:
+            reasons.append(f"changed column type(s) {mismatched}")
+        raise ValueError(
+            f"kafka message schema is incompatible with the reader schema: "
+            f"{'; '.join(reasons)}. message columns: {src_schema.names}, "
+            f"reader columns: {dst_schema.names}."
+        )
+
+    if len(src_schema) == len(dst_schema) and indices == list(range(len(indices))):
+        return None
+    return indices
 
 
 def _offsets_for_times_batched(
@@ -223,7 +276,6 @@ class KafkaReader(BaseReader):
             drop_remainder,
         )
 
-        self._drop_columns = []
         self._has_embedded_schema = False
 
         if input_fields:
@@ -240,8 +292,6 @@ class KafkaReader(BaseReader):
                 if field.name in self._selected_cols:
                     fields.append(field)
                     self._ordered_cols.append(field.name)
-                else:
-                    self._drop_columns.append(field.name)
             self._schema = pa.schema(fields)
         else:
             self._schema = self._full_schema
@@ -431,6 +481,9 @@ class KafkaReader(BaseReader):
         heartbeat_thread.start()
 
         batch_size_per_msg = None
+        # name-based projection per seen message schema, so an upstream schema
+        # change costs one recompute rather than one per message.
+        projections: Dict[pa.Schema, Optional[List[int]]] = {}
         try:
             while True:
                 num_messages = (
@@ -485,6 +538,27 @@ class KafkaReader(BaseReader):
                         record_batch = pa.ipc.read_record_batch(
                             msg_data, self._full_schema
                         )
+
+                    # Project onto the reader schema by column name. For embedded
+                    # schemas this absorbs upstream columns being added or
+                    # reordered; for schema-less ones it only selects columns.
+                    msg_schema = record_batch.schema
+                    if msg_schema not in projections:
+                        if projections:
+                            logger.info(
+                                f"new kafka message schema {msg_schema.names}, "
+                                f"reading columns {self._schema.names}."
+                            )
+                        projections[msg_schema] = _build_projection(
+                            msg_schema, self._schema
+                        )
+                    projection = projections[msg_schema]
+                    if projection is not None:
+                        record_batch = pa.RecordBatch.from_arrays(
+                            [record_batch.column(i) for i in projection],
+                            names=self._schema.names,
+                        )
+
                     current_batch_size += len(record_batch)
                     record_batchs.append(record_batch)
 
@@ -515,11 +589,7 @@ class KafkaReader(BaseReader):
                     )
 
                 # combine into one record batch
-                t = (
-                    pa.Table.from_batches(record_batchs)
-                    .drop_columns(self._drop_columns)
-                    .combine_chunks()
-                )
+                t = pa.Table.from_batches(record_batchs).combine_chunks()
 
                 # Add checkpoint metadata columns
                 t = t.append_column(
@@ -536,7 +606,7 @@ class KafkaReader(BaseReader):
                 for batch in t.to_batches():
                     yield batch
         except Exception as e:
-            logger.error(f"KafkaReader exception: {e}", flush=True)
+            logger.error(f"KafkaReader exception: {e}")
             raise e
         finally:
             stop_event.set()

--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -113,12 +113,15 @@ def _build_projection(
 
     Returns:
         list: src_schema column index per dst_schema field, or ``None`` when the two
-            schemas already line up and no projection is needed.
+            schemas are already identical and no projection is needed.
 
     Raises:
         ValueError: if a dst_schema column is missing from src_schema or has a
             different type there.
     """
+    if src_schema.equals(dst_schema):
+        return None
+
     indices = []
     missing = []
     mismatched = []
@@ -144,8 +147,6 @@ def _build_projection(
             f"reader columns: {dst_schema.names}."
         )
 
-    if len(src_schema) == len(dst_schema) and indices == list(range(len(indices))):
-        return None
     return indices
 
 
@@ -554,10 +555,13 @@ class KafkaReader(BaseReader):
                         )
                     projection = projections[msg_schema]
                     if projection is not None:
+                        # cast normalizes the nested nullability differences
+                        # _build_projection tolerates, so that batches read from
+                        # either schema still combine into one table below.
                         record_batch = pa.RecordBatch.from_arrays(
                             [record_batch.column(i) for i in projection],
                             names=self._schema.names,
-                        )
+                        ).cast(self._schema)
 
                     current_batch_size += len(record_batch)
                     record_batchs.append(record_batch)

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -28,6 +28,7 @@ from torch.utils.data import DataLoader
 
 from tzrec.datasets.kafka_dataset import (
     KafkaDataset,
+    _build_projection,
     _offsets_for_times_batched,
     _parse_kafka_uri,
 )
@@ -190,6 +191,82 @@ class OffsetsForTimesBatchedTest(unittest.TestCase):
         self.assertEqual(sleep_fn.call_count, 1)
 
 
+class BuildProjectionTest(unittest.TestCase):
+    """Unit tests for _build_projection."""
+
+    DST = pa.schema(
+        [
+            pa.field("id_a", pa.string()),
+            pa.field("raw_c", pa.int64()),
+            pa.field("label", pa.int64()),
+        ]
+    )
+
+    def test_identical_schema_needs_no_projection(self):
+        self.assertIsNone(_build_projection(self.DST, self.DST))
+
+    def test_upstream_added_column(self):
+        src = pa.schema(
+            [
+                pa.field("id_a", pa.string()),
+                pa.field("raw_c", pa.int64()),
+                pa.field("label", pa.int64()),
+                pa.field("new_col", pa.float32()),
+            ]
+        )
+        self.assertEqual(_build_projection(src, self.DST), [0, 1, 2])
+
+    def test_upstream_reordered_column(self):
+        src = pa.schema(
+            [
+                pa.field("label", pa.int64()),
+                pa.field("new_col", pa.float32()),
+                pa.field("id_a", pa.string()),
+                pa.field("raw_c", pa.int64()),
+            ]
+        )
+        projection = _build_projection(src, self.DST)
+        self.assertEqual(projection, [2, 3, 0])
+        batch = pa.record_batch(
+            [
+                pa.array([7], type=pa.int64()),
+                pa.array([1.5], type=pa.float32()),
+                pa.array(["a"], type=pa.string()),
+                pa.array([3], type=pa.int64()),
+            ],
+            schema=src,
+        )
+        projected = pa.RecordBatch.from_arrays(
+            [batch.column(i) for i in projection], names=self.DST.names
+        )
+        self.assertEqual(
+            projected.to_pydict(), {"id_a": ["a"], "raw_c": [3], "label": [7]}
+        )
+
+    def test_missing_column_raises(self):
+        src = pa.schema([pa.field("id_a", pa.string()), pa.field("label", pa.int64())])
+        with self.assertRaisesRegex(ValueError, r"missing column\(s\) \['raw_c'\]"):
+            _build_projection(src, self.DST)
+
+    def test_changed_column_type_raises(self):
+        src = pa.schema(
+            [
+                pa.field("id_a", pa.string()),
+                pa.field("raw_c", pa.int32()),
+                pa.field("label", pa.int64()),
+            ]
+        )
+        with self.assertRaisesRegex(ValueError, r"changed column type\(s\).*raw_c"):
+            _build_projection(src, self.DST)
+
+    def test_nested_nullability_is_ignored(self):
+        dst = pa.schema([pa.field("raw_g", pa.list_(pa.field("item", pa.float32())))])
+        src = pa.schema(
+            [pa.field("raw_g", pa.list_(pa.field("element", pa.float32(), False)))]
+        )
+        self.assertIsNone(_build_projection(src, dst))
+
+
 class KafkaDatasetTest(unittest.TestCase):
     def setUp(self):
         credential = CredClient()
@@ -257,25 +334,28 @@ class KafkaDatasetTest(unittest.TestCase):
         config = {"bootstrap.servers": self.brokers}
         producer = Producer(config)
 
-        for _ in range(10000):
-            record_batch = pa.record_batch(
-                {
-                    "unused": pa.array(["unused"] * 128, type=pa.string()),
-                    "id_a": pa.array(["1"] * 128, type=pa.string()),
-                    "tag_b": pa.array(["2\x1d3"] * 128, type=pa.string()),
-                    "raw_c": pa.array([4] * 128, type=pa.int64()),
-                    "raw_d": pa.array([5.0] * 128, type=pa.float64()),
-                    "raw_e": pa.array([3] * 128, type=pa.int32()),
-                    "raw_f": pa.array([4.0] * 128, type=pa.float32()),
-                    "raw_g": pa.array(
-                        [[1.0, 2.0, 3.0]] * 128, type=pa.list_(pa.float32())
-                    ),
-                    "map_h": pa.array(
-                        [{"1": 1, "2": 2}] * 128, type=pa.map_(pa.string(), pa.int64())
-                    ),
-                    "label": pa.array([0] * 128, type=pa.int64()),
-                }
-            )
+        for i in range(10000):
+            columns = {
+                "unused": pa.array(["unused"] * 128, type=pa.string()),
+                "id_a": pa.array(["1"] * 128, type=pa.string()),
+                "tag_b": pa.array(["2\x1d3"] * 128, type=pa.string()),
+                "raw_c": pa.array([4] * 128, type=pa.int64()),
+                "raw_d": pa.array([5.0] * 128, type=pa.float64()),
+                "raw_e": pa.array([3] * 128, type=pa.int32()),
+                "raw_f": pa.array([4.0] * 128, type=pa.float32()),
+                "raw_g": pa.array([[1.0, 2.0, 3.0]] * 128, type=pa.list_(pa.float32())),
+                "map_h": pa.array(
+                    [{"1": 1, "2": 2}] * 128, type=pa.map_(pa.string(), pa.int64())
+                ),
+                "label": pa.array([0] * 128, type=pa.int64()),
+            }
+            # emulate an upstream schema change: a new column appears and the
+            # existing ones are reordered. Alternating per message so that a
+            # single consume() call mixes both schemas.
+            if embedded_schema and i % 2 == 1:
+                columns["added_i"] = pa.array([6] * 128, type=pa.int64())
+                columns = dict(reversed(list(columns.items())))
+            record_batch = pa.record_batch(columns)
             if embedded_schema:
                 # Serialize with embedded schema using IPC stream format
                 sink = io.BytesIO()

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -23,7 +23,7 @@ from alibabacloud_credentials.client import Client as CredClient
 from alibabacloud_tea_openapi import models as openapi_models
 from alibabacloud_tea_util import models as util_models
 from confluent_kafka import KafkaException, Producer, TopicPartition
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torch.utils.data import DataLoader
 
 from tzrec.datasets.kafka_dataset import (
@@ -259,12 +259,37 @@ class BuildProjectionTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"changed column type\(s\).*raw_c"):
             _build_projection(src, self.DST)
 
-    def test_nested_nullability_is_ignored(self):
-        dst = pa.schema([pa.field("raw_g", pa.list_(pa.field("item", pa.float32())))])
-        src = pa.schema(
-            [pa.field("raw_g", pa.list_(pa.field("element", pa.float32(), False)))]
-        )
-        self.assertIsNone(_build_projection(src, dst))
+    @parameterized.expand(
+        [
+            param(
+                "list",
+                dst_type=pa.list_(pa.float32()),
+                src_type=pa.list_(pa.field("element", pa.float32(), False)),
+            ),
+            param(
+                "map",
+                dst_type=pa.map_(pa.string(), pa.int64()),
+                src_type=pa.map_(
+                    pa.field("key", pa.string(), False),
+                    pa.field("value", pa.int64(), False),
+                ),
+            ),
+        ]
+    )
+    def test_nested_nullability_is_normalized(self, _name, dst_type, src_type):
+        """A nullability-only delta is accepted, and casting makes batches combine."""
+        dst = pa.schema([pa.field("raw_g", dst_type)])
+        src = pa.schema([pa.field("raw_g", src_type)])
+        projection = _build_projection(src, dst)
+        self.assertEqual(projection, [0])
+
+        value = [1.0, 2.0] if pa.types.is_list(dst_type) else [("k", 1)]
+        src_batch = pa.record_batch([pa.array([value], type=src_type)], schema=src)
+        dst_batch = pa.record_batch([pa.array([value], type=dst_type)], schema=dst)
+        projected = pa.RecordBatch.from_arrays(
+            [src_batch.column(i) for i in projection], names=dst.names
+        ).cast(dst)
+        self.assertEqual(len(pa.Table.from_batches([projected, dst_batch])), 2)
 
 
 class KafkaDatasetTest(unittest.TestCase):

--- a/tzrec/datasets/utils.py
+++ b/tzrec/datasets/utils.py
@@ -915,7 +915,7 @@ def calc_slice_intervals(
 
 
 def remove_nullable(field_type: pa.DataType) -> pa.DataType:
-    """Recursive removal of the null=False property from lists and nested lists."""
+    """Recursive removal of the null=False property from lists, nested lists, maps."""
     if pa.types.is_list(field_type):
         # Get element fields
         value_field = field_type.value_field
@@ -925,6 +925,11 @@ def remove_nullable(field_type: pa.DataType) -> pa.DataType:
         normalized_value_type = remove_nullable(normalized_value_field.type)
         # Construct a new list type
         return pa.list_(normalized_value_type)
+
+    elif pa.types.is_map(field_type):
+        return pa.map_(
+            remove_nullable(field_type.key_type), remove_nullable(field_type.item_type)
+        )
 
     else:
         return field_type

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"


### PR DESCRIPTION
## Problem

`KafkaReader` freezes one schema at construction — from `data_config.input_fields` /
`input_fields_str`, or peeked off the *newest* message on partition 0 when the producer
embeds an Arrow IPC schema — and then assumes every message matches it positionally.

With embedded schemas each message carries its own schema, so a producer that appends or
reorders a column still decodes fine, but the resulting batches no longer share a schema
and `pa.Table.from_batches` / `pa.concat_tables` abort the job mid-stream. Resuming from a
checkpoint or `start.timestamp.ms` hits the same wall, because the peek reads the newest
message while consumption starts from older ones — so a topic that ever evolved is already
guaranteed to break on resume.

A second bug sat on the same path: the reader's exception handler called
`logger.error(..., flush=True)` on a stdlib `logging.Logger`, which raises `TypeError` and
replaces every reader error with an unrelated one.

## Change

Decoded batches are projected onto the reader schema **by column name** instead of by
position:

- an upstream column that appears and that no feature/label reads is ignored;
- reordered columns land in the right place;
- a column the reader *does* need but the message lacks, or whose type changed, raises a
  `ValueError` naming the columns and both schemas. Filling nulls was deliberately rejected:
  it would turn a broken upstream into a model quietly trained on feature default values;
- the projection is cached per message schema, and one INFO line is logged the first time a
  new schema is seen;
- the projection subsumes the previously precomputed `_drop_columns`, for both
  serialization formats.

Schema-less messages (`record_batch.serialize()`) are raw buffers reinterpreted against a
fixed schema — there is no per-message schema to compare, so evolution there stays
unsupported and the docs now say so explicitly.

## Test Plan

- New `BuildProjectionTest` in `tzrec/datasets/kafka_dataset_test.py`, broker-free: identity
  fast path, added column, reordered columns (asserted on values, not just schema), missing
  column raises, changed type raises, nested nullability ignored. The existing broker-backed
  tests are `skipIf CI_ALIKAFKA_INSTANCE_ID`, so the logic is testable standalone.
- The broker-backed `test_kafka_dataset` producer now alternates schemas per message, so a
  single `consume()` call mixes an old and a new schema.
- End-to-end run of `KafkaReader._reader` against a stubbed consumer feeding alternating
  schemas: batches combine, values stay aligned to their columns, extra columns dropped, one
  INFO per new schema. The same scenario on master fails inside pyarrow, with the real error
  masked by the `flush=True` `TypeError`.
- `python -m unittest tzrec.datasets.dataset_test tzrec.datasets.parquet_dataset_test
  tzrec.datasets.csv_dataset_test tzrec.datasets.kafka_dataset_test tzrec.datasets.utils_test`
  → 109 tests, OK.
- `pre-commit run --files` on the three changed files → clean.

Note, unrelated to this change: `.pyre_configuration` has a trailing comma in
`ignore_all_errors`, so `scripts/pyre_check.py` bails with "Invalid configuration" and still
prints "Found no critical type errors" — type checking has been a silent no-op. Running pyre
with the comma removed reports 1192 pre-existing errors, none on the lines this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpMqKURChA7Kh5ht8ZDmxZ