### PR TITLE
[ci] build the PPU image from this repo

### DIFF
--- a/.github/workflows/unittest_ppu_ci.yml
+++ b/.github/workflows/unittest_ppu_ci.yml
@@ -43,7 +43,7 @@ jobs:
             -v "$WORK_ROOT/_tool":/__w/_tool \
             -v "$WORK_ROOT/_temp/_github_home":/github/home \
             -v "$WORK_ROOT/_temp/_github_workflow":/github/workflow \
-            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.1-ppu \
+            mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec/tzrec-devel:1.2-ppu \
             bash -c 'mkdir -p /__w/TorchEasyRec/tzrec-ci-cache/triton /__w/TorchEasyRec/tzrec-ci-cache/inductor && cd run_${{ github.run_id }} && bash scripts/ci/ci_test_ppu.sh'
       - name: StopDockerContainer
         if: always()

--- a/docker/Dockerfile.ppu
+++ b/docker/Dockerfile.ppu
@@ -1,0 +1,46 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN sed -i "s@http://archive.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    sed -i "s@http://security.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    sed -i "s@http://ports.ubuntu.com@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/ubuntu.sources && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential ca-certificates \
+        ccache cmake gcc git vim watchman wget curl sudo iproute2 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://tzrec.oss-accelerate.aliyuncs.com/third_party/libidn11_1.33-2.2ubuntu2_amd64.deb && \
+    apt-get install ./libidn11_1.33-2.2ubuntu2_amd64.deb && rm libidn11_1.33-2.2ubuntu2_amd64.deb
+
+ARG PIP_MIRROR=mirrors.aliyun.com
+RUN mkdir -p /root/.config/pip && \
+    printf '[global]\nindex-url = http://%s/pypi/simple\ntrusted-host = %s\ntimeout = 120\n' "${PIP_MIRROR}" "${PIP_MIRROR}" > /root/.config/pip/pip.conf
+
+ARG PPU_PIP_INDEX
+RUN pip install torch==2.11.0 triton==3.6.0 -i ${PPU_PIP_INDEX} && \
+    pip install fbgemm-gpu==1.6.0 faiss==1.14.1 -i ${PPU_PIP_INDEX} && \
+    pip install torchmetrics==1.0.3 tensordict && \
+    pip install torchrec==1.6.0 -f https://tzrec.oss-accelerate.aliyuncs.com/third_party/torchrec/repo.html && \
+    pip cache purge
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+ADD requirements /root/requirements
+ADD requirements.txt /root/requirements.txt
+RUN cd /root && \
+    pip install -r requirements.txt && \
+    rm -rf requirements requirements.txt && \
+    pip cache purge
+
+RUN mkdir -p /home/pai/bin && \
+    wget -O /home/pai/bin/prepare_dlc_environment https://tzrec.oss-accelerate.aliyuncs.com/third_party/pai/prepare_dlc_environment.sh && \
+    chmod +x /home/pai/bin/prepare_dlc_environment && \
+    apt-get update && apt-get install -y --no-install-recommends openssh-server && rm -rf /var/lib/apt/lists/* && service ssh start
+ENV PATH $PATH:/home/pai/bin
+
+ENV SHELL=/bin/bash
+RUN echo "dash dash/sh boolean false" | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash

--- a/docs/source/develop.md
+++ b/docs/source/develop.md
@@ -75,3 +75,9 @@ bash scripts/build_wheel.sh release
 ```bash
 bash scripts/build_docker.sh
 ```
+
+**构建PPU镜像**
+
+```bash
+bash scripts/build_docker_ppu.sh
+```

--- a/docs/source/quick_start/ppu_odps_dataset_tutorial.md
+++ b/docs/source/quick_start/ppu_odps_dataset_tutorial.md
@@ -36,7 +36,7 @@ bash upload_data.sh ${ODPS_PROJECT_NAME}
 
 进入[PAI控制台](https://pai.console.aliyun.com)，并选择需要使用的工作空间，点击 **模型开发与训练-分布式训练(DLC)**，点击创建任务。
 
-**节点镜像** 选择官方镜像`torcheasyrec:1.1.0-pytorch2.10.0-ppu-py312-cu130-ubuntu24.04`
+**节点镜像** 选择官方镜像`torcheasyrec:1.2.0-pytorch2.11.0-ppu-py312-cu130-ubuntu24.04`
 
 **数据集配置** 选择刚新建的NAS数据集
 

--- a/scripts/build_docker_ppu.sh
+++ b/scripts/build_docker_ppu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Build the PPU image on top of the vendor PPU base image. torch/triton/faiss are the
+# PPU builds from the FlyTiger Eco pypi index; everything else comes from requirements/.
+
+REGISTRY=mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec
+REPO_NAME=tzrec-test
+DOCKER_TAG=1.2
+DOCKER_TAG_SUFFIX=-u1
+BASE_IMAGE=pkg.flytiger-eco.com/docker_release/ppu:v2.1.1-cuda13.0-ubuntu24-py312
+PPU_PIP_INDEX=https://pkg.flytiger-eco.com/artifactory/api/pypi/pypi_index/simple
+
+rm -rf docker/requirements*
+cp -r requirements*.txt docker/
+cp -r requirements/ docker/requirements
+cd docker
+
+docker build --network host -f Dockerfile.ppu -t ${REGISTRY}/${REPO_NAME}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX} \
+    --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg PPU_PIP_INDEX=${PPU_PIP_INDEX} \
+    ${PIP_MIRROR:+--build-arg PIP_MIRROR=${PIP_MIRROR}} .
+docker push ${REGISTRY}/${REPO_NAME}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX}

--- a/scripts/doc/build_doc_pre_work.sh
+++ b/scripts/doc/build_doc_pre_work.sh
@@ -11,8 +11,8 @@ sed -i '1i\# 简介' docs/source/intro.md
 # replace wheel and docker version
 ALL_WHEEL_VERSIONS=$(pip index versions tzrec -f http://tzrec.oss-accelerate.aliyuncs.com/release/nightly/repo.html --trusted-host tzrec.oss-accelerate.aliyuncs.com)
 LATEST_WHEEL_VERSION=$(echo "${ALL_WHEEL_VERSIONS}" | awk 'NR==1{print $2}' | sed 's/[()]//g')
-# PPU runs on the 1.1.x line; pick the latest 1.1.x from the available versions list
-LATEST_PPU_WHEEL_VERSION=$(echo "${ALL_WHEEL_VERSIONS}" | grep -i 'available versions' | tr ',' '\n' | tr -d ' ' | grep '^1\.1\.' | head -1)
+# PPU runs on the 1.2.x line; pick the latest 1.2.x from the available versions list
+LATEST_PPU_WHEEL_VERSION=$(echo "${ALL_WHEEL_VERSIONS}" | grep -i 'available versions' | tr ',' '\n' | tr -d ' ' | grep '^1\.2\.' | head -1)
 LATEST_DOCKER_VERSION=$(grep DOCKER_TAG= scripts/build_docker.sh | awk -F= '{print $2}')
 for f in docs/source/quick_start/*.md; do
     cp $f $f.bak

--- a/scripts/promote_docker_ppu.sh
+++ b/scripts/promote_docker_ppu.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Promote tzrec-test:<tag>-ppu<suffix> to tzrec-devel:<tag>-ppu after PPU CI passes.
+# Separate from promote_docker.sh: the PPU image is built and validated on its own
+# cadence and may lag the cpu/cu* images, and it never takes the <tag>/latest aliases.
+
+REGISTRY=mybigpai-public-registry.cn-beijing.cr.aliyuncs.com/easyrec
+SRC_REPO=tzrec-test
+DST_REPO=tzrec-devel
+DOCKER_TAG=1.2
+DOCKER_TAG_SUFFIX=-u1
+
+docker pull ${REGISTRY}/${SRC_REPO}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX}
+docker tag ${REGISTRY}/${SRC_REPO}:${DOCKER_TAG}-ppu${DOCKER_TAG_SUFFIX} ${REGISTRY}/${DST_REPO}:${DOCKER_TAG}-ppu
+docker push ${REGISTRY}/${DST_REPO}:${DOCKER_TAG}-ppu

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"


### PR DESCRIPTION
Forward-port the PPU image build from release/v1.2 (#613) to master, and move the PPU tutorial onto the 1.2 line.

The PPU image build (`docker/Dockerfile.ppu` plus its build/promote scripts) only existed on release/v1.2, so it would be lost at the next release branch cut. This cherry-picks it onto master unchanged. The image itself stays on the 1.2 line: the vendor publishes PPU builds of torch up to 2.11.0 and triton up to 3.6.0, so master's pins have nothing to build against yet, and the PPU CI lane only runs on `release/**` pull requests.

The PPU DLC image and the PPU nightly wheel have also both moved to the 1.2 line, so the tutorial's image reference follows, and the docs build now substitutes the latest 1.2.x nightly for `TZREC_PPU_NIGHTLY_VERSION` instead of the latest 1.1.x.

## Test Plan

- `pre-commit run --files` over every changed file: clean.
- Ran the version-selection pipeline from `scripts/doc/build_doc_pre_work.sh` against the nightly repo: it resolves to `1.2.24+20260823.24d4aa4`, the wheel built from the merged PPU commit (previously it picked `1.1.18+20260526.47763cf`).
- The image build itself was validated on release/v1.2 before the merge: built cache-cold, PPU builds of torch/triton/faiss/fbgemm resolved, all imports pass, and the full PPU unit-test lane was green on the resulting image.
