### PR TITLE
[feat] support timestamp order in HSTU Match

### DIFF
--- a/docs/source/models/hstu_match.md
+++ b/docs/source/models/hstu_match.md
@@ -200,6 +200,7 @@ model_config {
         }
         similarity: COSINE
         temperature: 0.05
+        sequence_timestamp_is_ascending: true
     }
     metrics {
         recall_at_k {
@@ -254,6 +255,7 @@ model_config {
   - output_dim: 可选，user/item 输出 embedding 维度；默认 0，表示不再追加 output Linear，由 user 塔的 STU 输出与 item 塔的 MLP 输出直接对齐
   - similarity: 向量相似度函数，包括 [COSINE, INNER_PRODUCT]，默认 INNER_PRODUCT (示例使用 COSINE)
   - temperature: 相似度缩放因子，softmax 前对 logits 除以该值，默认 1.0
+  - sequence_timestamp_is_ascending: UIH 时间戳是否按从旧到新的顺序排列，默认 true；输入按从新到旧排列时设为 false。该配置只调整用户侧序列，候选 Item 与负采样结果的顺序保持不变
 
 - kernel: 算子实现，可选 TRITON/PYTORCH/CUTLASS，详见 [DLRM-HSTU](dlrm_hstu.md) 文档
 

--- a/tzrec/models/dlrm_hstu.py
+++ b/tzrec/models/dlrm_hstu.py
@@ -36,8 +36,9 @@ from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.protos.tower_pb2 import FusionSubTaskConfig
 from tzrec.utils.config_util import config_to_kwargs
-from tzrec.utils.fx_util import fx_int_item, fx_numel
+from tzrec.utils.fx_util import _fx_flip_tensor_dict, fx_int_item, fx_numel
 
+torch.fx.wrap(_fx_flip_tensor_dict)
 torch.fx.wrap(fx_int_item)
 torch.fx.wrap(fx_numel)
 
@@ -67,16 +68,6 @@ def _fx_avg_batch_size(x: torch.Tensor) -> torch.Tensor:
     if dist.is_initialized():
         dist.all_reduce(batch_size, op=dist.ReduceOp.AVG)
     return batch_size
-
-
-@torch.fx.wrap
-def _fx_flip_tensor_dict(
-    grouped_features: Dict[str, torch.Tensor],
-) -> Dict[str, torch.Tensor]:
-    new_grouped_features = {}
-    for k, v in grouped_features.items():
-        new_grouped_features[k] = torch.flip(v, [0])
-    return new_grouped_features
 
 
 class DlrmHSTU(RankModel):

--- a/tzrec/models/dlrm_hstu.py
+++ b/tzrec/models/dlrm_hstu.py
@@ -36,9 +36,9 @@ from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.protos.models import multi_task_rank_pb2
 from tzrec.protos.tower_pb2 import FusionSubTaskConfig
 from tzrec.utils.config_util import config_to_kwargs
-from tzrec.utils.fx_util import _fx_flip_tensor_dict, fx_int_item, fx_numel
+from tzrec.utils.fx_util import fx_flip_tensor_dict, fx_int_item, fx_numel
 
-torch.fx.wrap(_fx_flip_tensor_dict)
+torch.fx.wrap(fx_flip_tensor_dict)
 torch.fx.wrap(fx_int_item)
 torch.fx.wrap(fx_numel)
 
@@ -199,7 +199,7 @@ class DlrmHSTU(RankModel):
         if not self._model_config.sequence_timestamp_is_ascending:
             # if timestamp of sequence is descending,
             # we should reverse all features
-            grouped_features = _fx_flip_tensor_dict(grouped_features)
+            grouped_features = fx_flip_tensor_dict(grouped_features)
 
         with record_function("## item_forward ##"):
             candidates_item_embeddings = self._item_embedding_mlp(
@@ -216,7 +216,7 @@ class DlrmHSTU(RankModel):
         if not self._model_config.sequence_timestamp_is_ascending:
             # if timestamp of sequence is descending,
             # we should reverse predictions back to input order
-            mt_preds = _fx_flip_tensor_dict(mt_preds)
+            mt_preds = fx_flip_tensor_dict(mt_preds)
 
         predictions = {}
         for task_cfg in self._task_configs:

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -42,12 +42,12 @@ torch.fx.wrap(fx_flip_tensor_dict)
 
 @torch.fx.wrap
 def _fx_filter_tensor_dict(
-    tensor_dict: Dict[str, torch.Tensor], filter_keys: List[str]
+    tensor_dict: Dict[str, torch.Tensor], filter_prefix: str
 ) -> Dict[str, torch.Tensor]:
-    """Return a tensor dictionary without the filtered keys."""
+    """Return a tensor dictionary without keys matching a prefix."""
     filtered_tensor_dict = {}
     for key, value in tensor_dict.items():
-        if key not in filter_keys:
+        if not key.startswith(filter_prefix):
             filtered_tensor_dict[key] = value
     return filtered_tensor_dict
 
@@ -238,13 +238,6 @@ class HSTUMatchItemTower(MatchTowerWoEG):
             return self._feature_groups_scalar
         return self._feature_groups
 
-    @property
-    def grouped_feature_name(self) -> str:
-        """Grouped candidate feature name in the current inference view."""
-        # `.sequence` (jagged) at training, `.query` (scalar) at export.
-        suffix = ".query" if self._is_inference else ".sequence"
-        return self._group_name + suffix
-
     def _build_scalar_features(self) -> None:
         """Project each grouped sequence sub-feature into a scalar export feature."""
         scalar_configs = [
@@ -278,7 +271,9 @@ class HSTUMatchItemTower(MatchTowerWoEG):
         Returns:
             item embeddings of shape (sum_candidates, D).
         """
-        cand_emb = grouped_features[self.grouped_feature_name]
+        # `.sequence` (jagged) at training, `.query` (scalar) at export.
+        suffix = ".query" if self._is_inference else ".sequence"
+        cand_emb = grouped_features[self._group_name + suffix]
         item_emb = self.mlp(cand_emb)
         if self._output_dim > 0:
             item_emb = self.output(item_emb)
@@ -341,7 +336,7 @@ class HSTUMatch(MatchModel):
         )
 
         user_tower_cfg = self._model_config.user_tower
-        item_tower_cfg = self._model_config.item_tower
+        self.item_tower_cfg = self._model_config.item_tower
         set_static_max_seq_lens([user_tower_cfg.max_seq_len])
 
         self.embedding_group = EmbeddingGroup(
@@ -349,7 +344,7 @@ class HSTUMatch(MatchModel):
         )
 
         name_to_feature_group = {x.group_name: x for x in model_config.feature_groups}
-        candidate_feature_group = name_to_feature_group[item_tower_cfg.input]
+        candidate_feature_group = name_to_feature_group[self.item_tower_cfg.input]
         # User tower consumes every feature group except the candidate. That
         # includes the primary uih group, optional contextual, and any
         # auxiliary uih_* groups (uih_action / uih_watchtime / uih_timestamp)
@@ -360,7 +355,7 @@ class HSTUMatch(MatchModel):
         user_feature_groups = [
             feature_group
             for feature_group in model_config.feature_groups
-            if feature_group.group_name != item_tower_cfg.input
+            if feature_group.group_name != self.item_tower_cfg.input
         ]
         user_features = self.get_features_in_feature_groups(user_feature_groups)
         candidate_features = self.get_features_in_feature_groups(
@@ -380,7 +375,7 @@ class HSTUMatch(MatchModel):
         )
 
         self.item_tower = HSTUMatchItemTower(
-            tower_config=item_tower_cfg,
+            tower_config=self.item_tower_cfg,
             output_dim=self._model_config.output_dim,
             similarity=self._model_config.similarity,
             feature_groups=[candidate_feature_group],
@@ -401,11 +396,15 @@ class HSTUMatch(MatchModel):
         """
         grouped_features = self.embedding_group(batch)
 
+        if self._model_config.sequence_timestamp_is_ascending:
+            user_emb = self.user_tower(grouped_features)
+        else:
+            user_grouped_features = _fx_filter_tensor_dict(
+                grouped_features,
+                self.item_tower_cfg.input + ".",
+            )
+            user_emb = self.user_tower(user_grouped_features)
         item_emb = self.item_tower(grouped_features)
-        user_grouped_features = _fx_filter_tensor_dict(
-            grouped_features, [self.item_tower.grouped_feature_name]
-        )
-        user_emb = self.user_tower(user_grouped_features)
 
         pos_lengths_t = batch.additional_infos.get(CAND_POS_LENGTHS, None)
         assert pos_lengths_t is not None, (

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -246,6 +246,7 @@ class HSTUMatchItemTower(MatchTowerWoEG):
     @property
     def grouped_feature_name(self) -> str:
         """Grouped candidate feature name in the current inference view."""
+        # `.sequence` (jagged) at training, `.query` (scalar) at export.
         suffix = ".query" if self._is_inference else ".sequence"
         return self._group_name + suffix
 

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -37,6 +37,17 @@ from tzrec.protos.models import match_model_pb2
 from tzrec.utils.config_util import config_to_kwargs
 
 
+@torch.fx.wrap
+def _fx_flip_user_tensor_dict(
+    grouped_features: Dict[str, torch.Tensor], candidate_group_name: str
+) -> Dict[str, torch.Tensor]:
+    candidate_prefix = candidate_group_name + "."
+    return {
+        key: value if key.startswith(candidate_prefix) else torch.flip(value, [0])
+        for key, value in grouped_features.items()
+    }
+
+
 class HSTUUserTower(MatchTowerWoEG):
     """HSTU user tower (reusable beyond match — produces a user embedding).
 
@@ -60,6 +71,10 @@ class HSTUUserTower(MatchTowerWoEG):
         features (list): list of features for every group in `feature_groups`.
         embedding_group (EmbeddingGroup): shared embedding group used to
             resolve per-group dims at construction time (not stored).
+        sequence_timestamp_is_ascending (bool): whether UIH timestamps are
+            ordered from oldest to newest.
+        candidate_group_name (str): candidate feature group whose tensors must
+            retain sampler order while user-side tensors are reversed.
     """
 
     def __init__(
@@ -70,8 +85,12 @@ class HSTUUserTower(MatchTowerWoEG):
         feature_groups: List[model_pb2.FeatureGroupConfig],
         features: List[BaseFeature],
         embedding_group: EmbeddingGroup,
+        sequence_timestamp_is_ascending: bool,
+        candidate_group_name: str,
     ) -> None:
         super().__init__(tower_config, output_dim, similarity, feature_groups, features)
+        self._sequence_timestamp_is_ascending = sequence_timestamp_is_ascending
+        self._candidate_group_name = candidate_group_name
 
         contextual_feature_group = next(
             (
@@ -131,7 +150,13 @@ class HSTUUserTower(MatchTowerWoEG):
         Returns:
             user embeddings of shape (B, D), last-position embedding per user.
         """
+        if not self._sequence_timestamp_is_ascending:
+            grouped_features = _fx_flip_user_tensor_dict(
+                grouped_features, self._candidate_group_name
+            )
         user_emb = self._hstu_encoder(grouped_features)
+        if not self._sequence_timestamp_is_ascending:
+            user_emb = torch.flip(user_emb, [0])
         if self._output_dim > 0:
             user_emb = self.output(user_emb)
         if self._similarity == simi_pb2.Similarity.COSINE:
@@ -346,6 +371,10 @@ class HSTUMatch(MatchModel):
             feature_groups=user_feature_groups,
             features=user_features,
             embedding_group=self.embedding_group,
+            sequence_timestamp_is_ascending=(
+                self._model_config.sequence_timestamp_is_ascending
+            ),
+            candidate_group_name=item_tower_cfg.input,
         )
 
         self.item_tower = HSTUMatchItemTower(

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -35,14 +35,9 @@ from tzrec.protos import model_pb2, simi_pb2, tower_pb2
 from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.protos.models import match_model_pb2
 from tzrec.utils.config_util import config_to_kwargs
+from tzrec.utils.fx_util import _fx_flip_tensor_dict
 
-
-@torch.fx.wrap
-def _fx_flip_user_tensor_dict(
-    grouped_features: Dict[str, torch.Tensor],
-) -> Dict[str, torch.Tensor]:
-    """Reverse every user-side grouped feature tensor."""
-    return {key: torch.flip(value, [0]) for key, value in grouped_features.items()}
+torch.fx.wrap(_fx_flip_tensor_dict)
 
 
 @torch.fx.wrap
@@ -156,7 +151,7 @@ class HSTUUserTower(MatchTowerWoEG):
             user embeddings of shape (B, D), last-position embedding per user.
         """
         if not self._sequence_timestamp_is_ascending:
-            grouped_features = _fx_flip_user_tensor_dict(grouped_features)
+            grouped_features = _fx_flip_tensor_dict(grouped_features)
         user_emb = self._hstu_encoder(grouped_features)
         if not self._sequence_timestamp_is_ascending:
             user_emb = torch.flip(user_emb, [0])

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -35,13 +35,13 @@ from tzrec.protos import model_pb2, simi_pb2, tower_pb2
 from tzrec.protos.model_pb2 import ModelConfig
 from tzrec.protos.models import match_model_pb2
 from tzrec.utils.config_util import config_to_kwargs
-from tzrec.utils.fx_util import _fx_flip_tensor_dict
+from tzrec.utils.fx_util import fx_flip_tensor_dict
 
-torch.fx.wrap(_fx_flip_tensor_dict)
+torch.fx.wrap(fx_flip_tensor_dict)
 
 
 @torch.fx.wrap
-def _fix_filter_tensor_dict(
+def _fx_filter_tensor_dict(
     tensor_dict: Dict[str, torch.Tensor], filter_keys: List[str]
 ) -> Dict[str, torch.Tensor]:
     """Return a tensor dictionary without the filtered keys."""
@@ -151,7 +151,7 @@ class HSTUUserTower(MatchTowerWoEG):
             user embeddings of shape (B, D), last-position embedding per user.
         """
         if not self._sequence_timestamp_is_ascending:
-            grouped_features = _fx_flip_tensor_dict(grouped_features)
+            grouped_features = fx_flip_tensor_dict(grouped_features)
         user_emb = self._hstu_encoder(grouped_features)
         if not self._sequence_timestamp_is_ascending:
             user_emb = torch.flip(user_emb, [0])
@@ -402,7 +402,7 @@ class HSTUMatch(MatchModel):
         grouped_features = self.embedding_group(batch)
 
         item_emb = self.item_tower(grouped_features)
-        user_grouped_features = _fix_filter_tensor_dict(
+        user_grouped_features = _fx_filter_tensor_dict(
             grouped_features, [self.item_tower.grouped_feature_name]
         )
         user_emb = self.user_tower(user_grouped_features)

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -41,15 +41,15 @@ torch.fx.wrap(_fx_flip_tensor_dict)
 
 
 @torch.fx.wrap
-def _fx_filter_grouped_feature(
-    grouped_features: Dict[str, torch.Tensor], grouped_feature_name: str
+def _fix_filter_tensor_dict(
+    tensor_dict: Dict[str, torch.Tensor], filter_keys: List[str]
 ) -> Dict[str, torch.Tensor]:
-    """Return grouped features without the named feature tensor."""
-    filtered_features = {}
-    for key, value in grouped_features.items():
-        if key != grouped_feature_name:
-            filtered_features[key] = value
-    return filtered_features
+    """Return a tensor dictionary without the filtered keys."""
+    filtered_tensor_dict = {}
+    for key, value in tensor_dict.items():
+        if key not in filter_keys:
+            filtered_tensor_dict[key] = value
+    return filtered_tensor_dict
 
 
 class HSTUUserTower(MatchTowerWoEG):
@@ -402,8 +402,8 @@ class HSTUMatch(MatchModel):
         grouped_features = self.embedding_group(batch)
 
         item_emb = self.item_tower(grouped_features)
-        user_grouped_features = _fx_filter_grouped_feature(
-            grouped_features, self.item_tower.grouped_feature_name
+        user_grouped_features = _fix_filter_tensor_dict(
+            grouped_features, [self.item_tower.grouped_feature_name]
         )
         user_emb = self.user_tower(user_grouped_features)
 

--- a/tzrec/models/hstu.py
+++ b/tzrec/models/hstu.py
@@ -39,13 +39,22 @@ from tzrec.utils.config_util import config_to_kwargs
 
 @torch.fx.wrap
 def _fx_flip_user_tensor_dict(
-    grouped_features: Dict[str, torch.Tensor], candidate_group_name: str
+    grouped_features: Dict[str, torch.Tensor],
 ) -> Dict[str, torch.Tensor]:
-    candidate_prefix = candidate_group_name + "."
-    return {
-        key: value if key.startswith(candidate_prefix) else torch.flip(value, [0])
-        for key, value in grouped_features.items()
-    }
+    """Reverse every user-side grouped feature tensor."""
+    return {key: torch.flip(value, [0]) for key, value in grouped_features.items()}
+
+
+@torch.fx.wrap
+def _fx_filter_grouped_feature(
+    grouped_features: Dict[str, torch.Tensor], grouped_feature_name: str
+) -> Dict[str, torch.Tensor]:
+    """Return grouped features without the named feature tensor."""
+    filtered_features = {}
+    for key, value in grouped_features.items():
+        if key != grouped_feature_name:
+            filtered_features[key] = value
+    return filtered_features
 
 
 class HSTUUserTower(MatchTowerWoEG):
@@ -73,8 +82,6 @@ class HSTUUserTower(MatchTowerWoEG):
             resolve per-group dims at construction time (not stored).
         sequence_timestamp_is_ascending (bool): whether UIH timestamps are
             ordered from oldest to newest.
-        candidate_group_name (str): candidate feature group whose tensors must
-            retain sampler order while user-side tensors are reversed.
     """
 
     def __init__(
@@ -86,11 +93,9 @@ class HSTUUserTower(MatchTowerWoEG):
         features: List[BaseFeature],
         embedding_group: EmbeddingGroup,
         sequence_timestamp_is_ascending: bool,
-        candidate_group_name: str,
     ) -> None:
         super().__init__(tower_config, output_dim, similarity, feature_groups, features)
         self._sequence_timestamp_is_ascending = sequence_timestamp_is_ascending
-        self._candidate_group_name = candidate_group_name
 
         contextual_feature_group = next(
             (
@@ -151,9 +156,7 @@ class HSTUUserTower(MatchTowerWoEG):
             user embeddings of shape (B, D), last-position embedding per user.
         """
         if not self._sequence_timestamp_is_ascending:
-            grouped_features = _fx_flip_user_tensor_dict(
-                grouped_features, self._candidate_group_name
-            )
+            grouped_features = _fx_flip_user_tensor_dict(grouped_features)
         user_emb = self._hstu_encoder(grouped_features)
         if not self._sequence_timestamp_is_ascending:
             user_emb = torch.flip(user_emb, [0])
@@ -240,6 +243,12 @@ class HSTUMatchItemTower(MatchTowerWoEG):
             return self._feature_groups_scalar
         return self._feature_groups
 
+    @property
+    def grouped_feature_name(self) -> str:
+        """Grouped candidate feature name in the current inference view."""
+        suffix = ".query" if self._is_inference else ".sequence"
+        return self._group_name + suffix
+
     def _build_scalar_features(self) -> None:
         """Project each grouped sequence sub-feature into a scalar export feature."""
         scalar_configs = [
@@ -273,9 +282,7 @@ class HSTUMatchItemTower(MatchTowerWoEG):
         Returns:
             item embeddings of shape (sum_candidates, D).
         """
-        # `.sequence` (jagged) at training, `.query` (scalar) at export.
-        suffix = ".query" if self._is_inference else ".sequence"
-        cand_emb = grouped_features[self._group_name + suffix]
+        cand_emb = grouped_features[self.grouped_feature_name]
         item_emb = self.mlp(cand_emb)
         if self._output_dim > 0:
             item_emb = self.output(item_emb)
@@ -374,7 +381,6 @@ class HSTUMatch(MatchModel):
             sequence_timestamp_is_ascending=(
                 self._model_config.sequence_timestamp_is_ascending
             ),
-            candidate_group_name=item_tower_cfg.input,
         )
 
         self.item_tower = HSTUMatchItemTower(
@@ -399,8 +405,11 @@ class HSTUMatch(MatchModel):
         """
         grouped_features = self.embedding_group(batch)
 
-        user_emb = self.user_tower(grouped_features)
         item_emb = self.item_tower(grouped_features)
+        user_grouped_features = _fx_filter_grouped_feature(
+            grouped_features, self.item_tower.grouped_feature_name
+        )
+        user_emb = self.user_tower(user_grouped_features)
 
         pos_lengths_t = batch.additional_infos.get(CAND_POS_LENGTHS, None)
         assert pos_lengths_t is not None, (

--- a/tzrec/models/hstu_test.py
+++ b/tzrec/models/hstu_test.py
@@ -19,7 +19,7 @@ from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, CAND_POS_LENGTHS, Batch
 from tzrec.features.feature import create_features
-from tzrec.models.hstu import HSTUMatch
+from tzrec.models.hstu import HSTUMatch, _fx_filter_tensor_dict
 from tzrec.models.match_model import TowerWoEGWrapper
 from tzrec.models.model import TrainWrapper
 from tzrec.ops import Kernel
@@ -279,7 +279,6 @@ class HSTUMatchTest(unittest.TestCase):
         # The query_time DEEP group is detected and threaded as the per-row
         # time-bias anchor (request-time anchoring, not the last UIH event).
         self.assertEqual(hstu.user_tower._hstu_encoder._query_time_key, "query_time")
-        self.assertEqual(hstu.item_tower.grouped_feature_name, "candidate.sequence")
         hstu.set_kernel(kernel)
         batch = _build_batch(
             device=device,
@@ -310,7 +309,27 @@ class HSTUMatchTest(unittest.TestCase):
         self.assertFalse(scalar_features[0].is_grouped_sequence)
         self.assertEqual(scalar_feature_groups[0].feature_names, ["video_id"])
         self.assertEqual(scalar_feature_groups[0].group_name, "candidate")
-        self.assertEqual(hstu.item_tower.grouped_feature_name, "candidate.query")
+
+    def test_filter_tensor_dict_by_prefix(self) -> None:
+        """Candidate prefix filtering leaves unrelated grouped features intact."""
+        value = torch.tensor([1])
+        grouped_features = {
+            "candidate.query": value,
+            "candidate.sequence": value,
+            "candidate.sequence_length": value,
+            "candidate_aux.sequence": value,
+            "uih.sequence": value,
+        }
+
+        filtered_features = _fx_filter_tensor_dict(
+            grouped_features,
+            "candidate.",
+        )
+
+        self.assertEqual(
+            list(filtered_features.keys()),
+            ["candidate_aux.sequence", "uih.sequence"],
+        )
 
     def test_sequence_timestamp_order_parity(self) -> None:
         """Equivalent ascending and descending UIH inputs produce equal outputs."""
@@ -379,6 +398,18 @@ class HSTUMatchTest(unittest.TestCase):
             sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
         )
         hstu_wrapped = create_test_model(hstu, graph_type)
+        if graph_type == TestGraphType.FX_TRACE:
+            filter_nodes = [
+                node
+                for node in hstu_wrapped.graph.nodes
+                if node.target == _fx_filter_tensor_dict
+            ]
+            self.assertEqual(
+                len(filter_nodes),
+                int(not sequence_timestamp_is_ascending),
+            )
+            if filter_nodes:
+                self.assertEqual(filter_nodes[0].args[1], "candidate.")
         if graph_type == TestGraphType.JIT_SCRIPT:
             predictions = hstu_wrapped(batch.to_dict(), device)
         else:

--- a/tzrec/models/hstu_test.py
+++ b/tzrec/models/hstu_test.py
@@ -279,6 +279,7 @@ class HSTUMatchTest(unittest.TestCase):
         # The query_time DEEP group is detected and threaded as the per-row
         # time-bias anchor (request-time anchoring, not the last UIH event).
         self.assertEqual(hstu.user_tower._hstu_encoder._query_time_key, "query_time")
+        self.assertEqual(hstu.item_tower.grouped_feature_name, "candidate.sequence")
         hstu.set_kernel(kernel)
         batch = _build_batch(
             device=device,
@@ -309,6 +310,7 @@ class HSTUMatchTest(unittest.TestCase):
         self.assertFalse(scalar_features[0].is_grouped_sequence)
         self.assertEqual(scalar_feature_groups[0].feature_names, ["video_id"])
         self.assertEqual(scalar_feature_groups[0].group_name, "candidate")
+        self.assertEqual(hstu.item_tower.grouped_feature_name, "candidate.query")
 
     def test_sequence_timestamp_order_parity(self) -> None:
         """Equivalent ascending and descending UIH inputs produce equal outputs."""

--- a/tzrec/models/hstu_test.py
+++ b/tzrec/models/hstu_test.py
@@ -14,11 +14,13 @@ import unittest
 import torch
 from hypothesis import Verbosity, assume, given
 from hypothesis import strategies as st
+from parameterized import parameterized
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, CAND_POS_LENGTHS, Batch
 from tzrec.features.feature import create_features
 from tzrec.models.hstu import HSTUMatch
+from tzrec.models.match_model import TowerWoEGWrapper
 from tzrec.models.model import TrainWrapper
 from tzrec.ops import Kernel
 from tzrec.protos import (
@@ -37,13 +39,16 @@ from tzrec.utils.test_util import (
     create_test_model,
     gpu_unavailable,
     mark_ci_scope,
+    parameterized_name_func,
 )
 from tzrec.utils.test_util import (
     hypothesis_settings as settings,
 )
 
 
-def _build_model(device: torch.device) -> HSTUMatch:
+def _build_model(
+    device: torch.device, sequence_timestamp_is_ascending: bool = True
+) -> HSTUMatch:
     """Build an HSTUMatch model with standard test configuration.
 
     Mirrors the production grouped-sequence pattern: `uih_seq` and
@@ -162,6 +167,7 @@ def _build_model(device: torch.device) -> HSTUMatch:
             ),
             similarity=simi_pb2.Similarity.COSINE,
             temperature=0.05,
+            sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
         ),
         losses=[
             loss_pb2.LossConfig(softmax_cross_entropy=loss_pb2.SoftmaxCrossEntropy())
@@ -179,7 +185,9 @@ def _build_model(device: torch.device) -> HSTUMatch:
     return hstu
 
 
-def _build_batch(device: torch.device) -> Batch:
+def _build_batch(
+    device: torch.device, sequence_timestamp_is_ascending: bool = True
+) -> Batch:
     """Build a test Batch with the row-(B-1) suffix candidate layout.
 
     UIH: user1 has 3 items, user2 has 4 items.
@@ -187,24 +195,32 @@ def _build_batch(device: torch.device) -> Batch:
     simple_neg_1] -- the shared simple-neg pool sits in the last row's suffix.
     pos_lengths = [1, 1].
 
-    A per-row ``request_time`` dense scalar (strictly after each user's last
-    UIH event at ts 3 / 7) is included as the time-bias anchor.
+    When ``sequence_timestamp_is_ascending`` is false, only each user's UIH
+    values and timestamps are reversed. Candidate sampler order is unchanged.
+    Distinct per-row ``request_time`` scalars exercise request-time alignment
+    while the user rows are temporarily reversed by the model.
     """
+    if sequence_timestamp_is_ascending:
+        uih_values = [1, 2, 3, 4, 5, 6, 7]
+        uih_timestamps = [1, 2, 3, 4, 5, 6, 7]
+    else:
+        uih_values = [3, 2, 1, 7, 6, 5, 4]
+        uih_timestamps = [3, 2, 1, 7, 6, 5, 4]
     sparse_feature = KeyedJaggedTensor.from_lengths_sync(
         keys=["uih_seq__video_id", "cand_seq__video_id"],
-        values=torch.tensor([1, 2, 3, 4, 5, 6, 7, 100, 200, 101, 201]),
+        values=torch.tensor(uih_values + [100, 200, 101, 201]),
         lengths=torch.tensor([3, 4, 1, 3]),
     )
     sequence_dense_features = {
         "uih_seq__historical_ts": JaggedTensor(
-            values=torch.tensor([[1], [2], [3], [4], [5], [6], [7]]),
+            values=torch.tensor(uih_timestamps).unsqueeze(-1),
             lengths=torch.tensor([3, 4]),
         ),
     }
     dense_features = {
         BASE_DATA_GROUP: KeyedTensor.from_tensor_list(
             keys=["request_time"],
-            tensors=[torch.tensor([[100.0], [100.0]])],
+            tensors=[torch.tensor([[100.0], [200.0]])],
         )
     }
     return Batch(
@@ -233,13 +249,16 @@ class HSTUMatchTest(unittest.TestCase):
         ),
         kernel=st.sampled_from([Kernel.PYTORCH, Kernel.TRITON]),
         device_str=st.sampled_from(["cpu", "cuda"]),
+        sequence_timestamp_is_ascending=st.sampled_from([True, False]),
     )
     @settings(
         verbosity=Verbosity.verbose,
         max_examples=6,
         deadline=None,
     )
-    def test_hstu_match(self, graph_type, kernel, device_str) -> None:
+    def test_hstu_match(
+        self, graph_type, kernel, device_str, sequence_timestamp_is_ascending
+    ) -> None:
         # CUDA needs a GPU.
         if device_str == "cuda":
             assume(not gpu_unavailable[0])
@@ -253,12 +272,18 @@ class HSTUMatchTest(unittest.TestCase):
         )
 
         device = torch.device(device_str)
-        hstu = _build_model(device=device)
+        hstu = _build_model(
+            device=device,
+            sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
+        )
         # The query_time DEEP group is detected and threaded as the per-row
         # time-bias anchor (request-time anchoring, not the last UIH event).
         self.assertEqual(hstu.user_tower._hstu_encoder._query_time_key, "query_time")
         hstu.set_kernel(kernel)
-        batch = _build_batch(device=device)
+        batch = _build_batch(
+            device=device,
+            sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
+        )
 
         if graph_type == TestGraphType.JIT_SCRIPT:
             hstu_wrapped = create_test_model(hstu, graph_type)
@@ -284,6 +309,79 @@ class HSTUMatchTest(unittest.TestCase):
         self.assertFalse(scalar_features[0].is_grouped_sequence)
         self.assertEqual(scalar_feature_groups[0].feature_names, ["video_id"])
         self.assertEqual(scalar_feature_groups[0].group_name, "candidate")
+
+    def test_sequence_timestamp_order_parity(self) -> None:
+        """Equivalent ascending and descending UIH inputs produce equal outputs."""
+        device = torch.device("cpu")
+        ascending = _build_model(
+            device=device, sequence_timestamp_is_ascending=True
+        ).eval()
+        descending = _build_model(
+            device=device, sequence_timestamp_is_ascending=False
+        ).eval()
+        descending.load_state_dict(ascending.state_dict())
+        ascending.set_kernel(Kernel.PYTORCH)
+        descending.set_kernel(Kernel.PYTORCH)
+
+        ascending_batch = _build_batch(
+            device=device, sequence_timestamp_is_ascending=True
+        )
+        descending_batch = _build_batch(
+            device=device, sequence_timestamp_is_ascending=False
+        )
+        with torch.no_grad():
+            ascending_predictions = ascending.predict(ascending_batch)
+            descending_predictions = descending.predict(descending_batch)
+        torch.testing.assert_close(
+            descending_predictions["similarity"],
+            ascending_predictions["similarity"],
+        )
+
+        ascending.set_is_inference(True)
+        descending.set_is_inference(True)
+        ascending_user_tower = TowerWoEGWrapper(ascending.user_tower).eval()
+        descending_user_tower = TowerWoEGWrapper(descending.user_tower).eval()
+        init_parameters(ascending_user_tower, device=device)
+        init_parameters(descending_user_tower, device=device)
+        descending_user_tower.load_state_dict(ascending_user_tower.state_dict())
+        with torch.no_grad():
+            ascending_user_emb = ascending_user_tower.predict(ascending_batch)[
+                "user_tower_emb"
+            ]
+            descending_user_emb = descending_user_tower.predict(descending_batch)[
+                "user_tower_emb"
+            ]
+        torch.testing.assert_close(descending_user_emb, ascending_user_emb)
+
+    @parameterized.expand(
+        [
+            (TestGraphType.FX_TRACE, True),
+            (TestGraphType.FX_TRACE, False),
+            (TestGraphType.JIT_SCRIPT, True),
+            (TestGraphType.JIT_SCRIPT, False),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_sequence_timestamp_order_graph_modes(
+        self, graph_type: TestGraphType, sequence_timestamp_is_ascending: bool
+    ) -> None:
+        """Timestamp-order handling supports FX and JIT user-model graphs."""
+        device = torch.device("cpu")
+        hstu = _build_model(
+            device=device,
+            sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
+        )
+        hstu.set_kernel(Kernel.PYTORCH)
+        batch = _build_batch(
+            device=device,
+            sequence_timestamp_is_ascending=sequence_timestamp_is_ascending,
+        )
+        hstu_wrapped = create_test_model(hstu, graph_type)
+        if graph_type == TestGraphType.JIT_SCRIPT:
+            predictions = hstu_wrapped(batch.to_dict(), device)
+        else:
+            predictions = hstu_wrapped(batch)
+        self.assertEqual(predictions["similarity"].size(0), 2)
 
 
 if __name__ == "__main__":

--- a/tzrec/protos/models/match_model.proto
+++ b/tzrec/protos/models/match_model.proto
@@ -32,6 +32,8 @@ message HSTUMatch {
     optional float temperature = 4 [default = 1.0];
     // use in batch items as negative items.
     optional bool in_batch_negative = 5 [default = false];
+    // timestamp of sequence is ascending or descending
+    optional bool sequence_timestamp_is_ascending = 8 [default = true];
 }
 
 message DSSMV2 {

--- a/tzrec/tests/configs/hstu_kuairand_1k.config
+++ b/tzrec/tests/configs/hstu_kuairand_1k.config
@@ -234,7 +234,6 @@ model_config {
         }
         similarity: COSINE
         temperature: 0.05
-        sequence_timestamp_is_ascending: true
     }
     metrics {
         recall_at_k {

--- a/tzrec/tests/configs/hstu_kuairand_1k.config
+++ b/tzrec/tests/configs/hstu_kuairand_1k.config
@@ -234,6 +234,7 @@ model_config {
         }
         similarity: COSINE
         temperature: 0.05
+        sequence_timestamp_is_ascending: true
     }
     metrics {
         recall_at_k {

--- a/tzrec/utils/fx_util.py
+++ b/tzrec/utils/fx_util.py
@@ -83,7 +83,7 @@ def fx_numel(x: torch.Tensor) -> int:
 
 
 @torch.fx.wrap
-def _fx_flip_tensor_dict(
+def fx_flip_tensor_dict(
     tensor_dict: Dict[str, torch.Tensor],
 ) -> Dict[str, torch.Tensor]:
     """Reverse every tensor in a dictionary along its first dimension."""

--- a/tzrec/utils/fx_util.py
+++ b/tzrec/utils/fx_util.py
@@ -83,6 +83,17 @@ def fx_numel(x: torch.Tensor) -> int:
 
 
 @torch.fx.wrap
+def _fx_flip_tensor_dict(
+    tensor_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Reverse every tensor in a dictionary along its first dimension."""
+    flipped_tensor_dict = {}
+    for key, value in tensor_dict.items():
+        flipped_tensor_dict[key] = torch.flip(value, [0])
+    return flipped_tensor_dict
+
+
+@torch.fx.wrap
 def fx_mark_keyed_tensor(name: str, x: KeyedTensor, is_dense: bool = False) -> None:
     """Mark a KeyedTensor in fx.graph.
 

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"


### PR DESCRIPTION
## Summary

- add `sequence_timestamp_is_ascending` to HSTU Match with a backward-compatible `true` default
- normalize descending UIH tensors inside the user tower while preserving candidate and negative-sampler order
- restore request order before user projection/normalization so training and standalone user-tower export share the same behavior
- share the public `fx_flip_tensor_dict` helper with DLRM-HSTU
- bump the package version to `1.3.16`
- document the option and add ascending/descending parity plus FX/JIT coverage

## Motivation

HSTU Match always passed grouped UIH tensors directly to the encoder, so inputs ordered newest-to-oldest were interpreted in the wrong temporal direction. Handling the option in the user tower also ensures exported user embeddings use the same ordering semantics as training and evaluation.

## Test Plan

- `PYTHONPATH=. conda run -n tzrec130 python -m tzrec.models.hstu_test` (6 tests passed)
- `PYTHONPATH=. conda run -n tzrec130 python -m tzrec.models.dlrm_hstu_test` (3 tests passed)
- `conda run -n tzrec130 pre-commit run -a`
- `conda run -n tzrec130 bash scripts/gen_proto.sh`

Pyre could not run with the checked-in `.pyre_configuration` because the installed Pyre rejects its existing trailing comma as invalid JSON.
