### PR TITLE
[chore] bump feature-store-py to 2.2.10 and use oss-accelerate

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -3,7 +3,7 @@ anytree
 common_io @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/common_io-0.4.1%2Btunnel-py2.py3-none-any.whl
 confluent-kafka
 fbgemm-gpu==1.7.0
-feature_store_py @ https://feature-store-py.oss-cn-beijing.aliyuncs.com/package/feature_store_py-2.2.8-py3-none-any.whl
+feature_store_py @ https://feature-store-py.oss-accelerate.aliyuncs.com/package/feature_store_py-2.2.10-py3-none-any.whl
 fsspec
 graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
 graphlearn @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/graphlearn/graphlearn-1.3.9-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"

--- a/tzrec/utils/feature_store_delta_uploader.py
+++ b/tzrec/utils/feature_store_delta_uploader.py
@@ -757,11 +757,11 @@ class FeatureStoreDeltaUploader:
                 raise RuntimeError(
                     "DynamicEmbedding FeatureView embedding type mismatch: "
                     f"existing view {self._settings.feature_view_name!r} reports "
-                    "no embedding_field_type (a legacy float view, or "
-                    "feature_store_py older than 2.2.8), but the current delta "
-                    f"dump requires {self._embedding_field_type!r}; keep "
-                    "delta_embedding_dump_config.quant_type as NONE, or "
-                    "recreate the feature view with feature_store_py >= 2.2.8"
+                    "no embedding_field_type (a legacy float view, or a "
+                    "feature_store_py without typed-embedding support), but the "
+                    f"current delta dump requires {self._embedding_field_type!r}; "
+                    "keep delta_embedding_dump_config.quant_type as NONE, or "
+                    "recreate the feature view with feature_store_py >= 2.2.10"
                 )
         elif actual_field_type != self._embedding_field_type:
             raise RuntimeError(
@@ -858,7 +858,7 @@ class FeatureStoreDeltaUploader:
                 raise RuntimeError(
                     "failed to create configured DynamicEmbedding FeatureView: "
                     "the installed feature_store_py does not accept "
-                    "embedding_field_type; upgrade to feature_store_py >= 2.2.8 "
+                    "embedding_field_type; upgrade to feature_store_py >= 2.2.10 "
                     "as pinned in requirements/runtime.txt"
                 ) from exc
             except Exception as exc:

--- a/tzrec/utils/feature_store_delta_uploader_test.py
+++ b/tzrec/utils/feature_store_delta_uploader_test.py
@@ -625,7 +625,7 @@ class FeatureStoreDeltaUploaderTest(unittest.TestCase):
         )
         uploader = self._uploader(client_factory=factory)
 
-        with self.assertRaisesRegex(RuntimeError, "feature_store_py.*2.2.8") as ctx:
+        with self.assertRaisesRegex(RuntimeError, "feature_store_py.*2.2.10") as ctx:
             uploader.start()
 
         self.assertIsInstance(ctx.exception.__cause__, TypeError)


### PR DESCRIPTION
Bumps the pinned `feature_store_py` wheel from 2.2.8 to 2.2.10 and moves it from `feature-store-py.oss-cn-beijing` to `feature-store-py.oss-accelerate`.

The version bump is what makes the accelerate move complete rather than cosmetic. 2.2.8's metadata pulled three of its own dependencies from region-specific endpoints, so pinning the accelerate URL of a 2.2.8 wheel would still have left the install closure hitting `oss-cn-beijing` and `oss-cn-zhangjiakou`:

| dependency | 2.2.8 | 2.2.10 |
| --- | --- | --- |
| `alibabacloud-paiautoml20220828` | `http://pai-automl.oss-cn-zhangjiakou…` | `https://feature-store-py.oss-accelerate…` |
| `feature_engineering` | `https://feature-store-py.oss-cn-beijing…` | `https://feature-store-py.oss-accelerate…` |
| `paiautoml` | `http://pai-automl.oss-cn-zhangjiakou…` | `https://feature-store-py.oss-accelerate…` |

Two of the three also move from plain HTTP to HTTPS. After this change no URL dependency anywhere under `requirements/` resolves to a non-accelerate aliyun endpoint.

### Why 2.2.10 and not 2.2.9

2.2.9 was the first release to carry the accelerate dependency URLs, but it also reverted the typed-embedding support that `[feat] support quantization in delta embedding dump (#629)` relies on: `create_dynamic_embedding_feature_view()` lost its `embedding_field_type` kwarg, `write_features_arrow()` went back to hard-casting to `list<float32>`, and the view handle stopped exposing `embedding_field_type`. Since `FeatureStoreDeltaUploader` passes that kwarg unconditionally, 2.2.9 would have broken every DynamicEmbedding view creation, float dumps included. 2.2.10 restores it — its package code is byte-identical to 2.2.8 apart from `version.py`.

Because 2.2.9 exists in the wild without the kwarg, the uploader's `">= 2.2.8"` remediation hints are no longer a correct lower bound for typed-embedding support, so they now name 2.2.10.

## Test Plan

- Verified the resolution end to end with `pip install --dry-run --ignore-installed --report` against the new pin: all 63 packages resolve, and every aliyun URL in the closure is `oss-accelerate`.
- Confirmed each of the three transitive accelerate URLs returns HTTP 200.
- Diffed the 2.2.8 / 2.2.9 / 2.2.10 wheel contents to establish the revert-and-restore above, and checked the `create_dynamic_embedding_feature_view` signature in each via AST rather than trusting the changelog.
- `python -m unittest tzrec.utils.feature_store_delta_uploader_test tzrec.tools.feature_store.check_feature_store_delta_test` — 57 tests, OK. Note these cannot catch an SDK signature regression on their own: the test double at `feature_store_delta_uploader_test.py:205` accepts `**kwargs`, which is why the wheel-level check above was done directly.
- `pre-commit run --files …` and `pyrefly check tzrec/utils/feature_store_delta_uploader.py` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgmVKPZGRn9zXmhJogMXN6