### PR TITLE
[bugfix] fix KafkaReader crash on kafka schemas with metadata

### DIFF
--- a/tzrec/datasets/kafka_dataset.py
+++ b/tzrec/datasets/kafka_dataset.py
@@ -540,10 +540,10 @@ class KafkaReader(BaseReader):
                             msg_data, self._full_schema
                         )
 
-                    # Project onto the reader schema by column name. For embedded
-                    # schemas this absorbs upstream columns being added or
-                    # reordered; for schema-less ones it only selects columns.
-                    msg_schema = record_batch.schema
+                    # Project onto the reader schema by column name, so upstream
+                    # columns may be added or reordered. Metadata is dropped as
+                    # a schema carrying it is unhashable and never projected on.
+                    msg_schema = record_batch.schema.remove_metadata()
                     if msg_schema not in projections:
                         if projections:
                             logger.info(

--- a/tzrec/datasets/kafka_dataset_test.py
+++ b/tzrec/datasets/kafka_dataset_test.py
@@ -382,6 +382,8 @@ class KafkaDatasetTest(unittest.TestCase):
                 columns = dict(reversed(list(columns.items())))
             record_batch = pa.record_batch(columns)
             if embedded_schema:
+                # real producers stamp key-value metadata on the embedded schema
+                record_batch = record_batch.replace_schema_metadata({b"pandas": b"{}"})
                 # Serialize with embedded schema using IPC stream format
                 sink = io.BytesIO()
                 with pa.ipc.new_stream(sink, record_batch.schema) as writer:


### PR DESCRIPTION
## Problem

Training against a Kafka source dies in the dataloader worker on the first message:

```
File "tzrec/datasets/kafka_dataset.py", line 547, in _reader
    if msg_schema not in projections:
File "pyarrow/types.pxi", line 2655, in pyarrow.lib.Schema.__hash__
TypeError: unhashable type: 'dict'
```

## Root cause

The per-message projection cache added in #633 keys a `dict` by the message's `pa.Schema`. `pa.Schema` is only conditionally hashable:

```python
def __hash__(self):
    return hash((tuple(self), self.metadata))
```

`Schema.metadata` is `None` for a schema built in-process, but a `dict` for any schema carrying key-value metadata — which Arrow IPC streams from real producers normally have (pandas metadata, writer stamps, business KV). So embedded-schema mode crashes on the very first production message.

## Fix

Key the cache on `record_batch.schema.remove_metadata()`. Schema equality already ignores metadata, so nothing about the projection semantics changes; schemas differing only in metadata now collapse to a single cache entry instead of raising.

An alternative — replacing the dict with a list scanned by `Schema.equals` — was considered but keeps a linear scan for no benefit over a hashable key.

## Test Plan

- The existing e2e `test_kafka_dataset[embedded_schema=True]` never reproduced this: its producer builds batches with `pa.record_batch(columns)`, whose schema has `metadata is None`, i.e. hashable. The producer now stamps key-value metadata on the embedded schema, matching real producers; that test fails with `TypeError: unhashable type: 'dict'` without the fix. It runs in the CI kafka lane (needs `CI_ALIKAFKA_INSTANCE_ID`), which is the gate for this PR.
- Local: `python -m unittest tzrec.datasets.kafka_dataset_test` — 26 tests, all pass (kafka e2e skipped without CI kafka), plus `pre-commit run --files ...`.
- Verified the pyarrow behavior directly: a metadata-bearing schema raises on `hash()`, `remove_metadata()` gives a stable key that hits for repeated messages and misses for a genuinely new schema, and batches from the two schemas still combine after the existing `cast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3iVNF8avBZ2Leoa1KwANY