### PR TITLE
[bugfix] keep bucketizer of fg dag intermediates in offline fg json

### DIFF
--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -302,6 +302,11 @@ pipeline.global-job-parameters: |
 
   ```
 
+- 注意：特征输入中`feature`side的输入(如`feature:xxx`)读到的是被引用特征**Bucketize之后**的值，因此被引用的特征需要满足以下条件之一，否则`--remove_bucketizer`会改变离线FG的计算结果，`create_fg_json`时会报错
+
+  - 被引用的特征配置`stub_type: true`，即该特征只作为FG DAG的中间结果，不输出到表中。`--remove_bucketizer`会保留`stub_type: true`特征的Bucketize配置，如果该特征使用了`vocab_file`，该文件同样需要上传至资源中
+  - 被引用的特征不配置Bucketize参数，如果模型需要Bucketize后的该特征，可以另外增加一个带Bucketize配置的特征来引用它
+
 ### fg_threads
 
 - 每个dataloader worker上fg的运行线程数，默认为1，`nproc-per-node * num_workers * fg_threads`建议小于单机CPU核数

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -15,7 +15,7 @@ import shutil
 from collections import OrderedDict
 from copy import copy
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
@@ -1310,9 +1310,43 @@ def _remove_one_feature_bucketizer(fg_json: Dict[str, Any]) -> Dict[str, Any]:
     fg_json.pop("vocab_list", None)
     fg_json.pop("boundaries", None)
     fg_json.pop("num_buckets", None)
-    if fg_json["feature_type"] != "tokenize_feature":
+    if not fg_json["feature_type"].endswith("tokenize_feature"):
         fg_json.pop("vocab_file", None)
     return fg_json
+
+
+def _remove_bucketizer(
+    feature: BaseFeature,
+    fg_jsons: List[Dict[str, Any]],
+    referenced_names: Set[str],
+) -> List[Dict[str, Any]]:
+    """Remove bucketizer params in fg jsons of one feature.
+
+    Bucketizer params of fg dag intermediates are kept, and a feature used by
+    other features as `feature:xxx` can not have a bucketizer.
+    """
+    is_referenced = feature.name in referenced_names
+    results = []
+    for fg_json in fg_jsons:
+        # a stub feature and the intermediate fg jsons of a feature, e.g. the
+        # lookup of a multi-value LookupFeature, are not output as columns, and
+        # downstream features consume their bucketized value.
+        if feature.stub_type or fg_json.get("stub_type", False):
+            results.append(fg_json)
+            continue
+        no_bucketizer_fg_json = _remove_one_feature_bucketizer(dict(fg_json))
+        if is_referenced and no_bucketizer_fg_json != fg_json:
+            raise ValueError(
+                f"feature[{feature.name}] is used by other features as "
+                f"feature:{feature.name} and has a bucketizer, which is not "
+                "supported when remove bucketizer, because the value used by "
+                "downstream features is bucketized. Please set stub_type=true "
+                f"on [{feature.name}] if it is only a fg dag intermediate "
+                "result, or add another feature with the bucketizer for the "
+                "model to use."
+            )
+        results.append(no_bucketizer_fg_json)
+    return results
 
 
 def create_fg_json(
@@ -1321,6 +1355,16 @@ def create_fg_json(
     remove_bucketizer: bool = False,
 ) -> Dict[str, Any]:
     """Create feature generate config for features."""
+    referenced_names = set()
+    if remove_bucketizer:
+        for feature in features:
+            try:
+                referenced_names |= {
+                    name for side, name in feature.side_inputs if side == "feature"
+                }
+            except InvalidFgInputError:
+                pass
+
     results = []
     seq_to_idx = {}
     for feature in features:
@@ -1340,13 +1384,13 @@ def create_fg_json(
                 seq_to_idx[feature.sequence_name] = len(results) - 1
             fg_json = feature.fg_json()
             if remove_bucketizer:
-                fg_json = [_remove_one_feature_bucketizer(x) for x in fg_json]
+                fg_json = _remove_bucketizer(feature, fg_json, referenced_names)
             idx = seq_to_idx[feature.sequence_name]
             results[idx]["features"].extend(fg_json)
         else:
             fg_json = feature.fg_json()
             if remove_bucketizer:
-                fg_json = [_remove_one_feature_bucketizer(x) for x in fg_json]
+                fg_json = _remove_bucketizer(feature, fg_json, referenced_names)
             results.extend(fg_json)
     return {"features": results}
 

--- a/tzrec/features/feature_test.py
+++ b/tzrec/features/feature_test.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pyarrow as pa
-from parameterized import parameterized
+from parameterized import param, parameterized
 
 from tzrec.features import (
     combo_feature,
@@ -29,7 +29,7 @@ from tzrec.features import (
 from tzrec.features import feature as feature_lib
 from tzrec.features.feature import FgMode
 from tzrec.protos import feature_pb2
-from tzrec.utils.test_util import make_test_dir
+from tzrec.utils.test_util import make_test_dir, parameterized_name_func
 
 
 class FeatureTest(unittest.TestCase):
@@ -617,6 +617,161 @@ class FeatureTest(unittest.TestCase):
         )
         if with_asset_dir:
             self.assertTrue(os.path.exists(os.path.join(asset_dir, token_file)))
+
+    def _create_test_dag_feature_cfgs(self, grouped, stub_type):
+        cat_a = feature_pb2.IdFeature(
+            feature_name="cat_a",
+            expression="item:cat_a",
+            embedding_dim=16,
+            num_buckets=100,
+        )
+        if stub_type:
+            cat_a.stub_type = True
+        combo_b = feature_pb2.ComboFeature(
+            feature_name="combo_b",
+            expression=[
+                "feature:click_seq__cat_a" if grouped else "feature:cat_a",
+                "item:cat_b",
+            ],
+            embedding_dim=16,
+            hash_bucket_size=1000,
+        )
+        if grouped:
+            return [
+                feature_pb2.FeatureConfig(
+                    sequence_feature=feature_pb2.SequenceFeature(
+                        sequence_name="click_seq",
+                        sequence_length=50,
+                        sequence_delim=";",
+                        features=[
+                            feature_pb2.SeqFeatureConfig(id_feature=cat_a),
+                            feature_pb2.SeqFeatureConfig(combo_feature=combo_b),
+                        ],
+                    )
+                )
+            ]
+        return [
+            feature_pb2.FeatureConfig(id_feature=cat_a),
+            feature_pb2.FeatureConfig(combo_feature=combo_b),
+        ]
+
+    @parameterized.expand(
+        [
+            param("flat", grouped=False),
+            param("grouped_sequence", grouped=True),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_create_fg_json_remove_bucketizer_with_stub_feature(self, _, grouped):
+        feature_cfgs = self._create_test_dag_feature_cfgs(grouped, stub_type=True)
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        fg_json = feature_lib.create_fg_json(features, remove_bucketizer=True)
+
+        fg_cfgs = fg_json["features"]
+        if grouped:
+            fg_cfgs = fg_cfgs[0]["features"]
+        self.assertEqual(fg_cfgs[0]["num_buckets"], 100)
+        self.assertEqual(fg_cfgs[0]["stub_type"], True)
+        self.assertNotIn("hash_bucket_size", fg_cfgs[1])
+
+    @parameterized.expand(
+        [
+            param("flat", grouped=False),
+            param("grouped_sequence", grouped=True),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_create_fg_json_remove_bucketizer_with_referenced_feature(self, _, grouped):
+        feature_cfgs = self._create_test_dag_feature_cfgs(grouped, stub_type=False)
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        with self.assertRaisesRegex(ValueError, "is used by other features"):
+            feature_lib.create_fg_json(features, remove_bucketizer=True)
+
+        fg_json = feature_lib.create_fg_json(features)
+        fg_cfgs = fg_json["features"]
+        if grouped:
+            fg_cfgs = fg_cfgs[0]["features"]
+        self.assertEqual(fg_cfgs[0]["num_buckets"], 100)
+
+    def test_create_fg_json_remove_bucketizer_without_bucketizer(self):
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                raw_feature=feature_pb2.RawFeature(
+                    feature_name="raw_a", expression="item:raw_a"
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                combo_feature=feature_pb2.ComboFeature(
+                    feature_name="combo_b",
+                    expression=["feature:raw_a", "item:cat_b"],
+                    embedding_dim=16,
+                    hash_bucket_size=1000,
+                )
+            ),
+        ]
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        fg_json = feature_lib.create_fg_json(features, remove_bucketizer=True)
+
+        fg_cfgs = fg_json["features"]
+        self.assertEqual(fg_cfgs[0]["feature_name"], "raw_a")
+        self.assertNotIn("hash_bucket_size", fg_cfgs[1])
+
+    def test_create_fg_json_remove_bucketizer_with_stub_mulval_lookup(self):
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                lookup_feature=feature_pb2.LookupFeature(
+                    feature_name="lookup_a",
+                    map="user:map_a",
+                    key="item:key_a",
+                    embedding_dim=16,
+                    value_dim=2,
+                    boundaries=[1.0, 2.0],
+                    stub_type=True,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                expr_feature=feature_pb2.ExprFeature(
+                    feature_name="expr_b",
+                    expression="lookup_a*10",
+                    variables=["feature:lookup_a"],
+                )
+            ),
+        ]
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        fg_json = feature_lib.create_fg_json(features, remove_bucketizer=True)
+
+        fg_cfgs = fg_json["features"]
+        self.assertEqual(fg_cfgs[1]["feature_name"], "lookup_a")
+        self.assertEqual(fg_cfgs[1]["boundaries"], [1.0, 2.0])
+
+    def test_create_fg_json_remove_bucketizer_with_sequence_tokenize(self):
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                sequence_tokenize_feature=feature_pb2.TokenizeFeature(
+                    feature_name="token_a",
+                    expression="item:txt_a",
+                    embedding_dim=16,
+                    vocab_file="data/test/tokenizer.json",
+                    sequence_length=50,
+                    sequence_delim=";",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                combo_feature=feature_pb2.ComboFeature(
+                    feature_name="combo_b",
+                    expression=["feature:token_a", "item:cat_b"],
+                    embedding_dim=16,
+                    hash_bucket_size=1000,
+                )
+            ),
+        ]
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        fg_json = feature_lib.create_fg_json(features, remove_bucketizer=True)
+
+        fg_cfgs = fg_json["features"]
+        self.assertEqual(fg_cfgs[0]["feature_type"], "sequence_tokenize_feature")
+        self.assertEqual(fg_cfgs[0]["vocab_file"], "data/test/tokenizer.json")
+        self.assertNotIn("hash_bucket_size", fg_cfgs[1])
 
     @parameterized.expand([[False], [True]])
     def test_create_feauture_configs(self, with_asset_dir=False):

--- a/tzrec/features/lookup_feature.py
+++ b/tzrec/features/lookup_feature.py
@@ -144,6 +144,8 @@ class LookupFeature(BaseFeature):
                 raw_fg_cfg["normalizer"] = self.config.normalizer
             if len(self.config.boundaries) > 0:
                 raw_fg_cfg["boundaries"] = list(self.config.boundaries)
+            if self.config.HasField("stub_type"):
+                raw_fg_cfg["stub_type"] = self.config.stub_type
         else:
             if self.config.separator != "\x1d":
                 fg_cfg["separator"] = self.config.separator

--- a/tzrec/tools/create_fg_json.py
+++ b/tzrec/tools/create_fg_json.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         "--remove_bucketizer",
         action="store_true",
         default=False,
-        help="remove bucktizer params in fg json.",
+        help="remove bucketizer params in fg json.",
     )
     parser.add_argument(
         "--debug",

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.18"
+__version__ = "1.3.19"


### PR DESCRIPTION
## Problem

A `feature` side input (`feature:xxx`) reads the referenced feature's value **after** bucketize, but `create_fg_json(remove_bucketizer=True)` — used by `create_fg_json.py --remove_bucketizer` to produce the offline fg json for `fg_mode=FG_BUCKETIZE` — stripped the bucketizer of every feature. The offline job then computed the downstream features from unbucketized values, and its output silently disagreed with what `FG_DAG` computes online. No error, no warning.

Minimal repro on pyfg 1.0.5 — `a` = `x*1` with `boundaries: [1.5, 2.5]`, `b` = `a*10` with `variables: ["feature:a"]`, input `x = [1, 2, 3]`:

| fg json | `a` | `b` |
| --- | --- | --- |
| with boundaries (online / FG_DAG) | `[0, 1, 2]` | `[0, 10, 20]` |
| boundaries removed (offline) | `[1, 2, 3]` | `[10, 20, 30]` |

It happens for `stub_type: true` intermediates too, which are not even output columns.

## Fix

- **Keep the bucketizer of `stub_type` features.** A stub is never output as a column and is never bucketized again by the dataset, so its only consumer is a downstream feature inside the offline dag — the offline json has to compute it exactly like the online dag does.
- **Reject a referenced non stub feature that has a bucketizer.** Such a feature has two contradictory requirements: its column must be unbucketized so the dataset can bucketize it, while its consumers need the bucketized value. The error names the feature and the two ways out — mark it `stub_type: true` if it is only a dag intermediate, or add a separate feature carrying the bucketizer for the model.

The check compares each fg json against its stripped copy rather than re-listing the bucketizer keys, so it stays in sync with `_remove_one_feature_bucketizer` and does not trip on a referenced `tokenize_feature`, whose `vocab_file` is deliberately kept. Matching is on `feature.name`, not the fg json `feature_name`: inside a grouped sequence the entry is named `is_same_cate` while the reference is written `feature:click_seq__is_same_cate`.

Only `remove_bucketizer=True` is affected; the full fg json used by `FG_DAG` and by export is already self-consistent and is untouched. The internal `feature:` references built by `LookupFeature` (`value_dim > 1`) and `TokenizeFeature` (`__text_norm`) are unaffected — those intermediates already carry `stub_type: True` and no bucketizer.

## Test Plan

- New tests in `tzrec/features/feature_test.py`, each over a flat and a grouped-sequence config (the grouped one is what covers the prefixed-name matching): a stub feature with `num_buckets` referenced through `feature:` keeps its `num_buckets` while its consumer's own bucketizer is still stripped; the same config without `stub_type` raises `ValueError`, and stays valid when `remove_bucketizer` is not set.
- End to end against pyfg: built both jsons for a stub-with-boundaries chain and ran them on the same input — the downstream feature is now `[0, 10, 20]` in both, where the offline one used to be `[10, 20, 30]`.
- `tzrec/features/feature_test.py`, `lookup_feature_test.py`, `tokenize_feature_test.py`, `expr_feature_test.py`, `bool_mask_feature_test.py`, `tzrec/datasets/data_parser_test.py` all pass; the existing `test_create_fg_json` / `test_create_fg_json_remove_bucketizer` expectations are unchanged. `pre-commit run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUtoVaSwFYeKdPFvRjVw6U