### PR TITLE
[feat] support weighted id feature not using weight in model

### DIFF
--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -116,6 +116,8 @@ feature_configs {
 
 - **weighted**: 是否为带权重的Id特征，输入形式为`k1:v1\x1dk2:v2`
 
+- **use_weight**: 默认值是false，仅在**weighted**=true时生效。默认情况下权重只用于解析输入，不参与模型计算，权重不会被解析和传输。设置为true时，权重会作为per_sample_weights参与Embedding pooling；**pooling**=mean时，权重会按每个样本归一化到和为1，pooling以sum的方式完成，保证训练和推理结果一致。注意同一特征组内不能有配置了**dynamicemb**的特征（dynamicemb复用了权重通道传递频次计数，不支持带权重的pooling）
+
 - **value_dim**: 默认值是0，可以设置1，value_dim=0时支持多值ID输出
 
 - **default_bucketize_value**: （可选）指定超出词表的词的编码。当配置了default_bucketize_value时，vocab_list和vocab_dict将不会预留编码给默认值和超出词表的词，用户可完全自主控制vocab_list或vocab_dict

--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -117,7 +117,7 @@ feature_configs {
 
 - **weighted**: 是否为带权重的Id特征，输入形式为`k1:v1\x1dk2:v2`
 
-- **use_weight**: 默认值是false，仅在**weighted**=true时生效。默认情况下权重只用于解析输入，不参与模型计算，权重不会被解析和传输。设置为true时，权重会作为per_sample_weights参与Embedding pooling；**pooling**=mean时，权重会按每个样本归一化到和为1，pooling以sum的方式完成，保证训练和推理结果一致。注意同一特征组内不能有配置了**dynamicemb**的特征（dynamicemb复用了权重通道传递频次计数，不支持带权重的pooling）
+- **use_weight**: 默认值是false，仅在**weighted**=true时生效。默认情况下，权重仅用于从`k:v`格式的输入中解析出id，解析后即被丢弃，不参与模型计算，也不会传输给模型。设置为true时，权重会作为per_sample_weights参与Embedding pooling；**pooling**=mean时，权重会按每个样本归一化到和为1，pooling以sum的方式完成，保证训练和推理结果一致。注意：开启后，同一**数据组（data group）**内的所有特征都会带上权重（其余特征填充为1）并走带权重的pooling kernel，会有一定的内存和计算开销；且同一数据组内不能有配置了**dynamicemb**的特征（dynamicemb复用了权重通道传递频次计数，不支持带权重的pooling）
 
 - **value_dim**: 默认值是0，可以设置1，value_dim=0时支持多值ID输出
 

--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -117,7 +117,7 @@ feature_configs {
 
 - **weighted**: 是否为带权重的Id特征，输入形式为`k1:v1\x1dk2:v2`
 
-- **use_weight**: 默认值是false，仅在**weighted**=true时生效。默认情况下，权重仅用于从`k:v`格式的输入中解析出id，解析后即被丢弃，不参与模型计算，也不会传输给模型。设置为true时，权重会作为per_sample_weights参与Embedding pooling；**pooling**=mean时，权重会按每个样本归一化到和为1，pooling以sum的方式完成，保证训练和推理结果一致。注意：开启后，同一**数据组（data group）**内的所有特征都会带上权重（其余特征填充为1）并走带权重的pooling kernel，会有一定的内存和计算开销；且同一数据组内不能有配置了**dynamicemb**的特征（dynamicemb复用了权重通道传递频次计数，不支持带权重的pooling）
+- **use_weight**: 默认值是false，仅在**weighted**=true时生效。默认情况下，权重仅用于从`k:v`格式的输入中解析出id，解析后即被丢弃，不参与模型计算，也不会传输给模型。设置为true时，权重会参与embedding pooling。注意：开启后，同一**数据组（data group）**内的所有特征都会带上权重（其余特征填充为1），会有一定的内存和计算开销；且同一数据组内不能有配置了**dynamicemb**的特征（dynamicemb目前不支持带权重的pooling）
 
 - **value_dim**: 默认值是0，可以设置1，value_dim=0时支持多值ID输出
 

--- a/tzrec/datasets/data_parser.py
+++ b/tzrec/datasets/data_parser.py
@@ -20,6 +20,7 @@ import pyarrow.compute as pc
 import pyfg
 import torch
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
+from torchrec.modules.embedding_configs import PoolingType
 
 from tzrec.acc.utils import (
     is_cuda_export,
@@ -46,6 +47,26 @@ def _to_tensor(x: npt.NDArray) -> torch.Tensor:
     if not x.flags.writeable:
         x = np.array(x)
     return torch.from_numpy(x)
+
+
+def _normalize_weight(weight: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    """Normalize weight of each bag to sum to one.
+
+    Mean pooling of a weighted feature is expressed as a sum pooling over
+    weights normalized per bag, so that the pooled result does not depend on
+    whether the divisor of the underlying kernel is the bag length or the sum
+    of the weights.
+
+    Args:
+        weight (torch.Tensor): per value weight.
+        lengths (torch.Tensor): value count of each bag.
+
+    Returns:
+        per value weight normalized by the weight sum of its bag.
+    """
+    weight_sum = torch.segment_reduce(weight, "sum", lengths=lengths)
+    weight_sum = torch.where(weight_sum == 0, torch.ones_like(weight_sum), weight_sum)
+    return weight / torch.repeat_interleave(weight_sum, lengths.long())
 
 
 @torch.fx.wrap
@@ -104,6 +125,7 @@ class DataParser:
         self.sequence_mulval_sparse_keys = defaultdict(list)
         self.sequence_dense_keys = []
         self.has_weight_keys = defaultdict(list)
+        self.mean_pooling_keys = defaultdict(list)
 
         self.sampler_type = sampler_type
 
@@ -124,8 +146,14 @@ class DataParser:
             else:
                 self.dense_keys[feature.data_group].append(feature.name)
                 self.dense_length_per_key[feature.data_group].append(feature.value_dim)
-            if feature.is_weighted:
+            if feature.use_weight:
                 self.has_weight_keys[feature.data_group].append(feature.name)
+            if (
+                feature.is_sparse
+                and not feature.is_sequence
+                and feature.pooling_type == PoolingType.MEAN
+            ):
+                self.mean_pooling_keys[feature.data_group].append(feature.name)
 
         if self._fg_mode in [FgMode.FG_DAG, FgMode.FG_BUCKETIZE]:
             self._init_fg_hander()
@@ -386,7 +414,7 @@ class DataParser:
                             feat_lengths, (0, max_batch_size - len(feat_lengths))
                         )
                     output_data[f"{feat_name}.lengths"] = _to_tensor(feat_lengths)
-                    if feature.is_weighted:
+                    if feature.use_weight:
                         output_data[f"{feat_name}.weights"] = _to_tensor(
                             feat_data.np_weights
                         )
@@ -547,6 +575,7 @@ class DataParser:
             mulval_key_lengths = []
 
             dg_has_weight_keys = self.has_weight_keys[dg]
+            dg_mean_pooling_keys = self.mean_pooling_keys[dg]
             dg_sequence_mulval_sparse_keys = self.sequence_mulval_sparse_keys[dg]
             for key in keys:
                 values.append(input_data[f"{key}.values"])
@@ -565,13 +594,14 @@ class DataParser:
                 lengths.append(length)
                 if len(dg_has_weight_keys) > 0:
                     if key in dg_has_weight_keys:
-                        weights.append(input_data[f"{key}.weights"])
+                        weight = input_data[f"{key}.weights"]
                     else:
-                        weights.append(
-                            torch.ones_like(
-                                input_data[f"{key}.values"], dtype=torch.float32
-                            )
+                        weight = torch.ones_like(
+                            input_data[f"{key}.values"], dtype=torch.float32
                         )
+                    if key in dg_mean_pooling_keys:
+                        weight = _normalize_weight(weight, input_data[f"{key}.lengths"])
+                    weights.append(weight)
 
             sparse_feature = KeyedJaggedTensor(
                 keys=keys,
@@ -672,6 +702,7 @@ class DataParser:
             mulval_key_lengths = []
 
             dg_has_weight_keys = self.has_weight_keys[dg]
+            dg_mean_pooling_keys = self.mean_pooling_keys[dg]
             dg_sequence_mulval_sparse_keys = self.sequence_mulval_sparse_keys[dg]
 
             for key in keys:
@@ -704,6 +735,8 @@ class DataParser:
                         weight = torch.ones_like(
                             input_data[f"{key}.values"], dtype=torch.float32
                         )
+                    if key in dg_mean_pooling_keys:
+                        weight = _normalize_weight(weight, input_data[f"{key}.lengths"])
                     if key in self.user_feats:
                         weight = weight.tile(tile_size)
                     weights.append(weight)
@@ -767,6 +800,7 @@ class DataParser:
             mulval_key_lengths_user = []
 
             dg_has_weight_keys = self.has_weight_keys[dg]
+            dg_mean_pooling_keys = self.mean_pooling_keys[dg]
             dg_sequence_mulval_sparse_keys = self.sequence_mulval_sparse_keys[dg]
             for key in keys:
                 value = input_data[f"{key}.values"]
@@ -807,6 +841,8 @@ class DataParser:
                         weight = torch.ones_like(
                             input_data[f"{key}.values"], dtype=torch.float32
                         )
+                    if key in dg_mean_pooling_keys:
+                        weight = _normalize_weight(weight, input_data[f"{key}.lengths"])
                     if key in self.user_feats:
                         weights_user.append(weight)
                     else:
@@ -889,7 +925,7 @@ class DataParser:
                     lengths = input_data[f"{f.name}.lengths"]
                     values = input_data[f"{f.name}.values"].cpu().numpy().astype(str)
                     weights = None
-                    if f.is_weighted:
+                    if f.use_weight:
                         weights = (
                             input_data[f"{f.name}.weights"].cpu().numpy().astype(str)
                         )

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -162,6 +162,7 @@ class DataParserTest(unittest.TestCase):
                     embedding_dim=16,
                     num_buckets=100,
                     weighted=True,
+                    use_weight=True,
                 )
             ),
             feature_pb2.FeatureConfig(
@@ -170,6 +171,7 @@ class DataParserTest(unittest.TestCase):
                     embedding_dim=16,
                     num_buckets=100,
                     weighted=True,
+                    use_weight=True,
                     fg_encoded_default_value="0",
                 )
             ),
@@ -179,6 +181,7 @@ class DataParserTest(unittest.TestCase):
                     embedding_dim=8,
                     num_buckets=1000,
                     weighted=True,
+                    use_weight=True,
                 )
             ),
             feature_pb2.FeatureConfig(
@@ -187,6 +190,7 @@ class DataParserTest(unittest.TestCase):
                     embedding_dim=8,
                     num_buckets=1000,
                     weighted=True,
+                    use_weight=True,
                     fg_encoded_default_value="0",
                 )
             ),
@@ -353,6 +357,7 @@ class DataParserTest(unittest.TestCase):
         tag_b_seq=False,
         with_const=False,
         with_stub_feat=False,
+        tag_b_use_weight=True,
     ):
         seq_sub_feas = [
             feature_pb2.SeqFeatureConfig(
@@ -407,6 +412,7 @@ class DataParserTest(unittest.TestCase):
                     embedding_dim=8,
                     num_buckets=1000,
                     weighted=tag_b_weighted,
+                    use_weight=tag_b_use_weight,
                 )
             ),
             feature_pb2.FeatureConfig(
@@ -702,6 +708,110 @@ class DataParserTest(unittest.TestCase):
             )
         )
         torch.testing.assert_close(batch.labels["label"], expected_label)
+
+    def test_fg_encoded_weighted_id_mean_pooling(self):
+        # mean pooling in a weighted data group is carried by the per-sample
+        # weights, normalized to sum to one per bag, so that pooling stays a
+        # plain weighted sum in every lookup kernel.
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="tag_a",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="tag_b",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="tag_c",
+                    embedding_dim=8,
+                    num_buckets=100,
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        data_parser = DataParser(features=features)
+        data = data_parser.parse(
+            input_data={
+                "tag_a": pa.array(["1:1.0\x032:3.0", "", "3:2.0"]),
+                "tag_b": pa.array(["1\x032", "", "3"]),
+                "tag_c": pa.array(["1\x032", "", "3"]),
+            }
+        )
+        # raw weights are kept in the parsed inputs, normalization is in to_batch
+        torch.testing.assert_close(data["tag_a.weights"], torch.tensor([1.0, 3.0, 2.0]))
+
+        batch = data_parser.to_batch(data)
+        weights = batch.sparse_features["__BASE__"].weights()
+        # tag_a: weighted mean -> w / sum(w); tag_b: plain mean -> 1 / length;
+        # tag_c: sum pooling -> untouched ones
+        torch.testing.assert_close(
+            weights,
+            torch.tensor(
+                [0.25, 0.75, 1.0, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0],
+            ),
+        )
+
+    @parameterized.expand(
+        [
+            param("fg_normal", fg_mode=FgMode.FG_NORMAL),
+            param("fg_dag", fg_mode=FgMode.FG_DAG),
+            param("fg_none", fg_mode=FgMode.FG_NONE),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_fg_weighted_id_without_use_weight(self, name, fg_mode):
+        feature_cfgs = self._create_test_fg_feature_cfgs(
+            tag_b_weighted=True, tag_b_use_weight=False
+        )
+        features = create_features(feature_cfgs, fg_mode=fg_mode)
+        data_parser = DataParser(features=features)
+        self.assertEqual(len(data_parser.has_weight_keys["__BASE__"]), 0)
+
+        if fg_mode == FgMode.FG_NONE:
+            input_data = {
+                "f_cat_a": pa.array(["1", "2", "3"]),
+                "f_tag_b": pa.array(["4:0.1\x035:0.2", "", "6:0.3"]),
+                "f_int_a": pa.array([7, 8, 9], pa.float32()),
+                "f_int_b": pa.array(["27\x0337", "28\x0338", "29\x0339"]),
+                "f_lookup_a": pa.array([0.1, 0.0, 0.2], pa.float32()),
+                "click_seq__f_cat_a": pa.array(["10;11;12", "13", ""]),
+                "click_seq__f_int_a": pa.array(["14;15;16", "17", ""]),
+            }
+        else:
+            input_data = {
+                "cat_a": pa.array([1, 2, 3]),
+                "tag_b": pa.array(["4:0.1\x1d5:0.2", "", "6:0.3"]),
+                "int_a": pa.array([7, 8, 9], pa.float32()),
+                "int_b": pa.array(["27\x1d37", "28\x1d38", "29\x1d39"]),
+                "map_a": pa.array(["1:0.1\x1d3:0.2", "", "1:0.1\x1d3:0.2"]),
+                "click_seq__cat_a": pa.array(["10;11;12", "13", ""]),
+                "click_seq__int_a": pa.array(["14;15;16", "17", ""]),
+            }
+
+        data = data_parser.parse(input_data=input_data)
+        self.assertNotIn("f_tag_b.weights", data)
+        torch.testing.assert_close(
+            data["f_tag_b.lengths"], torch.tensor([2, 0, 1], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            torch.sort(data["f_tag_b.values"][:2]).values,
+            torch.tensor([4, 5], dtype=torch.int64),
+        )
+
+        batch = data_parser.to_batch(data)
+        self.assertIsNone(batch.sparse_features["__BASE__"].weights_or_none())
 
     def test_fg_with_const(self):
         feature_cfgs = self._create_test_fg_feature_cfgs(

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -33,6 +33,7 @@ from tzrec.utils.test_util import parameterized_name_func
 class DataParserTest(unittest.TestCase):
     def tearDown(self):
         os.environ.pop("INPUT_TILE", None)
+        os.environ.pop("INPUT_TILE_3_ONLINE", None)
 
     def test_nofg(self):
         feature_cfgs = [
@@ -358,6 +359,7 @@ class DataParserTest(unittest.TestCase):
         with_const=False,
         with_stub_feat=False,
         tag_b_use_weight=True,
+        tag_b_pooling="sum",
     ):
         seq_sub_feas = [
             feature_pb2.SeqFeatureConfig(
@@ -413,6 +415,7 @@ class DataParserTest(unittest.TestCase):
                     num_buckets=1000,
                     weighted=tag_b_weighted,
                     use_weight=tag_b_use_weight,
+                    pooling=tag_b_pooling,
                 )
             ),
             feature_pb2.FeatureConfig(
@@ -744,13 +747,17 @@ class DataParserTest(unittest.TestCase):
         data_parser = DataParser(features=features)
         data = data_parser.parse(
             input_data={
-                "tag_a": pa.array(["1:1.0\x032:3.0", "", "3:2.0"]),
-                "tag_b": pa.array(["1\x032", "", "3"]),
-                "tag_c": pa.array(["1\x032", "", "3"]),
+                # the last row has an all-zero weight bag, its weight sum is
+                # guarded to one so that normalization does not divide by zero
+                "tag_a": pa.array(["1:1.0\x032:3.0", "", "3:2.0", "4:0.0\x035:0.0"]),
+                "tag_b": pa.array(["1\x032", "", "3", "4"]),
+                "tag_c": pa.array(["1\x032", "", "3", "4"]),
             }
         )
         # raw weights are kept in the parsed inputs, normalization is in to_batch
-        torch.testing.assert_close(data["tag_a.weights"], torch.tensor([1.0, 3.0, 2.0]))
+        torch.testing.assert_close(
+            data["tag_a.weights"], torch.tensor([1.0, 3.0, 2.0, 0.0, 0.0])
+        )
 
         batch = data_parser.to_batch(data)
         weights = batch.sparse_features["__BASE__"].weights()
@@ -759,8 +766,127 @@ class DataParserTest(unittest.TestCase):
         torch.testing.assert_close(
             weights,
             torch.tensor(
-                [0.25, 0.75, 1.0, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0],
+                # fmt: off
+                [
+                    0.25,
+                    0.75,
+                    1.0,
+                    0.0,
+                    0.0,  # tag_a  w / sum(w), 0/0 -> 0
+                    0.5,
+                    0.5,
+                    1.0,
+                    1.0,  # tag_b  1 / length
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,  # tag_c  untouched ones
+                ],
+                # fmt: on
             ),
+        )
+
+    def _weighted_input_tile_features(self):
+        """A weighted mean, a plain mean and a sum feature, user/user/item side."""
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="u_w",
+                    expression="user:u_w",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="u_m",
+                    expression="user:u_m",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="i_s",
+                    expression="item:i_s",
+                    embedding_dim=8,
+                    num_buckets=100,
+                )
+            ),
+        ]
+        return create_features(feature_cfgs)
+
+    @staticmethod
+    def _weighted_input_tile_input_data():
+        # the same user in every row, so tiling row 0 is equivalent to the batch
+        return {
+            "u_w": pa.array(["4:1.0\x035:3.0"] * 3),
+            "u_m": pa.array(["1\x032\x033"] * 3),
+            "i_s": pa.array(["7", "8", "9"]),
+        }
+
+    def test_weighted_id_mean_pooling_input_tile(self):
+        # INPUT_TILE=2: user weights are normalized on the untiled bag and only
+        # then tiled, so each tiled copy keeps weights summing to one.
+        os.environ["INPUT_TILE"] = "2"
+        os.environ["INPUT_TILE_3_ONLINE"] = "1"
+        data_parser = DataParser(features=self._weighted_input_tile_features())
+        data = data_parser.parse(input_data=self._weighted_input_tile_input_data())
+        batch = data_parser.to_batch(data)
+
+        sparse_feature = batch.sparse_features["__BASE__"]
+        self.assertEqual(sparse_feature.keys(), ["u_w", "u_m", "i_s"])
+        torch.testing.assert_close(
+            sparse_feature.weights(),
+            torch.tensor(
+                # fmt: off
+                [
+                    0.25,
+                    0.75,
+                    0.25,
+                    0.75,
+                    0.25,
+                    0.75,  # u_w  w / sum(w), tiled
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,
+                    1 / 3,  # u_m  1 / length, tiled
+                    1.0,
+                    1.0,
+                    1.0,  # i_s  untouched ones
+                ],
+                # fmt: on
+            ),
+        )
+
+    def test_weighted_id_mean_pooling_input_tile_emb(self):
+        # INPUT_TILE=3: user features stay at batch_size=1 in their own kjt, the
+        # weights are split across the user and the item collection.
+        os.environ["INPUT_TILE"] = "3"
+        os.environ["INPUT_TILE_3_ONLINE"] = "1"
+        data_parser = DataParser(features=self._weighted_input_tile_features())
+        data = data_parser.parse(input_data=self._weighted_input_tile_input_data())
+        batch = data_parser.to_batch(data)
+
+        user_feature = batch.sparse_features["__BASE___user"]
+        self.assertEqual(user_feature.keys(), ["u_w", "u_m"])
+        torch.testing.assert_close(
+            user_feature.weights(),
+            torch.tensor([0.25, 0.75, 1 / 3, 1 / 3, 1 / 3]),
+        )
+        item_feature = batch.sparse_features["__BASE__"]
+        self.assertEqual(item_feature.keys(), ["i_s"])
+        torch.testing.assert_close(
+            item_feature.weights(), torch.tensor([1.0, 1.0, 1.0])
         )
 
     @parameterized.expand(

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -83,6 +83,7 @@ def _parse_fg_encoded_sparse_feature_impl(
     multival_sep: str = chr(3),
     default_value: Optional[List[int]] = None,
     is_weighted: bool = False,
+    use_weight: bool = False,
 ) -> SparseData:
     """Parse fg encoded sparse feature.
 
@@ -92,6 +93,7 @@ def _parse_fg_encoded_sparse_feature_impl(
         multival_sep (str): string separator for multi-val data.
         default_value (list): default value.
         is_weighted (bool): input feature is weighted or not.
+        use_weight (bool): output weight of the weighted feature or not.
 
     Returns:
         an instance of SparseData.
@@ -127,12 +129,16 @@ def _parse_fg_encoded_sparse_feature_impl(
                 )
         else:
             # dtype = map<int,float> or others can cast to map<int,float>
-            weight = pa.ListArray.from_arrays(
-                feat.offsets, feat.items, mask=feat.is_null()
-            )
+            if is_weighted:
+                weight = pa.ListArray.from_arrays(
+                    feat.offsets, feat.items, mask=feat.is_null()
+                )
             feat = pa.ListArray.from_arrays(
                 feat.offsets, feat.keys, mask=feat.is_null()
             )
+
+        if not use_weight:
+            weight = None
 
         feat = feat.cast(pa.list_(pa.int64()), safe=False)
         if weight is not None:
@@ -412,6 +418,8 @@ class BaseFeature(object, metaclass=_meta_cls):
         self._is_neg = False
         self._is_sparse = None
         self._is_weighted = False
+        self._use_weight = False
+        self._in_weighted_group = False
         self._is_user_feat = None
         self._data_group = BASE_DATA_GROUP
         self._inputs = None
@@ -578,6 +586,11 @@ class BaseFeature(object, metaclass=_meta_cls):
         return self._is_weighted
 
     @property
+    def use_weight(self) -> bool:
+        """Weight of the weighted id feature is used in embedding or not."""
+        return self._use_weight
+
+    @property
     def has_embedding(self) -> bool:
         """Feature has embedding or not."""
         if self.is_sparse:
@@ -618,21 +631,42 @@ class BaseFeature(object, metaclass=_meta_cls):
             init_fn = None
             if self.config.HasField("init_fn"):
                 init_fn = init_util.create_init_fn(self.config.init_fn)
+            pooling = self.pooling_type
+            need_weight = self._use_weight
+            if self._in_weighted_group and pooling == PoolingType.MEAN:
+                # DataParser normalizes the per-sample weights of a mean pooled
+                # feature to sum to one per bag, so mean is done by sum pooling
+                # over them. eager EmbeddingBag does not support per_sample_weights
+                # with mean, and the mean divisor of the training and the inference
+                # kernel differ, so keeping mean would make them disagree.
+                pooling = PoolingType.SUM
+                need_weight = True
+            use_dynamicemb = hasattr(
+                self.config, "dynamicemb"
+            ) and self.config.HasField("dynamicemb")
+            if self._in_weighted_group and use_dynamicemb:
+                # dynamicemb reuses the kjt weights to carry frequency counters
+                # and does not support per_sample_weights in pooling.
+                raise ValueError(
+                    f"{self.__class__.__name__}[{self.name}] with dynamicemb cannot"
+                    " be in the same data group with a weighted id feature, please"
+                    " set use_weight = false on the weighted feature."
+                )
             emb_bag_config = EmbeddingBagConfig(
                 num_embeddings=self.num_embeddings,
                 embedding_dim=self._embedding_dim,
                 name=embedding_name,
                 feature_names=[self.name],
-                pooling=self.pooling_type,
+                pooling=pooling,
                 init_fn=init_fn,
                 data_type=_dtype_str_to_data_type(self.config.data_type),
             )
             # pyre-ignore [16]
             emb_bag_config.trainable = self.config.trainable
             # pyre-ignore [16]
-            emb_bag_config.use_dynamicemb = hasattr(
-                self.config, "dynamicemb"
-            ) and self.config.HasField("dynamicemb")
+            emb_bag_config.use_dynamicemb = use_dynamicemb
+            # pyre-ignore [16]
+            emb_bag_config.is_weighted = need_weight
             return emb_bag_config
         else:
             return None
@@ -931,6 +965,7 @@ class BaseFeature(object, metaclass=_meta_cls):
                         self.name,
                         feat,
                         is_weighted=self._is_weighted,
+                        use_weight=self._use_weight,
                         **self._fg_encoded_kwargs,
                     )
                 else:
@@ -961,7 +996,7 @@ class BaseFeature(object, metaclass=_meta_cls):
                         name=self.name,
                         values=feat_data.np_values,
                         lengths=feat_data.np_lengths,
-                        weights=feat_data.np_weights if self._is_weighted else None,
+                        weights=feat_data.np_weights if self._use_weight else None,
                     )
                 else:
                     parsed_feat = DenseData(
@@ -1228,6 +1263,10 @@ def create_features(
                     break
         except InvalidFgInputError:
             pass
+
+    weighted_data_groups = {x.data_group for x in features if x.use_weight}
+    for feature in features:
+        feature._in_weighted_group = feature.data_group in weighted_data_groups
 
     if has_dag:
         fg_json = create_fg_json(features)

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -1272,7 +1272,9 @@ def create_features(
         except InvalidFgInputError:
             pass
 
-    weighted_data_groups = {x.data_group for x in features if x.use_weight}
+    weighted_data_groups = {
+        x.data_group for x in features if x.use_weight and not x.stub_type
+    }
     for feature in features:
         feature._in_weighted_group = feature.data_group in weighted_data_groups
 

--- a/tzrec/features/feature_test.py
+++ b/tzrec/features/feature_test.py
@@ -148,12 +148,66 @@ class FeatureTest(unittest.TestCase):
             default_value=default_value,
             multival_sep=";",
             is_weighted=is_weighted,
+            use_weight=bool(is_weighted),
         )
         np.testing.assert_allclose(tag_data.values, np.array(expected_values))
         np.testing.assert_allclose(tag_data.lengths, np.array(expected_lengths))
         if is_weighted:
             assert tag_data.weights is not None
             np.testing.assert_allclose(tag_data.weights, np.array(expected_weights))
+
+    @parameterized.expand(
+        [
+            param(
+                "str",
+                input_feat=pa.array(["1:0.1;2:0.2;3:0.3", "", None, "4:0.4"]),
+                expected_values=[1, 2, 3, 4],
+                expected_lengths=[3, 0, 0, 1],
+                is_weighted=True,
+            ),
+            param(
+                "list",
+                input_feat=pa.array([["1:0.1", "2:0.2", "3:0.3"], [], None, ["4:0.4"]]),
+                expected_values=[1, 2, 3, 4],
+                expected_lengths=[3, 0, 0, 1],
+                is_weighted=True,
+            ),
+            param(
+                "map",
+                input_feat=pa.array(
+                    [{1: 0.1}, {2: 0.2}, None, {4: 0.4}],
+                    type=pa.map_(pa.int64(), pa.float32()),
+                ),
+                expected_values=[1, 2, 4],
+                expected_lengths=[1, 1, 0, 1],
+                is_weighted=True,
+            ),
+            param(
+                "map_wo_weighted",
+                input_feat=pa.array(
+                    [{1: 0.1}, {2: 0.2}, None, {4: 0.4}],
+                    type=pa.map_(pa.int64(), pa.float32()),
+                ),
+                expected_values=[1, 2, 4],
+                expected_lengths=[1, 1, 0, 1],
+                is_weighted=False,
+            ),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_parse_fg_encoded_sparse_feature_impl_wo_weight(
+        self, name, input_feat, expected_values, expected_lengths, is_weighted
+    ):
+        tag_data = feature_lib._parse_fg_encoded_sparse_feature_impl(
+            "tag",
+            input_feat,
+            multival_sep=";",
+            is_weighted=is_weighted,
+            use_weight=False,
+        )
+        np.testing.assert_allclose(tag_data.values, np.array(expected_values))
+        np.testing.assert_allclose(tag_data.lengths, np.array(expected_lengths))
+        self.assertIsNone(tag_data.weights)
 
     @parameterized.expand(
         [

--- a/tzrec/features/id_feature.py
+++ b/tzrec/features/id_feature.py
@@ -36,6 +36,14 @@ class IdFeature(BaseFeature):
         if isinstance(self.config, feature_pb2.IdFeature):
             self._is_weighted = self.config.weighted
             self._use_weight = self.config.weighted and self.config.use_weight
+            if self._is_weighted and self.is_sequence:
+                # fg does not parse weight for a sequence feature and
+                # SequenceSparseData has no weight, so the weight of a sequence
+                # feature would never reach the model.
+                raise ValueError(
+                    f"{self.__class__.__name__}[{self.name}] does not support "
+                    "weighted sequence feature."
+                )
 
     @property
     def value_dim(self) -> int:

--- a/tzrec/features/id_feature.py
+++ b/tzrec/features/id_feature.py
@@ -33,10 +33,9 @@ class IdFeature(BaseFeature):
     ) -> None:
         super().__init__(feature_config, **kwargs)
 
-        if isinstance(self.config, feature_pb2.IdFeature) and self.config.HasField(
-            "weighted"
-        ):
+        if isinstance(self.config, feature_pb2.IdFeature):
             self._is_weighted = self.config.weighted
+            self._use_weight = self.config.weighted and self.config.use_weight
 
     @property
     def value_dim(self) -> int:

--- a/tzrec/features/id_feature_test.py
+++ b/tzrec/features/id_feature_test.py
@@ -233,6 +233,21 @@ class IdFeatureTest(unittest.TestCase):
         np.testing.assert_allclose(parsed_feat.lengths, np.array([1, 2, 1]))
         self.assertIsNone(parsed_feat.weights)
 
+    def test_weighted_sequence_id_feature_raises(self):
+        # fg ignores weighted on a sequence feature and SequenceSparseData has no
+        # weight, so this used to blow up as a KeyError in a dataloader worker.
+        id_feat_cfg = feature_pb2.FeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="cate",
+                expression="item:cate",
+                embedding_dim=16,
+                num_buckets=100,
+                weighted=True,
+            )
+        )
+        with self.assertRaises(ValueError):
+            id_feature_lib.IdFeature(id_feat_cfg, is_sequence=True)
+
     def test_fg_encoded_id_feature_with_mask(self):
         id_feat_cfg = feature_pb2.FeatureConfig(
             id_feature=feature_pb2.IdFeature(

--- a/tzrec/features/id_feature_test.py
+++ b/tzrec/features/id_feature_test.py
@@ -18,7 +18,7 @@ import numpy as np
 import pyarrow as pa
 import pyfg
 import torch
-from parameterized import parameterized
+from parameterized import param, parameterized
 from torch import nn
 from torchrec.modules.embedding_configs import (
     EmbeddingBagConfig,
@@ -174,6 +174,7 @@ class IdFeatureTest(unittest.TestCase):
                 embedding_dim=16,
                 expression="item:cate",
                 weighted=True,
+                use_weight=True,
             )
         )
         id_feat = id_feature_lib.IdFeature(id_feat_cfg)
@@ -186,6 +187,51 @@ class IdFeatureTest(unittest.TestCase):
         np.testing.assert_allclose(parsed_feat.values, np.array(expected_values))
         np.testing.assert_allclose(parsed_feat.lengths, np.array(expected_lengths))
         np.testing.assert_allclose(parsed_feat.weights, np.array(expected_weights))
+
+    @parameterized.expand(
+        [
+            param(
+                "str",
+                inputs=pa.array(["1:1.0", "2:1.5\x033:2.0", "4:2.5"]),
+                weighted=True,
+            ),
+            param(
+                "map",
+                inputs=pa.array(
+                    [{1: 1.0}, {2: 1.5, 3: 2.0}, {4: 2.5}],
+                    type=pa.map_(pa.int64(), pa.float32()),
+                ),
+                weighted=True,
+            ),
+            param(
+                "map_wo_weighted",
+                inputs=pa.array(
+                    [{1: 1.0}, {2: 1.5, 3: 2.0}, {4: 2.5}],
+                    type=pa.map_(pa.int64(), pa.float32()),
+                ),
+                weighted=False,
+            ),
+        ],
+        name_func=test_util.parameterized_name_func,
+    )
+    def test_fg_encoded_without_use_weight(self, name, inputs, weighted):
+        # use_weight defaults to false, weight is parsed off the value and dropped
+        id_feat_cfg = feature_pb2.FeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="cate",
+                hash_bucket_size=10,
+                embedding_dim=16,
+                expression="item:cate",
+                weighted=weighted,
+            )
+        )
+        id_feat = id_feature_lib.IdFeature(id_feat_cfg)
+        self.assertFalse(id_feat.use_weight)
+
+        parsed_feat = id_feat.parse({"cate": inputs})
+        np.testing.assert_allclose(parsed_feat.values, np.array([1, 2, 3, 4]))
+        np.testing.assert_allclose(parsed_feat.lengths, np.array([1, 2, 1]))
+        self.assertIsNone(parsed_feat.weights)
 
     def test_fg_encoded_id_feature_with_mask(self):
         id_feat_cfg = feature_pb2.FeatureConfig(
@@ -231,6 +277,7 @@ class IdFeatureTest(unittest.TestCase):
                 embedding_dim=16,
                 expression="item:cate",
                 weighted=True,
+                use_weight=True,
             )
         )
         id_feat = id_feature_lib.IdFeature(id_feat_cfg, fg_mode=FgMode.FG_NORMAL)
@@ -249,6 +296,29 @@ class IdFeatureTest(unittest.TestCase):
         np.testing.assert_allclose(parsed_values, np.array([123, 1391, 12, 123]))
         np.testing.assert_allclose(parsed_feat.lengths, np.array([1, 1, 0, 2, 0]))
         self.assertTrue(np.allclose(parsed_weights, np.array([0.5, 0.3, 0.9, 0.21])))
+
+    def test_id_feature_with_weighted_without_use_weight(self):
+        id_feat_cfg = feature_pb2.FeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="cate",
+                num_buckets=100000,
+                embedding_dim=16,
+                expression="item:cate",
+                weighted=True,
+            )
+        )
+        id_feat = id_feature_lib.IdFeature(id_feat_cfg, fg_mode=FgMode.FG_NORMAL)
+        self.assertFalse(id_feat.use_weight)
+
+        parsed_feat = id_feat.parse(
+            {"cate": pa.array(["123:0.5", "1391:0.3", None, "12:0.9\035123:0.21", ""])}
+        )
+        parsed_values = np.concatenate(
+            [parsed_feat.values[:2], np.sort(parsed_feat.values[2:])]
+        )
+        np.testing.assert_allclose(parsed_values, np.array([123, 1391, 12, 123]))
+        np.testing.assert_allclose(parsed_feat.lengths, np.array([1, 1, 0, 2, 0]))
+        self.assertIsNone(parsed_feat.weights)
 
     @parameterized.expand(
         [

--- a/tzrec/modules/embedding.py
+++ b/tzrec/modules/embedding.py
@@ -598,8 +598,23 @@ def _add_embedding_bag_config(
         for feature_name in emb_bag_config.feature_names:
             if feature_name not in existed_emb_bag_config.feature_names:
                 existed_emb_bag_config.feature_names.append(feature_name)
+        # a shared table is weighted when any of its features needs weight
+        # pyre-ignore [16]
+        existed_emb_bag_config.is_weighted |= emb_bag_config.is_weighted
     else:
         emb_bag_configs[emb_bag_config.name] = emb_bag_config
+
+
+def _is_weighted(emb_bag_configs: Dict[str, EmbeddingBagConfig]) -> bool:
+    """Any table of the embedding bag collection is looked up with weight or not.
+
+    Args:
+        emb_bag_configs(Dict[str, EmbeddingBagConfig]): a dict contains emb_bag_configs
+
+    Returns:
+        whether the EmbeddingBagCollection should be built as weighted.
+    """
+    return any(x.is_weighted for x in emb_bag_configs.values())
 
 
 def _add_embedding_config(
@@ -854,11 +869,17 @@ class EmbeddingGroupImpl(nn.Module):
             self._group_feature_output_dims[group_name] = feature_output_dims
         self._all_group_str = "__".join(self._group_to_feature_names.keys())
 
-        self.ebc = EmbeddingBagCollection(list(emb_bag_configs.values()), device=device)
+        self.ebc = EmbeddingBagCollection(
+            list(emb_bag_configs.values()),
+            is_weighted=_is_weighted(emb_bag_configs),
+            device=device,
+        )
         if self.has_mc_sparse:
             self.mc_ebc = ManagedCollisionEmbeddingBagCollection(
                 EmbeddingBagCollection(
-                    list(mc_emb_bag_configs.values()), device=device
+                    list(mc_emb_bag_configs.values()),
+                    is_weighted=_is_weighted(mc_emb_bag_configs),
+                    device=device,
                 ),
                 ManagedCollisionCollection(
                     mc_modules, list(mc_emb_bag_configs.values())
@@ -873,12 +894,16 @@ class EmbeddingGroupImpl(nn.Module):
 
         if need_input_tile_emb:
             self.ebc_user = EmbeddingBagCollection(
-                list(emb_bag_configs_user.values()), device=device
+                list(emb_bag_configs_user.values()),
+                is_weighted=_is_weighted(emb_bag_configs_user),
+                device=device,
             )
             if self.has_mc_sparse_user:
                 self.mc_ebc_user = ManagedCollisionEmbeddingBagCollection(
                     EmbeddingBagCollection(
-                        list(mc_emb_bag_configs_user.values()), device=device
+                        list(mc_emb_bag_configs_user.values()),
+                        is_weighted=_is_weighted(mc_emb_bag_configs_user),
+                        device=device,
                     ),
                     ManagedCollisionCollection(
                         mc_modules_user, list(mc_emb_bag_configs_user.values())

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -19,6 +19,7 @@ import torch
 from parameterized import param, parameterized
 from torch import nn
 from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
+from torchrec.modules.embedding_configs import PoolingType
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, Batch
 from tzrec.features.feature import create_features
@@ -254,6 +255,239 @@ class EmbeddingGroupTest(unittest.TestCase):
 
         self.assertEqual(result["wide"].size(), (2, 8))
         self.assertEqual(result["deep"].size(), (2, 25))
+
+    @parameterized.expand(
+        [
+            param("use_weight", use_weight=True),
+            param("wo_use_weight", use_weight=False),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_embedding_group_impl_weighted(self, name, use_weight) -> None:
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a",
+                    embedding_dim=16,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=use_weight,
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["cat_a"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        self.assertEqual(embedding_group.ebc.is_weighted(), use_weight)
+
+        values = torch.tensor([1, 2, 3])
+        weights = torch.tensor([0.5, 2.0, 1.0])
+        sparse_feature = KeyedJaggedTensor.from_lengths_sync(
+            keys=["cat_a"],
+            values=values,
+            lengths=torch.tensor([2, 1]),
+            weights=weights,
+        )
+        result = embedding_group(sparse_feature, None, EMPTY_KJT)
+
+        emb = next(iter(embedding_group.ebc.embedding_bags.values())).weight
+        if use_weight:
+            expected = torch.stack(
+                [
+                    emb[1] * weights[0] + emb[2] * weights[1],
+                    emb[3] * weights[2],
+                ]
+            )
+        else:
+            expected = torch.stack([emb[1] + emb[2], emb[3]])
+        torch.testing.assert_close(result["deep"], expected)
+
+    def test_embedding_group_impl_weighted_with_mean_pooling(self) -> None:
+        # mean pooling of a weighted group is done by sum pooling over the
+        # per-sample weights that DataParser normalizes to sum to one per bag.
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a",
+                    embedding_dim=16,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_b",
+                    embedding_dim=8,
+                    num_buckets=1000,
+                    pooling="mean",
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        self.assertTrue(embedding_group.ebc.is_weighted())
+        for emb_bag_config in embedding_group.ebc.embedding_bag_configs():
+            self.assertEqual(emb_bag_config.pooling, PoolingType.SUM)
+
+        # weights as DataParser normalizes them: cat_a raw [1, 3], cat_b plain mean
+        sparse_feature = KeyedJaggedTensor.from_lengths_sync(
+            keys=["cat_a", "cat_b"],
+            values=torch.tensor([1, 2, 3, 4]),
+            lengths=torch.tensor([2, 2]),
+            weights=torch.tensor([0.25, 0.75, 0.5, 0.5]),
+        )
+        result = embedding_group(sparse_feature, None, EMPTY_KJT)
+
+        emb_a = embedding_group.ebc.embedding_bags["cat_a_emb"].weight
+        emb_b = embedding_group.ebc.embedding_bags["cat_b_emb"].weight
+        expected = torch.cat(
+            [
+                (0.25 * emb_a[1] + 0.75 * emb_a[2]).unsqueeze(0),
+                (0.5 * emb_b[3] + 0.5 * emb_b[4]).unsqueeze(0),
+            ],
+            dim=1,
+        )
+        torch.testing.assert_close(result["deep"], expected)
+
+    @parameterized.expand(
+        [
+            param("sum_neighbor", neighbor_pooling="sum", expected_ebc_weighted=False),
+            param("mean_neighbor", neighbor_pooling="mean", expected_ebc_weighted=True),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_embedding_group_impl_weighted_per_collection(
+        self, name, neighbor_pooling, expected_ebc_weighted
+    ) -> None:
+        # is_weighted is per EmbeddingBagCollection: the weighted feature lives in
+        # the zch collection, so the plain one only needs weights when it holds a
+        # mean pooled table, whose mean is carried by the normalized weights.
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a",
+                    embedding_dim=16,
+                    zch=feature_pb2.ZeroCollisionHash(
+                        zch_size=100, lfu=feature_pb2.LFU_EvictionPolicy()
+                    ),
+                    weighted=True,
+                    use_weight=True,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_b",
+                    embedding_dim=8,
+                    num_buckets=1000,
+                    pooling=neighbor_pooling,
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        self.assertEqual(embedding_group.ebc.is_weighted(), expected_ebc_weighted)
+        self.assertTrue(embedding_group.mc_ebc._embedding_bag_collection.is_weighted())
+
+    @parameterized.expand(
+        [
+            param("weighted_first", weighted_first=True),
+            param("weighted_second", weighted_first=False),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_embedding_group_impl_weighted_shared_table(self, name, weighted_first):
+        # a shared table is weighted when any of its features needs weight,
+        # whichever of them is merged into the config dict first.
+        weighted = feature_pb2.FeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="cat_a",
+                embedding_dim=8,
+                num_buckets=100,
+                embedding_name="shared_emb",
+                weighted=True,
+                use_weight=True,
+            )
+        )
+        plain = feature_pb2.FeatureConfig(
+            id_feature=feature_pb2.IdFeature(
+                feature_name="cat_b",
+                embedding_dim=8,
+                num_buckets=100,
+                embedding_name="shared_emb",
+            )
+        )
+        feature_cfgs = [weighted, plain] if weighted_first else [plain, weighted]
+        names = ["cat_a", "cat_b"] if weighted_first else ["cat_b", "cat_a"]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=names,
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        self.assertTrue(embedding_group.ebc.is_weighted())
+
+    def test_embedding_group_impl_weighted_with_dynamicemb(self) -> None:
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a",
+                    embedding_dim=16,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_b",
+                    embedding_dim=8,
+                    dynamicemb=feature_pb2.DynamicEmbedding(max_capacity=1024),
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["cat_a", "cat_b"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        with self.assertRaises(ValueError):
+            EmbeddingGroupImpl(features, feature_groups, device=torch.device("cpu"))
 
     @parameterized.expand(
         [

--- a/tzrec/modules/embedding_test.py
+++ b/tzrec/modules/embedding_test.py
@@ -459,6 +459,104 @@ class EmbeddingGroupTest(unittest.TestCase):
         )
         self.assertTrue(embedding_group.ebc.is_weighted())
 
+    def test_embedding_group_impl_weighted_input_tile_emb(self) -> None:
+        # under INPUT_TILE=3 the user side gets its own collections, so the
+        # weighted flag has to be resolved per collection there as well.
+        os.environ["INPUT_TILE"] = "3"
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="u_w",
+                    expression="user:u_w",
+                    embedding_dim=16,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="u_z",
+                    expression="user:u_z",
+                    embedding_dim=8,
+                    zch=feature_pb2.ZeroCollisionHash(
+                        zch_size=100, lfu=feature_pb2.LFU_EvictionPolicy()
+                    ),
+                    pooling="mean",
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="i_s",
+                    expression="item:i_s",
+                    embedding_dim=8,
+                    num_buckets=100,
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["u_w", "u_z", "i_s"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        # u_w carries its own weight, u_z is mean pooled in a weighted data group
+        # so its mean rides on the normalized weights
+        self.assertTrue(embedding_group.ebc_user.is_weighted())
+        mc_ebc_user = embedding_group.mc_ebc_user._embedding_bag_collection
+        self.assertTrue(mc_ebc_user.is_weighted())
+        for emb_bag_config in mc_ebc_user.embedding_bag_configs():
+            self.assertEqual(emb_bag_config.pooling, PoolingType.SUM)
+        # the item side holds only an unweighted sum table
+        self.assertFalse(embedding_group.ebc.is_weighted())
+
+    def test_embedding_group_impl_weighted_stub_feature(self) -> None:
+        # DataParser skips stub features when collecting weight keys, so a stub
+        # must not mark its data group weighted either, otherwise the group's
+        # mean tables would be rewritten to sum against a kjt with no weights.
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="stub_w",
+                    expression="user:stub_w",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    weighted=True,
+                    use_weight=True,
+                    stub_type=True,
+                )
+            ),
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_m",
+                    expression="item:cat_m",
+                    embedding_dim=8,
+                    num_buckets=100,
+                    pooling="mean",
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+        feature_groups = [
+            model_pb2.FeatureGroupConfig(
+                group_name="deep",
+                feature_names=["cat_m"],
+                group_type=model_pb2.FeatureGroupType.DEEP,
+            ),
+        ]
+        embedding_group = EmbeddingGroupImpl(
+            features, feature_groups, device=torch.device("cpu")
+        )
+        self.assertFalse(embedding_group.ebc.is_weighted())
+        self.assertEqual(
+            embedding_group.ebc.embedding_bag_configs()[0].pooling, PoolingType.MEAN
+        )
+
     def test_embedding_group_impl_weighted_with_dynamicemb(self) -> None:
         feature_cfgs = [
             feature_pb2.FeatureConfig(

--- a/tzrec/protos/feature.proto
+++ b/tzrec/protos/feature.proto
@@ -171,6 +171,8 @@ message IdFeature {
     optional bool stub_type = 34 [default = false];
     // embedding data type
     optional string data_type = 35 [default = 'FP32'];
+    // use weight in embedding pooling or not, only take effect when weighted = true
+    optional bool use_weight = 36 [default = false];
 
     // embedding param constraints
     optional ParameterConstraints embedding_constraints = 50;

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"


### PR DESCRIPTION
## Motivation

`IdFeature.weighted` tells fg that the input carries `id:weight` pairs (a `k1:v1\x1dk2:v2` string or a `map<*,float>` column). Some models only need the ids from such an input and do not want the weight to take part in the embedding pooling, but there was no way to say so: the weight was always parsed, written into the data group's `KeyedJaggedTensor` and shipped through `input_dist`.

While adding that knob it turned out that training and serving did not agree on those weights. `EmbeddingBagCollection` was constructed with the default `is_weighted=False`, and training and export treat that flag differently:

- the sharded training lookup reads `features.weights_or_none()` unconditionally (`torchrec/distributed/batched_embedding_kernel.py`, `BaseBatchedEmbeddingBag.forward`), so DMP training **did** apply the weights;
- both export modules gate them on the flag and therefore **dropped** them — the quantized `QuantEmbeddingBagCollection` (`torchrec/quant/embedding_modules.py:554`) that `QUANT_EMB=1` produces, and the eager `EmbeddingBagCollection` (`torchrec/modules/embedding_modules.py:253`) that `QUANT_EMB=0` produces.

Measured on a table whose row `i` is `[i, i, i, i]`, values `[1, 2]`, weights `[10, 100]` (unweighted sum = 3, weighted sum = 210):

| path | kernel | `is_weighted=False` | `is_weighted=True` |
|---|---|---|---|
| training (DMP, 1 GPU) | `SplitTableBatchedEmbeddingBagsCodegen` | 210 | 210 |
| export, `QUANT_EMB=1` | `IntNBitTableBatchedEmbeddingBagsCodegen` | 3 | 210 |
| export, `QUANT_EMB=0` | `nn.EmbeddingBag` | 3 | 210 |

## Changes

- New `IdFeature.use_weight`, **default `false`**. `weighted` keeps its meaning, "the input format carries weights, fg has to split them off the value"; `use_weight` decides whether the model consumes them. By default the weight is parsed off and dropped, so no `<feat>.weights` tensor is produced and the group's KJT stays unweighted.
- When `use_weight` is on, the `EmbeddingBagCollection` holding the feature is created with `is_weighted=True`, so the exported model pools the same way training does. `is_weighted` is a property of a whole collection, so each collection — `ebc`, `mc_ebc` and their input-tile variants — is weighted only when one of its own tables is looked up with per-sample weights. `emb_bag_config` stamps that on the table as `is_weighted` (next to the existing `trainable` and `use_dynamicemb` stamps), true when the feature's own weight is used or when it is a mean pooled table whose mean is carried by the normalized weights; `_add_embedding_bag_config` ORs it when a table is shared.
- **Mean pooling is carried by the weights.** `DataParser` normalizes the per-sample weights of a mean pooled feature to sum to one per bag, and `BaseFeature.emb_bag_config` declares its table with sum pooling. Pooling is then a plain weighted sum in every kernel. `is_weighted` is collection-level, so the unweighted features of the group are normalized the same way — their all-ones weights become `1/L` — and their tables are converted too. Since that is a data-group-level fact rather than a per-feature one, `create_features` marks every feature whose data group contains a `use_weight` feature (`in_weighted_group`), which is safe there because data groups are only ever assigned in that function.
- Raw weights stay in the parsed tensor dict; normalization happens in `to_batch`. So serving passes the weights it always did, and `dump_parsed_inputs` still round-trips to the original `id:weight` input.
- `dynamicemb` features cannot share a data group with a weighted feature — see below — and `emb_bag_config` raises a config error for that.
- Parsing a map input in `FG_NONE` mode used to extract the weight regardless of the `weighted` flag, leaving an unused weight tensor in the parsed inputs. The map branch is now gated on `weighted` like the string branch.

### Why normalize rather than fix the divisor

A weighted mean has no single definition in this stack, measured on the same input:

| path | who pools | weighted mean |
|---|---|---|
| training | torchrec RW callback | `Σ(wᵢ·eᵢ) / Σwᵢ` = 1.909 |
| export, `QUANT_EMB=1` | fbgemm nbit TBE | `Σ(wᵢ·eᵢ) / L` = 105 |
| export, `QUANT_EMB=0` | `nn.EmbeddingBag` | `NotImplementedError` |

Every fbgemm kernel normalizes by the bag length and ignores the weights in the divisor — nbit inference (`embedding_forward_quantized_split_nbit_kernel_template.cu`, and `RefImplementations.cc`'s `1.f / len`) and the training kernel (`embedding_forward_split_kernel_template.cu`'s `inv_L = 1.0 / L`) alike. Training escapes that only because `pooling_type_to_pooling_mode` forces the TBE to `SUM` under RW/TWRW sharding ("Mean pooling is not supported in TBE for TWRW/RW sharding") and torchrec normalizes afterwards in `_create_mean_pooling_divisor`, which switches the divisor to `Σw`.

Since `Σ(wᵢ·eᵢ)/Σwᵢ ≡ Σ(w'ᵢ·eᵢ)` with `w'ᵢ = wᵢ/Σw`, normalizing the weights removes the divisor from the problem entirely. Sum pooling has nothing to disagree about, and it is shard-additive, so the result is the same in eager, quantized and sharded lookups without relying on either divisor convention.

### Behavior change

None for a config that does not set `use_weight: true` — the default keeps today's serving numerics and stops shipping a weight tensor the exported model never used. Opting in makes training and serving agree on `Σ(w·e)/Σw`.

Note that the previous behaviour was already inconsistent: training applied the weights, serving did not. There is no default that preserves both. `false` preserves serving; a config that was relying on the weights being applied **in training** needs `use_weight: true`.

### dynamicemb

dynamicemb does not support per-sample weights for pooling, and it repurposes the KJT weights channel to carry LFU frequency counters (`dynamicemb/shard/embedding.py` sets `features._weights = frequency_counters.float()`, and `dynamicemb/input_dist.py::_determine_output_weights` preserves them on that assumption). `BatchedDynamicEmbeddingBag` has no `forward` override, so torchrec hands it `per_sample_weights=features.weights_or_none()`; `BatchedDynamicEmbeddingTablesV2.forward` passes that straight to `prefetch(frequency_counters=...)` in training and to `dynamicemb_eval_forward`'s `frequency_counters` parameter in eval, where it is cast with `.long()`. The pooling itself takes no weight term. A weighted id feature sharing a data group with a dynamicemb table would therefore get unweighted pooling *and* corrupted admission statistics — weights below 1.0 truncate to 0. This PR turns that into an explicit error.

### Out of scope

Weighted **sequence** id features remain unsupported. `SequenceSparseData` has no weights field, and on the fg side a sequence sub-feature is routed to `SequenceIdFeature`, which never reads `weighted`, has no weights slot in its output and rejects map inputs outright.

## Test Plan

- `use_weight: false` parsing for the string, list and map encodings in both `FG_NONE` and `FG_NORMAL`, and the map-input-without-`weighted` case (`tzrec/features/id_feature_test.py`, `tzrec/features/feature_test.py`).
- `DataParser` producing no `.weights` tensor and an unweighted KJT for all three fg modes; and, for a weighted group, KJT weights of `w/Σw` for the weighted mean feature, `1/L` for a plain mean feature and untouched ones for a sum feature (`tzrec/datasets/data_parser_test.py`).
- `EmbeddingGroupImpl` output compared against a hand computed weighted sum with and without `use_weight`; tables of a weighted group declared `SUM`, with the forward compared against `Σ(w·e)/Σw`; and the dynamicemb error (`tzrec/modules/embedding_test.py`).
- `python -m tzrec.features.id_feature_test`, `tzrec.features.feature_test`, `tzrec.datasets.data_parser_test`, `tzrec.modules.embedding_test` all pass. Full `python tzrec/tests/run.py` ran green (1650 tests; the only 6 failures were HSTU tests missing their gitignored KuaiRand fixtures in a fresh worktree, and all 6 pass once the fixtures are linked in).
- Both measurement tables above were taken directly with a deterministic embedding table, on `torchrec` 1.7.0 / `torch` 2.12.1+cu129, quantizing through `torchrec.inference.modules.quantize_embeddings` with the EBC nested in a parent module as it is in a real model.
- `pre-commit run -a` and `pyrefly check` clean.

### Note on integration coverage

No existing test config sets `use_weight: true`, so the weighted path is covered by unit tests only. I tried opting `multi_tower_din_zch_fg_mock.config` in, which would have exercised it through training, `QUANT_EMB=0` / `QUANT_EMB=1` export and INPUT_TILE. It made `test_multi_tower_din_zch_with_fg_train_eval_export` flaky: 1 failure in 3 runs, 2 of 8192 elements outside the `atol=1e-5` CPU-vs-GPU comparison, against 0 failures in 3 runs without it. The quantized lookup itself is bit-identical across CPU and CUDA with and without weights, so this is downstream float32 rounding at a different operating point rather than a defect — but rather than loosen a shared tolerance I left the configs untouched. Happy to add a dedicated config for weighted end-to-end coverage if you would like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRzbYSnTHNYc1he7gkGrZB
