### PR TITLE
[bugfix] make the AI code review post its findings before the run ends

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -17,6 +17,21 @@ Perform a comprehensive code review using subagents for key areas:
 Instruct each to only provide noteworthy feedback. Once they finish, review
 the feedback and post only the feedback that you also deem noteworthy.
 
+The subagents run in the background and report back as notifications, and this
+review runs headless: when your turn ends with nothing left to do, the run is
+over and any agent still working is killed. So:
+
+- Do not end a turn just to say you are waiting. If you are woken while some
+  agents are still pending, keep doing real work in that same turn — continue
+  reviewing the diff yourself with Read/Grep — so the run stays alive until the
+  rest report back.
+- Post your findings before the run can end. Never finish having posted
+  nothing; if some agents have still not reported by the time you have to
+  wrap up, post what you do have and say which reviews did not finish.
+- Always post at least a short top-level summary, even when nothing is
+  noteworthy, so a completed review is distinguishable from a review that
+  never ran.
+
 Use the `create_inline_comment` tool of the `github_inline_comment` MCP server for inline comments on specific lines.
 Use top-level comments for general observations or praise.
 Use `gh pr comment` for top-level summary comments.


### PR DESCRIPTION
## Background

The `claude-review` job has been finishing green while posting nothing. It happened on #643: the job succeeded, every step passed, and the PR got zero inline comments and zero top-level comments.

The job log shows why. `/review-pr` spawns the five reviewer subagents, which run in the background and report back as notifications. `claude -p` is headless, so the run is over once a turn ends with nothing left to do. On that PR:

1. Turn 1 spawned all five reviewers, then ended with "All five review agents are running in the background. I'll synthesize their findings and post comments when they report back."
2. Turn 2 was woken by the one fast reviewer finishing, replied "Performance review came back clean... Still waiting on the code-quality, test-coverage, documentation, and security reviewers", and ended.
3. The process exited and the runner logged `Cleaning up orphan processes`, killing the other four.

`create_inline_comment` was registered and available but never called. There were no errors in the log — the four reviewers were simply unfinished.

This is timing-dependent, which is why it only shows up on larger PRs. An earlier review (run 32122582171) got five notification wakes across six turns and posted nine inline comments; the #643 run got one wake across two turns and posted none, exiting after 16 minutes against the working run's 32.

## Fix

Tell the reviewer that ending a turn ends the run: don't spend a wake on a status update while agents are pending, keep doing real review work in the same turn so the run stays alive, and never finish having posted nothing — fall back to partial findings if some agents never report.

## Test Plan

Verified end to end by re-running the review against the same 80-file diff that failed on #643, from a base branch carrying this change (tiankongdeguiji/TorchEasyRec#21):

| | before | after |
| --- | --- | --- |
| turns | 2 | 1 |
| notification wakes | 1 of 5 | 0 needed |
| subagents that reported | 1 of 5 | 5 of 5 |
| `create_inline_comment` calls | 0 | 6 |
| comments posted | 0 | 5 inline + 1 summary |

The agent no longer ends its turn to wait at all — it spawns the five reviewers, collects all five within the same turn, and posts. The failing path is simply never entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8umv3ckMkiDkW5TCK3zyk