### PR TITLE
[feat] add Python random seed and version logging

### DIFF
--- a/tzrec/__init__.py
+++ b/tzrec/__init__.py
@@ -53,6 +53,7 @@ import logging as _logging  # NOQA
 import torch as _torch  # NOQA
 import numpy as _np  # NOQA
 from tzrec.utils import load_class as _load_class  # NOQA
+from tzrec.version import __version__ as _tzrec_version  # NOQA
 
 _log_level = _os.getenv("LOG_LEVEL")
 if _log_level:
@@ -60,6 +61,10 @@ if _log_level:
 _logging.basicConfig(
     format="[%(asctime)s][%(levelname)s] %(message)s", level=_log_level
 )
+_logger = _logging.getLogger("tzrec")
+_logger.setLevel(_logging.INFO)
+if int(_os.environ.get("RANK", 0)) == 0:
+    _logger.info(f"TorchEasyRec version: {_tzrec_version}")
 
 # reproducibility
 _python_random_seed = _os.getenv("PYTHON_RANDOM_SEED")

--- a/tzrec/__init__.py
+++ b/tzrec/__init__.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os as _os
+import random as _random
 import warnings as _warnings
 
 # Disable ECS metadata credential provider when ALIBABA_CLOUD_ECS_METADATA is not set.
@@ -61,6 +62,9 @@ _logging.basicConfig(
 )
 
 # reproducibility
+_python_random_seed = _os.getenv("PYTHON_RANDOM_SEED")
+if _python_random_seed:
+    _random.seed(int(_python_random_seed))
 _torch_manual_seed = _os.getenv("TORCH_MANUAL_SEED")
 if _torch_manual_seed:
     _torch.manual_seed(int(_torch_manual_seed))


### PR DESCRIPTION
## Summary

- Add the `PYTHON_RANDOM_SEED` environment variable to seed Python's global `random` generator during TorchEasyRec package initialization, including seed value `0`.
- Log `TorchEasyRec version: <version>` when `tzrec` is imported by global rank 0. Other global ranks remain silent, and an unset `RANK` is treated as rank 0 for single-process commands such as export.
- Use the standard-library `logging.getLogger("tzrec")` logger in package initialization without importing `tzrec.utils.logging_util` early.

These changes complement the existing Torch and NumPy reproducibility settings and make the running TorchEasyRec version visible in rank-zero startup logs.

## Test Plan

- All commit-time pre-commit hooks passed: license, Ruff lint/format, whitespace, YAML, merge-conflict, line-ending, codespell, and applicable file checks.
- Verified `RANK=0` and an unset `RANK` each log the version exactly once across repeated imports; verified `RANK=1` does not log it.
- Verified `python -m tzrec.export --help` logs the version exactly once on rank 0.
- Verified independent processes with equal `PYTHON_RANDOM_SEED` values (`100087` and `0`) produce equal Python random states, while different seeds produce different states.
- `git diff --check` passed.

`python scripts/pyre_check.py` was attempted previously, but the repository's existing `.pyre_configuration` is invalid JSON because of a trailing comma, so local Pyre did not produce an effective type-check result.