### PR TITLE
[bugfix] weight mixed SID losses by pair ratio

### DIFF
--- a/tzrec/loss/sid_recon_loss.py
+++ b/tzrec/loss/sid_recon_loss.py
@@ -17,8 +17,6 @@ import torch
 from torch.nn import functional as F
 from torch.nn.modules.loss import _Loss
 
-from tzrec.modules.utils import div_no_nan
-
 
 class SidReconLoss(_Loss):
     """Reconstruction loss for RQ-VAE: per-row distance reduced to a scalar.
@@ -56,13 +54,14 @@ class SidReconLoss(_Loss):
     ) -> torch.Tensor:
         """Mean over the masked-in rows (all rows if ``mask`` is None).
 
-        The masked mean divides by the valid-row count (``div_no_nan`` keeps an
-        empty mask at 0). No data-dependent branching -> ``torch.compile``-friendly.
+        The masked mean divides by the valid-row count. Clamping the denominator
+        keeps an empty mask at 0 in both forward and backward. No data-dependent
+        branching -> ``torch.compile``-friendly.
         """
         if mask is None:
             return per_sample.mean()
         mask = mask.float()
-        return div_no_nan((per_sample * mask).sum(), mask.sum())
+        return (per_sample * mask).sum() / mask.sum().clamp(min=1)
 
     def forward(
         self,

--- a/tzrec/loss/sid_recon_loss_test.py
+++ b/tzrec/loss/sid_recon_loss_test.py
@@ -61,11 +61,13 @@ class SidReconLossTest(unittest.TestCase):
             SidReconLoss._masked_mean(x, mask), torch.tensor(2.0)
         )  # (1+3)/2
 
-    def test_empty_mask_is_zero_not_nan(self) -> None:
-        out = SidReconLoss._masked_mean(
-            torch.tensor([1.0, 2.0, 3.0]), torch.zeros(3, dtype=torch.bool)
-        )
+    def test_empty_mask_has_zero_finite_gradient(self) -> None:
+        per_sample = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        out = SidReconLoss._masked_mean(per_sample, torch.zeros(3, dtype=torch.bool))
         self.assertEqual(out.item(), 0.0)
+        out.backward()
+        self.assertTrue(torch.isfinite(per_sample.grad).all())
+        torch.testing.assert_close(per_sample.grad, torch.zeros_like(per_sample))
 
     def test_forward_applies_mask(self) -> None:
         # l1 per-row of [[1,1],[2,2],[3,3],[4,4]] vs 0 is [1,2,3,4]; mask keeps 0,2.

--- a/tzrec/models/sid_model.py
+++ b/tzrec/models/sid_model.py
@@ -151,6 +151,12 @@ class BaseSidModel(BaseModel):
     ) -> Dict[str, torch.Tensor]:
         """Compute the configured SID losses from ``predictions``.
 
+        In mixed reconstruction + contrastive training, reconstruction and
+        contrastive modules each return a conditional mean over their valid
+        rows. Reweight those means by the corresponding row fraction so their
+        sum is normalized by the full batch size. Commitment loss remains an
+        unscaled mean over the quantized paths.
+
         Args:
             predictions (dict): a dict of predicted result (the raw tensors the
                 losses consume — ``x_hat``/``recon_target`` for reconstruction,
@@ -177,6 +183,9 @@ class BaseSidModel(BaseModel):
                 predictions["recon_target"],
                 predictions.get("recon_mask"),
             )
+            recon_mask = predictions.get("recon_mask")
+            if recon_mask is not None:
+                loss = loss * recon_mask.to(dtype=loss.dtype).mean()
             return {"recon_loss": loss}
         elif loss_type == "commitment_loss":
             loss = self._loss_modules["commitment_loss"](
@@ -191,6 +200,7 @@ class BaseSidModel(BaseModel):
                 predictions["embed_b_ori"],
                 predictions["pair_mask"],
             )
+            loss = loss * predictions["pair_mask"].to(dtype=loss.dtype).mean()
             return {"contrastive_loss": loss}
         else:
             raise ValueError(f"unsupported sid_loss variant: {loss_type!r}")

--- a/tzrec/models/sid_rqvae_test.py
+++ b/tzrec/models/sid_rqvae_test.py
@@ -316,6 +316,39 @@ class SidRqvaeTest(unittest.TestCase):
         total_loss.backward()
         self._assert_has_grad(model)
 
+    def test_mixed_losses_weighted_by_is_pair_ratio(self) -> None:
+        """Conditional recon/contrastive means are weighted by row ratios."""
+        B, input_dim = 10, 32
+        model = self._create_model(input_dim=input_dim, use_contrastive=True)
+        model.train()
+        model.init_loss()
+
+        is_pair = torch.zeros(B, 1)
+        is_pair[3:] = 1.0  # 3/10 recon rows and 7/10 pair rows
+        batch = self._contrastive_batch(B, input_dim, is_pair)
+        predictions = model.predict(batch)
+
+        raw_recon = model._loss_modules["recon_loss"](
+            predictions["x_hat"],
+            predictions["recon_target"],
+            predictions["recon_mask"],
+        )
+        raw_commitment = model._loss_modules["commitment_loss"](
+            predictions["encoder_out"], predictions["latents"]
+        )
+        raw_contrastive = model._loss_modules["contrastive_loss"](
+            predictions["embed_a"],
+            predictions["embed_b"],
+            predictions["embed_a_ori"],
+            predictions["embed_b_ori"],
+            predictions["pair_mask"],
+        )
+
+        losses = model.loss(predictions, batch)
+        torch.testing.assert_close(losses["recon_loss"], raw_recon * 0.3)
+        torch.testing.assert_close(losses["contrastive_loss"], raw_contrastive * 0.7)
+        torch.testing.assert_close(losses["commitment_loss"], raw_commitment)
+
     def test_rqvae_contrastive_all_recon(self) -> None:
         """Mixed mode, all-recon batch: contrastive term 0, recon term > 0."""
         B, input_dim = 4, 32
@@ -339,6 +372,10 @@ class SidRqvaeTest(unittest.TestCase):
         losses = model.loss(model.predict(batch), batch)
         self.assertEqual(losses["recon_loss"].item(), 0.0)
         self.assertGreater(losses["contrastive_loss"].item(), 0.0)
+        sum(losses.values()).backward()
+        for param in model.parameters():
+            if param.grad is not None:
+                self.assertTrue(torch.isfinite(param.grad).all())
 
     def test_rqvae_backward(self) -> None:
         """Test that backward pass works without errors."""


### PR DESCRIPTION
## Summary

Mixed SID RQ-VAE training computes reconstruction and contrastive losses as conditional means over disjoint subsets of a batch. Adding those means directly gave sparse and dense sample types equal weight regardless of their row counts, so the per-sample objective changed with the batch composition.

This change scales each conditional mean by its valid-row fraction, making their sum normalized by the full batch size. It also clamps the empty reconstruction-mask denominator so all-pair batches produce finite zero gradients. Commitment loss remains unchanged because it already averages over the quantized paths.

## Why this approach

The weighting is applied at the model loss aggregation boundary, preserving the reusable conditional-mean behavior of the individual loss modules and leaving pure reconstruction training unchanged.

## Test Plan

- `PYTHONPATH=. python -m tzrec.loss.sid_recon_loss_test`
- `PYTHONPATH=. python -m tzrec.loss.sid_contrastive_loss_test`
- `PYTHONPATH=. python -m tzrec.models.sid_rqvae_test`
- `pre-commit run -a`
