### PR TITLE
[feat] support external custom models

### DIFF
--- a/docs/source/models/user_define.md
+++ b/docs/source/models/user_define.md
@@ -1,44 +1,116 @@
 # 自定义模型
 
-## 编写模型proto文件
+TorchEasyRec 支持在**你自己的工程**里编写自定义模型，无需修改 TorchEasyRec 仓库中的任何文件。
+模型代码、模型配置 proto 和 pipeline config 都放在你的工程中，升级 TorchEasyRec 时不会产生代码冲突。
 
-TorchEasyRec使用 [Protocol Buffer](https://developers.google.com/protocol-buffers/docs/pythontutorial) 定义配置文件格式。
+pipeline config 通过 `custom_model.class_path` 指定模型类的完整 python 路径，通过
+`custom_model.config`（`google.protobuf.Any`）携带你自己定义的强类型模型配置。
+TorchEasyRec 在解析 pipeline config 前会先导入 `class_path` 所在的模块，因此模型模块中
+`import` 的 `*_pb2` 会自动完成 protobuf descriptor 注册。
 
-在 `tzrec/protos/models/rank_model.proto` 中增加一个 `CustomRankModel` Message来定义模型配置
+## 工程结构
 
-```protobuf
-message CustomRankModel {
-  required MLP mlp = 1;
-  ...
-};
+推荐的工程结构如下，包名和目录名可以自由选择：
+
+```text
+my-rec-project/
+├── my_models/
+│   ├── __init__.py
+│   ├── models/
+│   │   ├── __init__.py
+│   │   └── custom_rank_model.py
+│   └── protos/
+│       ├── __init__.py
+│       └── custom_rank_model.proto
+├── configs/
+│   └── custom_rank_model.config
+└── .vscode/
+    └── settings.json
 ```
 
-在 `tzrec/protos/model.proto的在` 的 `oneof model`里面增加 `CustomRankModel`
+TorchEasyRec 可以通过 pip 安装，也可以作为 git submodule 引入，两种方式后续步骤完全一致。
+
+### 方式一：pip 安装 TorchEasyRec
+
+```bash
+pip install tzrec==${TZREC_NIGHTLY_VERSION} -f http://tzrec.oss-accelerate.aliyuncs.com/release/nightly/repo.html --trusted-host tzrec.oss-accelerate.aliyuncs.com
+```
+
+运行命令时用 `PYTHONPATH=.` 让 python 可以导入你的包即可：
+
+```bash
+PYTHONPATH=. python -m tzrec.train_eval --pipeline_config_path configs/custom_rank_model.config ...
+```
+
+### 方式二：TorchEasyRec 作为 git submodule
+
+适合需要固定 TorchEasyRec 版本、或需要同时修改调试 TorchEasyRec 源码的场景。
+
+```bash
+git submodule add https://github.com/alibaba/TorchEasyRec.git third_party/TorchEasyRec
+pip install -r third_party/TorchEasyRec/requirements.txt
+```
+
+submodule 中不包含生成的 `*_pb2.py`，拉取和更新 submodule 后需要在 submodule 目录内生成：
+
+```bash
+cd third_party/TorchEasyRec && bash scripts/gen_proto.sh && cd -
+```
+
+运行命令时把 submodule 加入 `PYTHONPATH`：
+
+```bash
+PYTHONPATH=.:third_party/TorchEasyRec python -m tzrec.train_eval \
+    --pipeline_config_path configs/custom_rank_model.config ...
+```
+
+注意：`PYTHONPATH` 中的源码版本会覆盖 pip 安装的 tzrec，请不要同时使用两种方式。
+
+## 编写模型配置 proto
+
+TorchEasyRec 使用 [Protocol Buffer](https://developers.google.com/protocol-buffers/docs/pythontutorial)
+定义配置文件格式。在你自己的包里定义模型配置，可以直接复用 TorchEasyRec 的公共 message，
+例如 `tzrec.protos.MLP`：
 
 ```protobuf
-message ModelConfig {
-   ...
+// my_models/protos/custom_rank_model.proto
+syntax = "proto2";
+package my_models.protos;
 
-   oneof model {
-      ...
-      CustomRankModel custom_rank_model = 1001;
-      ...
-   }
-   ...
+import "tzrec/protos/module.proto";
+
+message CustomRankModelConfig {
+    required tzrec.protos.MLP mlp = 1;
 }
 ```
 
-生成proto python `*_pb2.py` 文件
+## 生成 protobuf binding
+
+在工程根目录用 protoc 编译自己的 proto：
 
 ```bash
-bash scripts/gen_proto.sh
+python -m grpc_tools.protoc -I . my_models/protos/*.proto --python_out=. --pyi_out=.
 ```
 
-## 编写模型文件
+如果自定义 proto `import` 了 TorchEasyRec 的 proto（例如上面复用 `tzrec.protos.MLP`），
+还需要把 TorchEasyRec 的目录加到 `-I` 中。protoc 读取的是 `.proto` 源文件，
+所以这里要填 `tzrec/protos/` 的上一级目录：
 
-### 继承
+```bash
+# submodule 方式
+TZREC_PATH=third_party/TorchEasyRec
+# pip 安装方式
+TZREC_PATH=$(python -c "import importlib.metadata as m; print(m.distribution('tzrec').locate_file(''))")
 
-继承 `tzrec.models.model.BaseModel` 来实现自定义模型，需重载以下函数
+python -m grpc_tools.protoc -I . -I "${TZREC_PATH}" \
+    my_models/protos/*.proto --python_out=. --pyi_out=.
+```
+
+## 编写模型
+
+继承 `tzrec.models.model.BaseModel` 来实现自定义模型，需重载以下函数。
+自定义模型的 `__init__` 签名与内置模型完全一致，框架会把 `custom_model.config` 解包成
+强类型 message 后赋值给 `self._model_config`。
 
 ### 初始化: \_\_init\_\_
 
@@ -68,10 +140,12 @@ bash scripts/gen_proto.sh
 - 多目标模型可直接继承 `tzrec.models.multi_task_rank.MultiTaskRank`
 - 召回模型可直接继承 `tzrec.models.match_model.MatchModel`
 
+**模型模块必须在顶层 `import` 自己的 `*_pb2`。**
+
 以排序模型为例
 
 ```python
-# tzrec/models/custom_rank_model.py
+# my_models/models/custom_rank_model.py
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -80,10 +154,11 @@ from torch import nn
 from tzrec.datasets.utils import Batch
 from tzrec.features.feature import BaseFeature
 from tzrec.models.rank_model import RankModel
-from tzrec.modules.embedding import EmbeddingGroup
 from tzrec.modules.mlp import MLP
 from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.utils.config_util import config_to_kwargs
+
+from my_models.protos.custom_rank_model_pb2 import CustomRankModelConfig  # NOQA
 
 
 class CustomRankModel(RankModel):
@@ -104,21 +179,13 @@ class CustomRankModel(RankModel):
         **kwargs: Any,
     ) -> None:
         super().__init__(model_config, features, labels, sample_weights, **kwargs)
-        # 构建EmbeddingGroup
-        self.embedding_group = EmbeddingGroup(
-            features, list(model_config.feature_groups)
-        )
-        # 构建MLP
-        total_in_dim = sum(self.embedding_group.group_total_dim(n) for n in self.embedding_group.group_names())
+        # self._model_config 即解包后的 CustomRankModelConfig
+        self.init_input()
         self.mlp = MLP(
-            in_features=total_in_dim,
+            self.embedding_group.group_total_dim("deep"),
             **config_to_kwargs(self._model_config.mlp),
         )
-        final_dim = self.mlp.output_dim()
-        self.output_mlp = nn.Linear(final_dim, self._num_class)
-        # 初始化其他模块
-        ...
-
+        self.output_mlp = nn.Linear(self.mlp.output_dim(), self._num_class)
 
     def predict(self, batch: Batch) -> Dict[str, torch.Tensor]:
         """Forward the model.
@@ -129,91 +196,143 @@ class CustomRankModel(RankModel):
         Return:
             predictions (dict): a dict of predicted result.
         """
-        grouped_features = self.embedding_group(
-            batch
-        )
-        features = torch.cat([grouped_features[name] for name in self.embedding_group.group_names()], dim=-1)
-        tower_output = self.mlp(features)
-        y = self.output_mlp(tower_output)
-        # 其他前向推理
-        ...
-
+        grouped_features = self.build_input(batch)
+        y = self.output_mlp(self.mlp(grouped_features["deep"]))
         return self._output_to_prediction(y)
 ```
 
-## 测试
+## 配置 pipeline
 
-编写 custom_rank_model.config
-
-```
-
-# 数据相关参数配置
-data_config {
-  ...
-}
-
-# 特征相关参数配置
-feature_configs {
-  ...
-}
-feature_configs {
-  ...
-}
-
-# 训练相关的参数配置
-train_config {
-  ...
-}
-
-# 评估相关参数配置
-eval_config {
-  ...
-}
-
-# 模型相关参数配置
+```protobuf
 model_config {
     feature_groups {
-        group_name: 'group1'
-        feature_names: 'f1'
-        feature_names: 'f2'
-        ...
-        wide_deep: DEEP
+        group_name: "deep"
+        feature_names: "f1"
+        feature_names: "f2"
+        group_type: DEEP
     }
-    feature_groups {
-        group_name: 'group2'
-        feature_names: 'f3'
-        feature_names: 'f4'
-        ...
-        wide_deep: DEEP
-    }
-    ...
-    custom_rank_model {
-        mlp {
-            hidden_units: [64]
+
+    custom_model {
+        class_path: "my_models.models.custom_rank_model.CustomRankModel"
+        config {
+            [type.googleapis.com/my_models.protos.CustomRankModelConfig] {
+                mlp {
+                    hidden_units: [128, 64]
+                    dropout_ratio: [0.1, 0.1]
+                }
+            }
         }
-        ...
+    }
+
+    losses {
+        binary_cross_entropy {}
     }
     metrics {
         auc {}
     }
-    losses {
-        binary_cross_entropy {}
-    }
 }
 ```
 
-运行
+- `class_path` 是模型类的完整 python 路径，运行时该路径必须可以被 python 导入。
+- 方括号中的 `my_models.protos.CustomRankModelConfig` 是 proto 文件里声明的 `package` 加
+  message 名，**不是** python 模块路径。
+- `custom_model.config` 可以省略，此时 `self._model_config` 为 `None`。
+
+## 运行
+
+以 pip 安装方式为例，submodule 方式只需把 `PYTHONPATH` 换成 `.:third_party/TorchEasyRec`。
+
+训练
 
 ```bash
 PYTHONPATH=. torchrun --master_addr=localhost --master_port=32555 \
     --nnodes=1 --nproc-per-node=2 --node_rank=0 \
-    tzrec/train_eval.py \
-    --pipeline_config_path custom_rank_model.config \
+    -m tzrec.train_eval \
+    --pipeline_config_path configs/custom_rank_model.config \
     --train_input_path ${TRAIN_INPUT_PATH} \
     --eval_input_path ${EVAL_INPUT_PATH} \
     --model_dir ${MODEL_DIR}
 ```
 
-### 打包发布
+评估、导出和预测与内置模型完全一致，`class_path` 会随 pipeline config 一起保存到
+`${MODEL_DIR}/pipeline.config`，因此后续命令无需任何额外配置：
 
-参考[开发指南](../develop.md)
+```bash
+PYTHONPATH=. torchrun --master_addr=localhost --master_port=32555 \
+    --nnodes=1 --nproc-per-node=2 --node_rank=0 \
+    -m tzrec.eval --pipeline_config_path ${MODEL_DIR}/pipeline.config
+
+PYTHONPATH=. torchrun --master_addr=localhost --master_port=32555 \
+    --nnodes=1 --nproc-per-node=2 --node_rank=0 \
+    -m tzrec.export --pipeline_config_path ${MODEL_DIR}/pipeline.config \
+    --export_dir ${EXPORT_DIR}
+```
+
+## 开发与调试
+
+### 编辑器跳转
+
+shell 中设置的 `PYTHONPATH` 不会传递给 VSCode 的 Pylance，需要在工程里增加
+`.vscode/settings.json`，否则无法跳转到 `tzrec` 的定义：
+
+```json
+{
+    "python.analysis.extraPaths": [".", "third_party/TorchEasyRec"],
+    "python.autoComplete.extraPaths": [".", "third_party/TorchEasyRec"]
+}
+```
+
+pip 安装方式下 `extraPaths` 只需要 `["."]`，`tzrec` 由解释器的 site-packages 解析；
+submodule 方式下跳转会进入 submodule 源码，可以直接修改和打断点调试 TorchEasyRec。
+protoc 的 `--pyi_out` 生成的 `*_pb2.pyi` 让自定义 proto 的类型也可以正常跳转和补全。
+
+### 单进程调试
+
+调试模型代码时使用单进程启动，可以正常使用 `pdb` / `debugpy`：
+
+```bash
+PYTHONPATH=. torchrun --master_addr=localhost --master_port=32555 \
+    --nnodes=1 --nproc-per-node=1 --node_rank=0 \
+    -m tzrec.train_eval --pipeline_config_path configs/custom_rank_model.config ...
+```
+
+### 常见问题
+
+- `config type [xxx] is not registered`：`class_path` 指向的模型模块没有在顶层
+  `import` 对应的 `*_pb2`，descriptor 未注册。
+- `ModuleNotFoundError` / `class xxx is not found in module xxx`：`class_path` 写错，
+  或者运行时 `PYTHONPATH` 中没有包含你的工程目录。
+- `duplicate file name tzrec/protos/xxx.proto` 或 `couldn't resolve name`：自定义 proto
+  编译时 `-I` 指向的 TorchEasyRec 和运行时使用的不一致，用实际运行的那一份重新编译。
+- `confilict class xxx is already register`：自定义模型的类名和 TorchEasyRec 内置模型
+  重名，换一个类名即可。
+
+## 打包发布
+
+自定义包可以打成 wheel 发布，安装后运行时不再需要设置 `PYTHONPATH`。
+
+`setup.py`：
+
+```python
+from setuptools import find_packages, setup
+
+setup(
+    name="my_models",
+    version="0.1.0",
+    packages=find_packages(),
+    package_data={"my_models.protos": ["*.proto", "*.pyi"]},
+)
+```
+
+先生成 binding 再打包，顺序和 TorchEasyRec 的 `scripts/build_wheel.sh` 一致：
+
+```bash
+python -m grpc_tools.protoc -I . -I "${TZREC_PATH}" \
+    my_models/protos/*.proto --python_out=. --pyi_out=.
+python setup.py bdist_wheel
+pip install dist/my_models-0.1.0-py3-none-any.whl
+```
+
+`*_pb2.py` 是普通的 python 文件，`find_packages()` 会自动打包进 wheel；`*_pb2.pyi`
+和 `.proto` 需要用 `package_data` 指定。如果 `.gitignore` 中忽略了 `*_pb2.py`，
+打包前必须先执行上面的 protoc 命令。

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -97,6 +97,7 @@ from tzrec.utils.export_util import (
     export_model,
 )
 from tzrec.utils.filesystem_util import url_to_fs
+from tzrec.utils.load_class import import_class
 from tzrec.utils.logging_util import ProgressLogger, logger
 from tzrec.utils.online_dense_export_util import OnlineDenseExportManager
 from tzrec.utils.plan_util import create_planner, get_default_sharders
@@ -154,9 +155,15 @@ def _create_model(
     Return:
         model: a EasyRec Model.
     """
-    model_cls_name = config_util.which_msg(model_config, "model")
-    # pyre-ignore [16]
-    model_cls = BaseModel.create_class(model_cls_name)
+    if model_config.WhichOneof("model") == "custom_model":
+        class_path = model_config.custom_model.class_path
+        model_cls = import_class(class_path)
+        if not isinstance(model_cls, type) or not issubclass(model_cls, BaseModel):
+            raise ValueError(f"Custom model class {class_path} must inherit BaseModel.")
+    else:
+        model_cls_name = config_util.which_msg(model_config, "model")
+        # pyre-ignore [16]
+        model_cls = BaseModel.create_class(model_cls_name)
 
     model: BaseModel = model_cls(
         model_config,

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -23,11 +23,14 @@ import torch
 from parameterized import parameterized
 
 from tzrec.datasets.utils import RecordBatchTensor
-from tzrec.main import _train_and_evaluate, predict, predict_checkpoint
+from tzrec.main import _create_model, _train_and_evaluate, predict, predict_checkpoint
+from tzrec.models.model import BaseModel
 from tzrec.optim.ema import DenseEMA
 from tzrec.protos.data_pb2 import DataConfig
 from tzrec.protos.eval_pb2 import EvalConfig
 from tzrec.protos.export_pb2 import ExportConfig
+from tzrec.protos.model_pb2 import ModelConfig
+from tzrec.protos.module_pb2 import MLP
 from tzrec.protos.optimizer_pb2 import DenseOptimizer, EMAConfig
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import predict_util
@@ -36,6 +39,35 @@ from tzrec.utils.test_util import parameterized_name_func
 
 class MainTest(unittest.TestCase):
     """Tests for tzrec.main orchestration."""
+
+    def test_create_custom_model(self) -> None:
+        """A custom model receives its unpacked protobuf configuration."""
+        model_config = ModelConfig()
+        model_config.custom_model.class_path = "tzrec.models.model.BaseModel"
+        model_config.custom_model.config.Pack(MLP(hidden_units=[32, 16]))
+
+        model = _create_model(model_config, [], [])
+
+        self.assertIsInstance(model, BaseModel)
+        self.assertEqual(list(model._model_config.hidden_units), [32, 16])
+
+    def test_create_custom_model_without_config(self) -> None:
+        """A custom model may omit its protobuf configuration."""
+        model_config = ModelConfig()
+        model_config.custom_model.class_path = "tzrec.models.model.BaseModel"
+
+        model = _create_model(model_config, [], [])
+
+        self.assertIsNone(model._model_config)
+
+    def test_create_custom_model_requires_base_model(self) -> None:
+        """Reject custom classes that do not implement the model contract."""
+        model_config = ModelConfig()
+        model_config.custom_model.class_path = "torch.nn.Linear"
+        model_config.custom_model.config.Pack(MLP(hidden_units=[32]))
+
+        with self.assertRaisesRegex(ValueError, "must inherit BaseModel"):
+            _create_model(model_config, [], [])
 
     def test_train_and_evaluate_closes_exporter_and_ckpt_on_exception(self) -> None:
         """A training exception must still drain the exporter and ckpt manager.

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -32,6 +32,7 @@ from tzrec.loss.pe_mtl_loss import ParetoEfficientMultiTaskLoss
 from tzrec.modules.utils import BaseModule
 from tzrec.protos.loss_pb2 import LossConfig
 from tzrec.protos.model_pb2 import FeatureGroupConfig, ModelConfig
+from tzrec.utils import config_util
 from tzrec.utils.load_class import get_register_class_meta
 
 _MODEL_CLASS_MAP = {}
@@ -62,9 +63,14 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
         self._features = features
         self._feature_groups = list(model_config.feature_groups)
         self._labels = labels
-        self._model_config = (
-            getattr(model_config, self._model_type) if self._model_type else None
-        )
+        if self._model_type == "custom_model":
+            self._model_config = config_util.unpack_any(
+                model_config.custom_model.config
+            )
+        elif self._model_type:
+            self._model_config = getattr(model_config, self._model_type)
+        else:
+            self._model_config = None
         self._metric_modules = nn.ModuleDict()
         self._loss_modules = nn.ModuleDict()
 

--- a/tzrec/protos/model.proto
+++ b/tzrec/protos/model.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 package tzrec.protos;
 
+import "google/protobuf/any.proto";
 import "tzrec/protos/models/rank_model.proto";
 import "tzrec/protos/models/multi_task_rank.proto";
 import "tzrec/protos/models/match_model.proto";
@@ -43,6 +44,11 @@ enum Kernel {
     CUTLASS = 2;
 }
 
+message CustomModel {
+    required string class_path = 1;
+    optional google.protobuf.Any config = 2;
+}
+
 message ModelConfig {
 
     repeated FeatureGroupConfig feature_groups = 1;
@@ -81,6 +87,8 @@ message ModelConfig {
         // SID generation models
         SidRqvae sid_rqvae = 600;
         SidRqkmeans sid_rqkmeans = 601;
+
+        CustomModel custom_model = 1000;
     }
 
     optional uint32 num_class = 2 [default = 1];

--- a/tzrec/protos/pipeline.proto
+++ b/tzrec/protos/pipeline.proto
@@ -27,3 +27,20 @@ message EasyRecConfig {
 
     optional ModelConfig model_config = 9;
 }
+
+// Minimal mirror of EasyRecConfig used to read custom_model.class_path before the
+// full config is parsed, so that the module defining the custom model registers
+// its protobuf descriptors first. Only the fields on the path to class_path are
+// declared, the rest of the config, including the not-yet-registered Any, is
+// skipped as unknown field. Keep the field names in sync with EasyRecConfig.
+message PreloadCustomModel {
+    optional string class_path = 1;
+}
+
+message PreloadModelConfig {
+    optional PreloadCustomModel custom_model = 1;
+}
+
+message PreloadConfig {
+    optional PreloadModelConfig model_config = 1;
+}

--- a/tzrec/tests/custom_model_integration_test.py
+++ b/tzrec/tests/custom_model_integration_test.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2025, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+import tzrec
+from tzrec.tests import utils
+from tzrec.utils.test_util import make_test_dir
+
+_PROTO = """syntax = "proto2";
+package my_models.protos;
+
+import "tzrec/protos/module.proto";
+
+message CustomRankModelConfig {
+    required tzrec.protos.MLP mlp = 1;
+}
+"""
+
+_MODEL = """from typing import Any, Dict, List, Optional
+
+import torch
+from torch import nn
+
+from tzrec.datasets.utils import Batch
+from tzrec.features.feature import BaseFeature
+from tzrec.models.rank_model import RankModel
+from tzrec.modules.mlp import MLP
+from tzrec.protos.model_pb2 import ModelConfig
+from tzrec.utils.config_util import config_to_kwargs
+
+from my_models.protos.rank_pb2 import CustomRankModelConfig  # NOQA
+
+
+class MyRankModel(RankModel):
+    \"\"\"A rank model defined outside of the TorchEasyRec source tree.\"\"\"
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        features: List[BaseFeature],
+        labels: List[str],
+        sample_weights: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(model_config, features, labels, sample_weights, **kwargs)
+        self.init_input()
+        self.mlp = MLP(
+            self.embedding_group.group_total_dim("deep"),
+            **config_to_kwargs(self._model_config.mlp),
+        )
+        self.output_mlp = nn.Linear(self.mlp.output_dim(), self._num_class)
+
+    def predict(self, batch: Batch) -> Dict[str, torch.Tensor]:
+        \"\"\"Forward the model.\"\"\"
+        grouped_features = self.build_input(batch)
+        y = self.output_mlp(self.mlp(grouped_features["deep"]))
+        return self._output_to_prediction(y)
+"""
+
+_CONFIG = """
+train_input_path: ""
+eval_input_path: ""
+model_dir: "experiments/custom_rank_model"
+train_config {
+    sparse_optimizer {
+        adagrad_optimizer {
+            lr: 0.001
+        }
+        constant_learning_rate {
+        }
+    }
+    dense_optimizer {
+        adam_optimizer {
+            lr: 0.001
+        }
+        constant_learning_rate {
+        }
+    }
+    num_epochs: 1
+}
+eval_config {
+}
+data_config {
+    batch_size: 8192
+    dataset_type: ParquetDataset
+    label_fields: "clk"
+    num_workers: 2
+}
+feature_configs {
+    id_feature {
+        feature_name: "id_1"
+        num_buckets: 100
+        embedding_dim: 16
+    }
+}
+feature_configs {
+    id_feature {
+        feature_name: "id_2"
+        num_buckets: 1000
+        embedding_dim: 8
+    }
+}
+feature_configs {
+    raw_feature {
+        feature_name: "raw_1"
+    }
+}
+model_config {
+    feature_groups {
+        group_name: "deep"
+        feature_names: "id_1"
+        feature_names: "id_2"
+        feature_names: "raw_1"
+        group_type: DEEP
+    }
+    custom_model {
+        class_path: "my_models.models.rank.MyRankModel"
+        config {
+            [type.googleapis.com/my_models.protos.CustomRankModelConfig] {
+                mlp {
+                    hidden_units: [32, 16]
+                }
+            }
+        }
+    }
+    metrics {
+        auc {}
+    }
+    losses {
+        binary_cross_entropy {}
+    }
+}
+"""
+
+
+class CustomModelIntegrationTest(unittest.TestCase):
+    """A custom model defined and trained from outside the TorchEasyRec tree."""
+
+    def setUp(self):
+        self.success = False
+        self.test_dir = make_test_dir()
+
+    def tearDown(self):
+        if self.success:
+            if os.path.exists(self.test_dir):
+                shutil.rmtree(self.test_dir)
+
+    def _create_custom_package(self) -> str:
+        """Write and compile a custom model package outside of tzrec."""
+        project_dir = os.path.abspath(os.path.join(self.test_dir, "my-rec-project"))
+        for pkg in ["my_models", "my_models/models", "my_models/protos"]:
+            os.makedirs(os.path.join(project_dir, pkg))
+            with open(os.path.join(project_dir, pkg, "__init__.py"), "w"):
+                pass
+        with open(os.path.join(project_dir, "my_models/protos/rank.proto"), "w") as f:
+            f.write(_PROTO)
+        with open(os.path.join(project_dir, "my_models/models/rank.py"), "w") as f:
+            f.write(_MODEL)
+
+        # the protoc command documented in docs/source/models/user_define.md
+        tzrec_path = os.path.dirname(os.path.dirname(os.path.abspath(tzrec.__file__)))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "grpc_tools.protoc",
+                "-I.",
+                f"-I{tzrec_path}",
+                "my_models/protos/rank.proto",
+                "--python_out=.",
+                "--pyi_out=.",
+            ],
+            cwd=project_dir,
+            check=True,
+        )
+        return project_dir
+
+    def test_custom_model_train_eval_export(self):
+        project_dir = self._create_custom_package()
+        config_path = os.path.join(project_dir, "custom_rank_model.config")
+        with open(config_path, "w") as f:
+            f.write(_CONFIG)
+        # the model module has to be importable to parse a config using it
+        sys.path.insert(0, project_dir)
+        pythonpath = f".:{project_dir}"
+
+        self.success = utils.test_train_eval(
+            config_path, self.test_dir, pythonpath=pythonpath
+        )
+        self.assertTrue(self.success)
+
+        # eval and export reload the config saved beside the model in a fresh
+        # process, class_path alone has to resolve the model there
+        saved_config_path = os.path.join(self.test_dir, "train/pipeline.config")
+        self.assertTrue(os.path.exists(saved_config_path))
+        self.success = utils.test_eval(
+            saved_config_path, self.test_dir, pythonpath=pythonpath
+        )
+        self.assertTrue(self.success)
+        self.success = utils.test_export(
+            saved_config_path, self.test_dir, pythonpath=pythonpath
+        )
+        self.assertTrue(self.success)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.test_dir, "export/scripted_model.pt"))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tzrec/tests/utils.py
+++ b/tzrec/tests/utils.py
@@ -1044,6 +1044,7 @@ def test_train_eval(
     num_rows: Optional[int] = None,
     learnable_label: Optional[str] = None,
     num_epochs: Optional[int] = None,
+    pythonpath: str = ".",
 ) -> bool:
     """Run train_eval integration test."""
     pipeline_config = load_config_for_test(
@@ -1061,7 +1062,7 @@ def test_train_eval(
     config_util.save_message(pipeline_config, test_config_path)
     log_dir = os.path.join(test_dir, "log_train_eval")
     cmd_str = (
-        f"PYTHONPATH=. torchrun {_standalone()} "
+        f"PYTHONPATH={pythonpath} torchrun {_standalone()} "
         f"--nnodes=1 --nproc-per-node={_get_nproc_per_node()} --log_dir {log_dir} "
         "-r 3 -t 3 tzrec/train_eval.py "
         f"--pipeline_config_path {test_config_path} {args_str}"
@@ -1077,11 +1078,12 @@ def test_eval(
     pipeline_config_path: str,
     test_dir: str,
     env_str: str = "",
+    pythonpath: str = ".",
 ) -> bool:
     """Run evaluate integration test."""
     log_dir = os.path.join(test_dir, "log_eval")
     cmd_str = (
-        f"PYTHONPATH=. torchrun {_standalone()} "
+        f"PYTHONPATH={pythonpath} torchrun {_standalone()} "
         f"--nnodes=1 --nproc-per-node={_get_nproc_per_node()} --log_dir {log_dir} "
         "-r 3 -t 3 tzrec/eval.py "
         f"--pipeline_config_path {pipeline_config_path}"
@@ -1101,12 +1103,13 @@ def test_export(
     env_str: str = "",
     additional_export_config: str = "",
     item_input_path: str = "",
+    pythonpath: str = ".",
 ) -> bool:
     """Run export integration test."""
     log_dir = os.path.join(test_dir, "log_export")
     export_dir = export_dir or f"{test_dir}/export"
     cmd_str = (
-        f"PYTHONPATH=. torchrun {_standalone()} "
+        f"PYTHONPATH={pythonpath} torchrun {_standalone()} "
         f"--nnodes=1 --nproc-per-node={_get_nproc_per_node()} --log_dir {log_dir} "
         "-r 3 -t 3 tzrec/export.py "
         f"--pipeline_config_path {pipeline_config_path} "

--- a/tzrec/utils/config_util.py
+++ b/tzrec/utils/config_util.py
@@ -14,11 +14,12 @@ import re
 from typing import Any, Dict, List, Optional, Type, Union
 
 import numpy as np
-from google.protobuf import json_format, text_format
+from google.protobuf import any_pb2, json_format, symbol_database, text_format
 from google.protobuf.message import Message
 
 from tzrec.protos import data_pb2, eval_pb2, export_pb2, pipeline_pb2, train_pb2
 from tzrec.protos.data_pb2 import FgMode
+from tzrec.utils.load_class import import_class
 from tzrec.utils.logging_util import logger
 
 
@@ -35,16 +36,65 @@ def load_pipeline_config(
     Return:
         a object of pipeline_pb2.EasyRecConfig.
     """
-    config = pipeline_pb2.EasyRecConfig()
     with open(pipeline_config_path) as f:
-        if pipeline_config_path.endswith(".json"):
-            json_format.Parse(
-                f.read(), config, ignore_unknown_fields=allow_unknown_field
-            )
-        else:
-            text_format.Merge(f.read(), config, allow_unknown_field=allow_unknown_field)
+        content = f.read()
+    is_json = pipeline_config_path.endswith(".json")
+    _preload_custom_model(content, is_json)
+
+    config = pipeline_pb2.EasyRecConfig()
+    if is_json:
+        json_format.Parse(content, config, ignore_unknown_fields=allow_unknown_field)
+    else:
+        text_format.Merge(content, config, allow_unknown_field=allow_unknown_field)
     # compatible for fg_encoded
     config.data_config.fg_mode = _get_compatible_fg_mode(config.data_config)
+    return config
+
+
+def _preload_custom_model(content: str, is_json: bool) -> None:
+    """Import the custom model module before the pipeline config is parsed.
+
+    A custom model config is embedded in a google.protobuf.Any, whose type must
+    be registered in the default descriptor pool before parsing. Read class_path
+    with a pre-parse that tolerates the not-yet-registered Any, and import the
+    module defining the model, which registers the descriptor on the way.
+
+    Args:
+        content (str): raw content of a pipeline config.
+        is_json (bool): whether the content is in json format.
+    """
+    preload = pipeline_pb2.PreloadConfig()
+    if is_json:
+        json_format.Parse(content, preload, ignore_unknown_fields=True)
+    else:
+        text_format.Merge(content, preload, allow_unknown_field=True)
+    class_path = preload.model_config.custom_model.class_path
+    if class_path:
+        import_class(class_path)
+
+
+def unpack_any(any_config: any_pb2.Any) -> Optional[Message]:
+    """Unpack a google.protobuf.Any into its concrete message.
+
+    Args:
+        any_config (Any): a google.protobuf.Any message.
+
+    Return:
+        the packed message, or None when the Any is not set.
+    """
+    type_name = any_config.TypeName()
+    if not type_name:
+        return None
+    try:
+        config_cls = symbol_database.Default().GetSymbol(type_name)
+    except KeyError as e:
+        raise ValueError(
+            f"config type [{type_name}] is not registered, please make sure the "
+            "module defining the model imports its generated *_pb2 module."
+        ) from e
+    config = config_cls()
+    if not any_config.Unpack(config):
+        raise ValueError(f"failed to unpack config of type [{type_name}].")
     return config
 
 

--- a/tzrec/utils/config_util_test.py
+++ b/tzrec/utils/config_util_test.py
@@ -9,13 +9,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import unittest
+from unittest import mock
 
+from tzrec.protos.module_pb2 import MLP
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import config_util
+from tzrec.utils.test_util import make_test_dir
 
 
 class ConfigUtilTest(unittest.TestCase):
+    _UNREGISTERED_MODEL_CONFIG = """
+        train_input_path: "odps://train"
+        feature_configs {
+          id_feature { feature_name: "f1" embedding_dim: 16 }
+        }
+        model_config {
+          feature_groups {
+            group_name: "g1"
+            feature_names: "f1"
+            group_type: DEEP
+          }
+          custom_model {
+            config {
+              [type.googleapis.com/my_models.protos.CustomRankModelConfig] {
+                mlp { hidden_units: 128 }
+              }
+            }
+            class_path: "my_models.models.rank.MyRankModel"
+          }
+        }
+        """
+
+    def test_preload_custom_model(self):
+        with mock.patch("tzrec.utils.config_util.import_class") as import_class:
+            config_util._preload_custom_model(
+                self._UNREGISTERED_MODEL_CONFIG, is_json=False
+            )
+        import_class.assert_called_once_with("my_models.models.rank.MyRankModel")
+
+    def test_preload_custom_model_json(self):
+        content = json.dumps(
+            {
+                "trainInputPath": "odps://train",
+                "modelConfig": {
+                    "customModel": {
+                        "config": {
+                            "@type": (
+                                "type.googleapis.com/"
+                                "my_models.protos.CustomRankModelConfig"
+                            ),
+                            "mlp": {"hiddenUnits": [128]},
+                        },
+                        "classPath": "my_models.models.rank.MyRankModel",
+                    }
+                },
+            }
+        )
+        with mock.patch("tzrec.utils.config_util.import_class") as import_class:
+            config_util._preload_custom_model(content, is_json=True)
+        import_class.assert_called_once_with("my_models.models.rank.MyRankModel")
+
+    def test_preload_custom_model_without_custom_model(self):
+        with mock.patch("tzrec.utils.config_util.import_class") as import_class:
+            config_util._preload_custom_model('train_input_path: "a"', is_json=False)
+        import_class.assert_not_called()
+
+    def test_load_custom_model_any_config(self):
+        config_path = os.path.join(make_test_dir(), "custom_model.config")
+        with open(config_path, "w") as f:
+            f.write(
+                """
+                model_config {
+                  custom_model {
+                    class_path: "tzrec.models.model.BaseModel"
+                    config {
+                      [type.googleapis.com/tzrec.protos.MLP] {
+                        hidden_units: 32
+                        hidden_units: 16
+                      }
+                    }
+                  }
+                }
+                """
+            )
+
+        pipeline_config = config_util.load_pipeline_config(config_path)
+        mlp_config = config_util.unpack_any(
+            pipeline_config.model_config.custom_model.config
+        )
+        self.assertEqual(list(mlp_config.hidden_units), [32, 16])
+
+    def test_unpack_any_not_set(self):
+        self.assertIsNone(
+            config_util.unpack_any(EasyRecConfig().model_config.custom_model.config)
+        )
+
+    def test_unpack_any_unregistered_type(self):
+        model_config = EasyRecConfig().model_config
+        model_config.custom_model.config.Pack(MLP(hidden_units=[8]))
+        model_config.custom_model.config.type_url = (
+            "type.googleapis.com/my_models.protos.NotRegistered"
+        )
+        with self.assertRaisesRegex(ValueError, "is not registered"):
+            config_util.unpack_any(model_config.custom_model.config)
+
     def test_get_inference_batch_size(self):
         pipeline_config = EasyRecConfig()
         pipeline_config.data_config.batch_size = 16

--- a/tzrec/utils/load_class.py
+++ b/tzrec/utils/load_class.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 import pkgutil
 import pydoc
@@ -143,6 +144,30 @@ def get_register_class_meta(class_map):
             return newclass
 
     return RegisterABCMeta
+
+
+def import_class(class_path):
+    """Import a class by its full python path.
+
+    Unlike :func:`load_by_path`, import errors are not swallowed, they propagate
+    with their original traceback.
+
+    Args:
+        class_path: full path of a class, such as: my_models.models.rank.MyModel
+
+    Return:
+        a class.
+    """
+    module_path, _, class_name = class_path.rpartition(".")
+    if not module_path:
+        raise ValueError(
+            f"{class_path} is not a full class path, expect a path like "
+            "my_models.models.rank.MyModel."
+        )
+    module = importlib.import_module(module_path)
+    if not hasattr(module, class_name):
+        raise ValueError(f"class {class_name} is not found in module {module_path}.")
+    return getattr(module, class_name)
 
 
 def load_by_path(path):

--- a/tzrec/utils/load_class_test.py
+++ b/tzrec/utils/load_class_test.py
@@ -13,10 +13,25 @@ import unittest
 
 import torch
 
-from tzrec.utils.load_class import load_by_path
+from tzrec.utils.load_class import import_class, load_by_path
 
 
 class LoadClassTest(unittest.TestCase):
+    def test_import_class(self):
+        self.assertEqual(import_class("torch.nn.ReLU"), torch.nn.ReLU)
+
+    def test_import_class_propagates_import_error(self):
+        with self.assertRaises(ModuleNotFoundError):
+            import_class("tzrec.no_such_module.MyModel")
+
+    def test_import_class_missing_attribute(self):
+        with self.assertRaisesRegex(ValueError, "is not found in module"):
+            import_class("torch.nn.MyReLU")
+
+    def test_import_class_without_module(self):
+        with self.assertRaisesRegex(ValueError, "is not a full class path"):
+            import_class("MyModel")
+
     def test_load_by_path(self):
         loaded_cls = load_by_path("nn.ReLU")
         self.assertEqual(loaded_cls, torch.nn.ReLU)


### PR DESCRIPTION
## Summary

Custom models can live entirely in the user's own project, with nothing to edit in this repo.

- add a generic `CustomModel` entry to the `ModelConfig` oneof, backed by `google.protobuf.Any`
- resolve the model class from `custom_model.class_path`, the only declaration a user needs
- import the module named by `class_path` before the pipeline config is parsed, so its protobuf descriptors are registered in time
- rewrite the custom-model documentation around a standalone project

## Motivation

The previous workflow required each user model to edit shared model protos and drop code into `tzrec/models/`. Those edits regularly conflict when merging or rebasing on upstream. Model code, config protos and pipeline configs should be able to live in an independent project while still reusing shared messages such as `MLP`.

## Design

**`class_path` is the single declaration.** A custom model config is embedded in a `google.protobuf.Any`, whose type must already be in the default descriptor pool when `text_format.Merge` runs, while the module that registers it is named by `class_path` inside that same config.

`load_pipeline_config` breaks that cycle by pre-parsing the content against `PreloadConfig`, a minimal mirror of `EasyRecConfig` that declares only the path down to `class_path` and omits the `Any` field. Because `config` is an unknown field there, `text_format` skips the whole block structurally, including the `[type.googleapis.com/...]` type URL, without consulting the pool. The module named by `class_path` is then imported, and the strict parse proceeds normally. The same holds for JSON configs via `ignore_unknown_fields`.

This avoids a second declaration (an env var or a package list), which matters because `class_path` is persisted into `model_dir/pipeline.config`. Eval, export, predict, feature selection and serving prep all reload that file in fresh processes and resolve the custom model with no extra environment.

**Same constructor as built-in models.** `BaseModel` unpacks the `Any` into `self._model_config` itself, so a custom model's `__init__` signature is identical to `DSSM`'s and existing config access patterns keep working.

**No new proto tooling.** A user's protos are compiled with plain `python -m grpc_tools.protoc`; the docs give the concrete `-I` for each layout (`third_party/TorchEasyRec` for a submodule, `pip show tzrec` Location for a wheel install), and note that the `-I` is only needed at all if the proto imports a tzrec proto. Only the user's protos are listed on the command line, so no `tzrec/protos/*_pb2.py` is emitted into their tree. Compiling user protos needs the tzrec `.proto` source, not its compiled bindings, so it is independent of whether tzrec's own `_pb2` have been generated yet.

An earlier revision added a `tzrec.tools.gen_proto` module for this. It was dropped: any `python -m tzrec.*` entry point executes `tzrec/__init__.py`, so it failed outright on a fresh submodule checkout (`ImportError: cannot import name 'data_pb2'`) and on corrupt bindings, which are exactly the states you would be regenerating protos to fix, while silently passing on stale bindings, the one state where a guard would help.

**Import errors surface.** `import_class` is used instead of `load_by_path`, whose `pydoc.locate` swallows `ErrorDuringImport` into a printed traceback and a `None` return, turning a typo in a user model into a misleading "must inherit BaseModel".

## User impact

```protobuf
model_config {
    feature_groups { ... }
    custom_model {
        class_path: "my_models.models.custom_rank_model.CustomRankModel"
        config {
            [type.googleapis.com/my_models.protos.CustomRankModelConfig] {
                mlp { hidden_units: [128, 64] }
            }
        }
    }
}
```

The package may be named anything and live anywhere importable. The docs cover two project layouts with equal weight: tzrec installed as a wheel, and tzrec pinned as a git submodule. They also cover editor navigation (a shell `PYTHONPATH` does not reach Pylance, so `.vscode/settings.json` needs `python.analysis.extraPaths`), single-process debugging, and the common errors.

## Test Plan

- `PYTHONPATH=. python -m unittest tzrec.utils.config_util_test tzrec.utils.load_class_test tzrec.main_test tzrec.tools.gen_proto_test`
- `pre-commit run -a`, `pyrefly check` (0 errors)
- `tzrec/tests/custom_model_integration_test.py` runs the whole loop out of tree on mock data: it writes a custom model package outside this repo, whose proto imports `tzrec/protos/module.proto` and whose model is the one in the documentation, compiles it with the exact protoc command the docs give, then runs real `train_eval`, `eval` and `export` under torchrun with the package on `PYTHONPATH`, asserting `scripted_model.pt` is produced. `eval` and `export` read the `pipeline.config` saved beside the model in fresh processes, so they prove `class_path` alone resolves the model with no extra environment. `test_train_eval`, `test_eval` and `test_export` in `tzrec/tests/utils.py` gained a `pythonpath` argument defaulting to the previous `.` so a test can put an out-of-tree package on the path.
- manual, against a wheel built from this branch and pip-installed into a venv: a project containing only `my_models/` and `configs/` generates its bindings with the documented command, loads and builds the model, saves the config, and a fresh process rebuilds the model from the saved config. Repeated for the git-submodule layout, including against a submodule with no `_pb2` generated yet.
- full unit test suite: 1649 tests, no failures. Six HSTU integration tests initially failed for missing `data/test/kuairand-*` fixtures that `scripts/ci/ci_data.sh` downloads; they pass once the data is present.
