### PR TITLE
[feat] support int value_type and id bucketizer in expr feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ docs/source/proto.html
 data/test/kuairand-1k*
 data/test/kuairand-mot-1k*
 
+# Test logs of graphlearn sampler
+graphlearn.INFO
+graphlearn.WARNING
+graphlearn.*.log.*
+
 # Other temp files
 .hypothesis/
 .config/

--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -379,6 +379,16 @@ feature_configs {
 
 - **value_dim**: 默认值是0，value_dim=0时支持多值ID输出
 
+- **fg_value_type**: 表达式的计算与输出类型，默认是`float`，可选`double` / `int32` / `int64`。
+  需要精确的整数输出（如0/1的Mask）时配置为`int64`。注意`int`类型不能与`boundaries`或
+  `hash_bucket_size`同时使用（FG会先把值截断成整数，分桶结果不符合预期），配置了会报错
+
+- **num_buckets**: 表达式输出为整数ID时的ID数目，ID取值范围为\[0, num_buckets)，配置后
+  `fg_value_type`默认为`int64`
+
+- **hash_bucket_size**: 对表达式输出做Hash分桶的桶数目，Hash基于字符串值计算，
+  故只能与浮点类型的`fg_value_type`一起使用
+
 - **内置函数**: 详见[表达式文档](https://help.aliyun.com/zh/airec/what-is-pai-rec/user-guide/built-in-feature-operator?#1d09c2da3aajb)
 
   | 函数名      | 参数数量 | 解释                                                                    |
@@ -478,6 +488,41 @@ feature_configs {
   | \_e    | Euler's number.      | 2.718281828459045235360287 |
 
 - 其余配置同RawFeature
+
+- **序列Mask用法**: 表达式特征可以作为序列的Mask，配合下文的BoolMaskFeature
+  筛选出序列中符合条件的元素，如只保留与目标物品同类目的点击序列。Mask特征只作为FG的中间结果，
+  需配置`stub_type: true`，并用`fg_value_type: "int64"`输出0/1
+
+  ```
+  feature_configs {
+      sequence_feature {
+          sequence_name: "click_seq"
+          sequence_length: 50
+          features {
+              expr_feature {
+                  feature_name: "is_same_cate"
+                  variables: ["item:cate", "item:tgt_cate"]
+                  sequence_fields: ["cate"]
+                  expression: "cate == tgt_cate"
+                  fg_value_type: "int64"
+                  stub_type: true
+              }
+          }
+          features {
+              bool_mask_feature {
+                  feature_name: "masked_iid"
+                  expression: ["item:iid", "feature:click_seq__is_same_cate"]
+                  embedding_dim: 16
+                  num_buckets: 1000
+              }
+          }
+      }
+  }
+  ```
+
+  其中`sequence_fields`指定表达式中的哪些字段是序列字段，未指定的item侧字段（如目标物品的
+  `tgt_cate`）为单值。BoolMaskFeature通过`feature:<sequence_name>__<feature_name>`
+  引用Mask特征。该用法需要`data_config.fg_mode`为`FG_DAG`
 
 ## OverlapFeature: 重合匹配特征
 

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -15,7 +15,7 @@ import unittest
 
 import pyarrow as pa
 import torch
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torchrec.sparse.jagged_tensor import (
     JaggedTensor,
     KeyedJaggedTensor,
@@ -27,6 +27,7 @@ from torchrec.sparse.jagged_tensor import (
 from tzrec.datasets.data_parser import DataParser
 from tzrec.features.feature import FgMode, create_features
 from tzrec.protos import feature_pb2
+from tzrec.utils.test_util import parameterized_name_func
 
 
 class DataParserTest(unittest.TestCase):
@@ -901,7 +902,14 @@ class DataParserTest(unittest.TestCase):
         )
         torch.testing.assert_close(batch.labels["label"], expected_label)
 
-    def test_fg_seq_bool_mask_with_expr_mask(self):
+    @parameterized.expand(
+        [
+            param("fg_dag", fg_mode=FgMode.FG_DAG),
+            param("fg_bucketize", fg_mode=FgMode.FG_BUCKETIZE),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_fg_seq_bool_mask_with_expr_mask(self, _, fg_mode):
         feature_cfgs = [
             feature_pb2.FeatureConfig(
                 sequence_feature=feature_pb2.SequenceFeature(
@@ -933,21 +941,28 @@ class DataParserTest(unittest.TestCase):
                 )
             )
         ]
-        features = create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        features = create_features(feature_cfgs, fg_mode=fg_mode)
         data_parser = DataParser(features=features)
-        self.assertEqual(
-            sorted(list(data_parser.feature_input_names)),
-            ["click_seq__cate", "click_seq__iid", "tgt_cate"],
-        )
         self.assertEqual(data_parser.sparse_keys["__BASE__"], ["click_seq__masked_iid"])
-
-        data = data_parser.parse(
-            input_data={
+        if fg_mode == FgMode.FG_DAG:
+            expected_input_names = ["click_seq__cate", "click_seq__iid", "tgt_cate"]
+            input_data = {
                 "click_seq__cate": pa.array(["1;2;3;2", "1;1", "2"]),
                 "click_seq__iid": pa.array(["11;12;13;14", "21;22", "31"]),
                 "tgt_cate": pa.array([2, 1, 2]),
             }
+        else:
+            # fg does not output the mask, it is a dag intermediate result, we
+            # only need the masked ids before bucketize.
+            expected_input_names = ["click_seq__masked_iid"]
+            input_data = {
+                "click_seq__masked_iid": pa.array([["12", "14"], ["21", "22"], ["31"]])
+            }
+        self.assertEqual(
+            sorted(list(data_parser.feature_input_names)), expected_input_names
         )
+
+        data = data_parser.parse(input_data=input_data)
         batch = data_parser.to_batch(data)
 
         expected_sparse_feat = KeyedJaggedTensor.from_lengths_sync(

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -901,6 +901,64 @@ class DataParserTest(unittest.TestCase):
         )
         torch.testing.assert_close(batch.labels["label"], expected_label)
 
+    def test_fg_seq_bool_mask_with_expr_mask(self):
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                sequence_feature=feature_pb2.SequenceFeature(
+                    sequence_name="click_seq",
+                    sequence_length=10,
+                    features=[
+                        feature_pb2.SeqFeatureConfig(
+                            expr_feature=feature_pb2.ExprFeature(
+                                feature_name="is_same_cate",
+                                expression="cate == tgt_cate",
+                                variables=["item:cate", "item:tgt_cate"],
+                                sequence_fields=["cate"],
+                                fg_value_type="int64",
+                                stub_type=True,
+                            )
+                        ),
+                        feature_pb2.SeqFeatureConfig(
+                            bool_mask_feature=feature_pb2.BoolMaskFeature(
+                                feature_name="masked_iid",
+                                expression=[
+                                    "item:iid",
+                                    "feature:click_seq__is_same_cate",
+                                ],
+                                embedding_dim=16,
+                                num_buckets=1000,
+                            )
+                        ),
+                    ],
+                )
+            )
+        ]
+        features = create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        data_parser = DataParser(features=features)
+        self.assertEqual(
+            sorted(list(data_parser.feature_input_names)),
+            ["click_seq__cate", "click_seq__iid", "tgt_cate"],
+        )
+        self.assertEqual(data_parser.sparse_keys["__BASE__"], ["click_seq__masked_iid"])
+
+        data = data_parser.parse(
+            input_data={
+                "click_seq__cate": pa.array(["1;2;3;2", "1;1", "2"]),
+                "click_seq__iid": pa.array(["11;12;13;14", "21;22", "31"]),
+                "tgt_cate": pa.array([2, 1, 2]),
+            }
+        )
+        batch = data_parser.to_batch(data)
+
+        expected_sparse_feat = KeyedJaggedTensor.from_lengths_sync(
+            keys=["click_seq__masked_iid"],
+            values=torch.tensor([12, 14, 21, 22, 31]),
+            lengths=torch.tensor([2, 2, 1], dtype=torch.int32),
+        )
+        self.assertTrue(
+            kjt_is_equal(batch.sparse_features["__BASE__"], expected_sparse_feat)
+        )
+
     def test_fg_bucketize_only(self):
         feature_cfgs = self._create_test_fg_feature_cfgs(tag_b_seq=True)
         features = create_features(feature_cfgs, fg_mode=FgMode.FG_BUCKETIZE)

--- a/tzrec/features/bool_mask_feature.py
+++ b/tzrec/features/bool_mask_feature.py
@@ -56,6 +56,7 @@ class BoolMaskFeature(IdFeature):
             "feature_name": self.config.feature_name,
             "default_value": self.default_value,
             "expression": list(self.config.expression),
+            "value_type": "string",
         }
         if self.config.separator != "\x1d":
             fg_cfg["separator"] = self.config.separator
@@ -74,10 +75,7 @@ class BoolMaskFeature(IdFeature):
             fg_cfg["default_bucketize_value"] = self.default_bucketize_value
         elif self.config.HasField("num_buckets"):
             fg_cfg["num_buckets"] = self.config.num_buckets
-        if self.config.HasField("value_dim"):
-            fg_cfg["value_dim"] = self.config.value_dim
-        else:
-            fg_cfg["value_dim"] = 0
+        fg_cfg["value_dim"] = self.value_dim
         if self.config.HasField("fg_value_type"):
             fg_cfg["value_type"] = self.config.fg_value_type
         if self.config.HasField("stub_type"):

--- a/tzrec/features/expr_feature.py
+++ b/tzrec/features/expr_feature.py
@@ -39,6 +39,28 @@ class ExprFeature(RawFeature):
         self._is_neg = value
         self._data_group = CROSS_NEG_DATA_GROUP
 
+    @property
+    def is_sparse(self) -> bool:
+        """Feature is sparse or dense."""
+        if self._is_sparse is None:
+            self._is_sparse = (
+                self.config.HasField("hash_bucket_size")
+                or self.config.HasField("num_buckets")
+                or len(self.config.boundaries) > 0
+            )
+        return self._is_sparse
+
+    @property
+    def num_embeddings(self) -> int:
+        """Get embedding row count."""
+        if self.config.HasField("hash_bucket_size"):
+            num_embeddings = self.config.hash_bucket_size
+        elif self.config.HasField("num_buckets"):
+            num_embeddings = self.config.num_buckets
+        else:
+            num_embeddings = len(self.config.boundaries) + 1
+        return num_embeddings
+
     def _build_side_inputs(self) -> Optional[List[Tuple[str, str]]]:
         """Input field names with side."""
         if len(self.config.variables) > 0:
@@ -60,10 +82,28 @@ class ExprFeature(RawFeature):
             fg_cfg["separator"] = self.config.separator
         if self.config.HasField("fill_missing"):
             fg_cfg["fill_missing"] = self.config.fill_missing
-        if len(self.config.boundaries) > 0:
+        if self.config.HasField("hash_bucket_size"):
+            fg_cfg["hash_bucket_size"] = self.config.hash_bucket_size
+        elif self.config.HasField("num_buckets"):
+            fg_cfg["num_buckets"] = self.config.num_buckets
+            fg_cfg["value_type"] = "int64"
+        elif len(self.config.boundaries) > 0:
             fg_cfg["boundaries"] = list(self.config.boundaries)
         if self.config.HasField("value_dim"):
             fg_cfg["value_dim"] = self.config.value_dim
+        elif self.is_sequence:
+            # pyfg requires an explicit value_dim for sequence sub-features
+            # consumed by bool_mask_feature.
+            fg_cfg["value_dim"] = self.value_dim
+        if self.config.HasField("fg_value_type"):
+            assert not self.config.fg_value_type.startswith("int") or (
+                len(self.config.boundaries) == 0
+                and not self.config.HasField("hash_bucket_size")
+            ), (
+                f"expr feature[{self.name}]: int fg_value_type is not supported "
+                "with boundaries or hash_bucket_size."
+            )
+            fg_cfg["value_type"] = self.config.fg_value_type
         if self.config.HasField("stub_type"):
             fg_cfg["stub_type"] = self.config.stub_type
 

--- a/tzrec/features/expr_feature_test.py
+++ b/tzrec/features/expr_feature_test.py
@@ -246,6 +246,91 @@ class ExprFeatureTest(unittest.TestCase):
         np.testing.assert_allclose(parsed_feat.values, np.array(expected_values))
         np.testing.assert_allclose(parsed_feat.lengths, np.array(expected_lengths))
 
+    @parameterized.expand(
+        [
+            [{"num_buckets": 100}, "int64", [10, 20, 30, 0]],
+            [{"hash_bucket_size": 100}, "float", [39, 63, 46, 0]],
+        ]
+    )
+    def test_expr_feature_with_id_bucketizer(
+        self, bucketizer, expected_value_type, expected_values
+    ):
+        expr_feat_cfg = feature_pb2.FeatureConfig(
+            expr_feature=feature_pb2.ExprFeature(
+                feature_name="expr_feat",
+                embedding_dim=16,
+                expression="a*10",
+                variables=["user:a"],
+                default_value="0",
+                **bucketizer,
+            )
+        )
+        expr_feat = expr_feature_lib.ExprFeature(
+            expr_feat_cfg, fg_mode=FgMode.FG_NORMAL
+        )
+        self.assertEqual(expr_feat.output_dim, 16)
+        self.assertEqual(expr_feat.is_sparse, True)
+        self.assertEqual(expr_feat.inputs, ["a"])
+        self.assertEqual(expr_feat.fg_json()[0]["value_type"], expected_value_type)
+        expected_emb_bag_config = EmbeddingBagConfig(
+            num_embeddings=100,
+            embedding_dim=16,
+            name="expr_feat_emb",
+            feature_names=["expr_feat"],
+            pooling=PoolingType.SUM,
+        )
+        self.assertEqual(repr(expr_feat.emb_bag_config), repr(expected_emb_bag_config))
+
+        input_data = {"a": pa.array([1.0, 2.0, 3.0, None])}
+        parsed_feat = expr_feat.parse(input_data)
+        self.assertEqual(parsed_feat.name, "expr_feat")
+        np.testing.assert_allclose(parsed_feat.values, np.array(expected_values))
+        np.testing.assert_allclose(parsed_feat.lengths, np.array([1, 1, 1, 1]))
+
+    def test_expr_feature_with_int_value_type(self):
+        expr_feat_cfg = feature_pb2.FeatureConfig(
+            expr_feature=feature_pb2.ExprFeature(
+                feature_name="expr_feat",
+                expression="a==b",
+                variables=["user:a", "item:b"],
+                fg_value_type="int64",
+                value_dim=4,
+                default_value="0",
+            )
+        )
+        expr_feat = expr_feature_lib.ExprFeature(
+            expr_feat_cfg, fg_mode=FgMode.FG_NORMAL
+        )
+        self.assertEqual(expr_feat.output_dim, 4)
+        self.assertEqual(expr_feat.is_sparse, False)
+        self.assertEqual(expr_feat.fg_json()[0]["value_type"], "int64")
+
+        input_data = {
+            "a": pa.array(["1\x1d2\x1d3\x1d2", "1\x1d1\x1d1\x1d1"]),
+            "b": pa.array([2, 1]),
+        }
+        parsed_feat = expr_feat.parse(input_data)
+        self.assertEqual(parsed_feat.name, "expr_feat")
+        np.testing.assert_allclose(
+            parsed_feat.values, np.array([[0, 1, 0, 1], [1, 1, 1, 1]])
+        )
+
+    def test_expr_feature_int_value_type_with_boundaries(self):
+        expr_feat_cfg = feature_pb2.FeatureConfig(
+            expr_feature=feature_pb2.ExprFeature(
+                feature_name="expr_feat",
+                embedding_dim=16,
+                boundaries=[0.5],
+                expression="a==b",
+                variables=["user:a", "item:b"],
+                fg_value_type="int64",
+            )
+        )
+        with self.assertRaises(AssertionError):
+            expr_feature_lib.ExprFeature(
+                expr_feat_cfg, fg_mode=FgMode.FG_NORMAL
+            ).fg_json()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tzrec/protos/feature.proto
+++ b/tzrec/protos/feature.proto
@@ -574,6 +574,8 @@ message ExprFeature {
     optional string separator = 7 [default = "\x1d"];
     // fill value when vector length mismatch, default is NaN.
     optional float fill_missing = 8;
+    // number of hash size for sparse expr value
+    optional uint64 hash_bucket_size = 9;
     // embedding pooling type, available is {sum | mean}
     optional string pooling = 10 [default = "sum"];
     // fg default value
@@ -584,11 +586,16 @@ message ExprFeature {
     optional bool use_mask =  13;
     // if value_dim = 0, it supports multi-value
     optional uint32 value_dim = 14 [default = 0];
+    // number of id enumerators for sparse expr value
+    optional uint64 num_buckets = 15;
 
     // default value when fg_mode = FG_NONE,
     // when use pai-fg, you do not need to set the param.
     // when use own fg and data contain null value, you can set the param for fill null
     optional string fg_encoded_default_value = 30;
+    // value_type after fg before bucketize, you can specify it for better performance.
+    // e.g. fg_value_type = int64 when use num_buckets
+    optional string fg_value_type = 32;
     // embedding param trainable or not
     optional bool trainable = 33 [default = true];
     // only used as fg dag intermediate result or not

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.17"
+__version__ = "1.3.18"


### PR DESCRIPTION
## What

`ExprFeature` hardcoded `"value_type": "float"` in its fg json and could only become sparse through `boundaries`. So an expression result could neither be emitted as an exact integer (e.g. a 0/1 mask consumed by `bool_mask_feature` through a fg DAG), nor be embedded directly as an id.

- `ExprFeature`: new `fg_value_type`, `num_buckets` and `hash_bucket_size` config, with `is_sparse` / `num_embeddings` extended accordingly. `num_buckets` implies `value_type: int64` (same as `custom_feature`).
- An int `fg_value_type` combined with `boundaries` or `hash_bucket_size` is rejected: fg truncates the value to an integer before bucketizing / hashing, so those combinations silently return wrong ids rather than failing.
- `BoolMaskFeature` now emits `value_type` and `value_dim` the way its base `IdFeature` does. fg requires `value_type` on every sequence sub-feature and rejects a multi-value mask, so a grouped-sequence `bool_mask_feature` could not be built at all before this. Sequence expr features emit `value_dim` for the same reason; this is output-identical for existing configs.

This makes the "keep only the sequence positions whose category equals the target item category" pattern expressible:

```
sequence_feature {
    sequence_name: "click_seq"
    features { expr_feature {
        feature_name: "is_same_cate"
        variables: ["item:cate", "item:tgt_cate"]
        sequence_fields: ["cate"]
        expression: "cate == tgt_cate"
        fg_value_type: "int64"
        stub_type: true
    } }
    features { bool_mask_feature {
        feature_name: "masked_iid"
        expression: ["item:iid", "feature:click_seq__is_same_cate"]
        embedding_dim: 16
        num_buckets: 1000
    } }
}
```

Documented in `docs/source/feature/feature.md`.

## Alternatives considered

`fg_value_type` is the name already used by `IdFeature` / `LookupFeature` / `MatchFeature` / `BoolMaskFeature` for the same fg json key, so expr reuses it (field 32) instead of introducing a second spelling. `zch` / `dynamicemb` / `vocab_*` were left off `ExprFeature`: they bucketize string values, and fg has no string instantiation of the expr operator.

## Test Plan

- `tzrec/features/expr_feature_test.py`: expr with `num_buckets` and with `hash_bucket_size` (sparse values, `emb_bag_config`, emitted `value_type`), an int `fg_value_type` mask over a multi-value input, and the boundaries + int rejection.
- `tzrec/datasets/data_parser_test.py`: end-to-end `FG_DAG` test of the grouped-sequence chain above — the stub mask stays out of the parsed keys and `click_seq__masked_iid` keeps only the matching positions.
- Full `tzrec/features/*_test.py`, `tzrec/datasets/data_parser_test.py`, `tzrec/datasets/dataset_test.py` pass; `pre-commit run -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUtoVaSwFYeKdPFvRjVw6U