### PR TITLE
[bugfix] bump graphlearn to 1.3.9 and pyodps to >=0.13.1

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -341,3 +341,40 @@ model_config {
 ```
 
 具体余量需大于`max_contextual_seq_len + 1`（`max_contextual_seq_len` = contextual feature group的特征数）。
+
+______________________________________________________________________
+
+**Q17: MaxCompute Storage API读表失败**
+
+**报错信息：** 图采样（负采样/TDM）加载图数据时报错，最终sampler server退出，训练任务失败：
+
+```
+E0824 16:36:02.523523 163241 storage_api_file_system.cc:309] Fail to create read session:
+E0824 16:36:02.523869 163241 edge_loader.cc:99] Try to read next edge file failed, Internal:Failed to create read session.
+E0824 16:36:06.686076 163234 storage_api_file_system.cc:309] Fail to create read session: Read error
+E0824 16:36:04.137389 163237 storage_api_file_system.cc:372] Reach the end of OdpsTable
+F0824 16:36:33.027580 163127 server_impl.cc:172] Server load data failed: Internal:Failed to create read session.
+```
+
+**原因：** graphlearn 1.3.8及以前版本和pyodps 0.12.x的storage api读表实现有缺陷：session创建的瞬时失败不重试，读流中断还会被当作读完，导致数据静默截断。
+
+**解决方法：** 升级依赖graphlearn>=1.3.9、pyodps>=0.13.1，TorchEasyRec 1.3.19之后的版本已默认包含。已有环境可手动升级（`cp311`需替换为实际的python版本）：
+
+```bash
+pip install --force-reinstall --no-deps \
+  https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp311-cp311-linux_x86_64.whl
+pip install -U "pyodps>=0.13.1"
+```
+
+**排查与调优：** graphlearn>=1.3.9新增了以下环境变量，默认值一般无需修改。如果升级后读表仍然失败，优先设置`STORAGE_API_LOG_LEVEL=DEBUG`，SDK默认只按ERROR级别打日志，看不到失败请求的HTTP状态码和响应体，DEBUG可以打印出来（输出到stdout）。
+
+| 环境变量                           | 默认值         | 作用                                                                    |
+| ---------------------------------- | -------------- | ----------------------------------------------------------------------- |
+| `STORAGE_API_LOG_LEVEL`            | SDK默认(ERROR) | 设为`DEBUG`打印失败请求的HTTP状态码与响应体，可选`DEBUG`/`INFO`/`ERROR` |
+| `STORAGE_API_CONNECT_TIMEOUT`      | 180（秒）      | socket连接超时                                                          |
+| `STORAGE_API_SOCKET_TIMEOUT`       | 300（秒）      | socket读写超时                                                          |
+| `STORAGE_API_RETRY_TIMES`          | 5              | create read session的重试次数（指数退避+抖动）                          |
+| `STORAGE_API_READ_RETRY_TIMES`     | 5              | 读流中断后从首个未消费行续读的重试次数                                  |
+| `STORAGE_API_SDK_RETRY_TIMES`      | 5              | SDK内部重试次数（仅对连接错误生效）                                     |
+| `STORAGE_API_SESSION_POLL_TIMEOUT` | 600（秒）      | 等待read session离开INIT状态的超时时间                                  |
+| `STORAGE_API_COMPRESSION`          | `LZ4_FRAME`    | 传输压缩方式，可选`ZSTD`/`UNCOMPRESSED`                                 |

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,9 +5,9 @@ confluent-kafka
 fbgemm-gpu==1.7.0
 feature_store_py @ https://feature-store-py.oss-cn-beijing.aliyuncs.com/package/feature_store_py-2.2.8-py3-none-any.whl
 fsspec
-graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.8-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
-graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.8-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
-graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.8-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
+graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
+graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
 grpcio-tools<1.63.0
 numpy
 packaging
@@ -16,7 +16,7 @@ psutil
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
 pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
-pyodps==0.12.5.1
+pyodps>=0.13.1
 safetensors
 scikit-learn
 tensorboard


### PR DESCRIPTION
## What

- `requirements/runtime.txt`: graphlearn `1.3.8` -> `1.3.9` (cp310/cp311/cp312), `pyodps==0.12.5.1` -> `pyodps>=0.13.1`.
- `docs/source/faq.md`: new **Q17** for the `Fail to create read session` failure, with the new `STORAGE_API_*` environment variables.

## Why

Graph loading (negative sampling / TDM) died with `Fail to create read session`, usually with nothing after the colon, and the sampler server aborted the whole job:

```
E storage_api_file_system.cc:309] Fail to create read session:
E edge_loader.cc:99] Try to read next edge file failed, Internal:Failed to create read session.
F server_impl.cc:172] Server load data failed: Internal:Failed to create read session.
```

Where it did not die it silently dropped rows — the `Reach the end of OdpsTable` lines in those logs are read failures, not the end of the table.

Root causes, all in graphlearn's storage api caller and all fixed in 1.3.9:

1. `CreateReadSession` answers HTTP 202 -> `Status::WAIT` when the server builds the session asynchronously, which is a success. Anything other than OK was treated as fatal, and the body's `Message` field is empty on an accept, hence the empty error message. `GetRecordCount` read `record_count_` off that same 202, where it is not yet meaningful, and so mis-sliced the table for every loader thread. 1.3.9 accepts WAIT and polls `GetReadSession` until the session leaves INIT.
2. Socket timeouts of 5s/10s against SDK defaults of 180s/300s produced `Read error` under quota contention, and the SDK retries connection errors only, so those were never retried. 1.3.9 defaults the timeouts to the SDK values and retries session creation with jittered exponential backoff.
3. `Reader::Read()` returns false for a clean EOF, a mid-stream failure and a cancel alike; `GetStatus()` is the only discriminator. Mapping every false to `OutOfRange` made a truncated stream look like the end of the table. 1.3.9 checks `GetStatus()`, resumes from the first undelivered row, and fails loudly on a short read.

1.3.9 also opens one read session per table per process instead of two per loader thread, and defaults the wire format to LZ4_FRAME.

pyodps 0.12.x has the same class of gap on the python read path used by `odps_dataset`: retry was a urllib3 adapter restricted to `DELETE/GET/HEAD`, so `create_read_session` and `read_rows`, both POST, were never retried on a connection error. 0.13.1 replaces it with `RestClient._request_with_retry`, which retries connection errors regardless of method and read errors / 502-503-504 for idempotent methods. `tzrec.datasets.odps_dataset`'s own `ODPSError` retries are kept — 0.13.1 deliberately does not retry those on POST.

The FAQ entry documents the failure signature, both causes, and the environment variables 1.3.9 adds, of which `STORAGE_API_LOG_LEVEL=DEBUG` is the one to reach for first: the SDK logs at ERROR by default and hides the HTTP status and response body of the failing request.

## Test Plan

Validated in a conda env cloned from the 1.3.0 env, with `pip install -r requirements/runtime.txt` from this branch (graphlearn 1.3.9, pyodps 0.13.1, torch 2.12.1+cu129, protobuf 4.25.9):

- Import smoke: `tzrec`, `graphlearn` and `torch` coexist in one process. This matters because 1.3.9 changed packaging — protobuf/grpc/glog are now static-linked into a single hidden-visibility extension that exports only `PyInit_pywrap_graphlearn` — and `GLOG_logtostderr=1` still routes graphlearn logs to stderr (FAQ Q7 depends on it).
- `python -m tzrec.datasets.sampler_test`: 22 tests, OK (1 skipped) — client/server, multi-node and TDM sampler paths.
- `python -m tzrec.datasets.odps_dataset_test`: 18 tests, OK, but 14 skip without ODPS credentials, which this host does not have; the live storage-api read/write path against MaxCompute was therefore not exercised here. `odps_dataset_v1_test` skips for the same reason.
- Full suite `python tzrec/tests/run.py`: 1635 tests, 6 failures, all of them `No parquet files exist in data/test/kuairand-1k-train-c4096-s100.parquet` — that fixture is gitignored and was missing from the scratch worktree, so the six HSTU integration tests failed at data loading. With the fixtures restored those six pass (`Ran 6 tests ... OK`). Note `run.py` runs `sampler_test` / `dataset_test` / `odps_dataset_test` through `subprocess.run(["python", ...])`, i.e. whatever `python` PATH resolves to, so the run has to be launched with the target env on PATH or those tests silently validate a different environment.
- `pre-commit run --files docs/source/faq.md requirements/runtime.txt`: clean. `pyrefly` not run — no python file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8sHRYjuSwnfXdwpXh4nTy

