### PR TITLE
[feat] bump pyfg to 1.0.6 and split the odps operator lib

### DIFF
--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -234,7 +234,7 @@ pipeline.global-job-parameters: |
 - 训练时不会在Dataset中执行FG，输入数据为Fg编码后的数据，数据列名与**特征名**(`feature_name`)同名，Dataset会自动分析所有特征的特征名来读取数据
   - 以上文LookupFeature为例，**特征名**为`lookup_feat`，Dataset会从输入表中直接读取编码后的`lookup_feat`列直接进行模型训练和推理
 - 该模式训练速度最佳，但需提前对数据提前进行FG编码，目前仅提供MaxCompute方式，步骤如下：
-  - 在DLC/DSW/Local环境中生成fg json配置，上传至DataWorks的资源中，如果fg_output_dir中有vocab_file等其他文件，也需要上传至资源中
+  - 在DLC/DSW/Local环境中生成fg json配置，上传至DataWorks的资源中，如果fg_output_dir中有vocab_file、自定义算子so等其他文件，也需要上传至资源中（`pyfg/lib/`开头的官方算子so由MaxCompute FG自行提供，不会输出到fg_output_dir中）
     ```shell
     cat <<EOF>> odps_conf
     access_id=${ACCESS_ID}
@@ -258,11 +258,11 @@ pipeline.global-job-parameters: |
     - --ODPS_CONFIG_FILE_PATH: 该环境变量指向的是odpscmd的配置文件
   - 在[DataWorks](https://workbench.data.aliyun.com/)的独享资源组中安装pyfg，「资源组列表」- 在一个调度资源组的「操作」栏 点「运维助手」-「创建命令」（选手动输入）-「运行命令」
     ```shell
-    /home/tops/bin/pip3 install http://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg104-1.0.4-cp37-cp37m-linux_x86_64.whl --index-url=https://mirrors.aliyun.com/pypi/simple/ --trusted-host=mirrors.cloud.aliyuncs.com
+    /home/tops/bin/pip3 install http://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg106-1.0.6-cp37-cp37m-linux_x86_64.whl --index-url=https://mirrors.aliyun.com/pypi/simple/ --trusted-host=mirrors.cloud.aliyuncs.com
     ```
   - 在DataWorks中建立`PyODPS 3`节点运行FG，节点调度参数中配置好bizdate参数
     ```
-    from pyfg104 import offline_pyfg
+    from pyfg106 import offline_pyfg
     offline_pyfg.run(
       o,
       input_table="YOU_PROJECT.TABLE_NAME",

--- a/docs/source/feature/feature.md
+++ b/docs/source/feature/feature.md
@@ -64,6 +64,7 @@ feature_configs {
         embedding_dim: 32
         vocab_dict: [{key:"a" value:2}, {key:"b" value:3}, {key:"c" value:2}]
     }
+}
 feature_configs {
     id_feature {
         feature_name: "cate"
@@ -702,7 +703,9 @@ feature_configs {
 
 - operator_name: 特征算子注册的名字，建议与实现的类名保持一致
 
-- operator_lib_file: 指定特征算子动态库文件的路径，必须以.so结尾。如果是`pyfg/lib/`开头的路径，则为pyfg官方自定义so
+- operator_lib_file: 指定特征算子动态库文件的路径，必须以.so结尾，需使用`_GLIBCXX_USE_CXX11_ABI=1`编译。如果是`pyfg/lib/`开头的路径，则为pyfg官方自定义so
+
+- operator_lib_cxx11abi0_file: 可选，指定使用`_GLIBCXX_USE_CXX11_ABI=0`编译的特征算子动态库文件的路径，仅在生成MaxCompute FG的fg json（`tzrec.tools.create_fg_json`）时使用，会作为MaxCompute资源上传，生成的fg json中的参数名仍为`operator_lib_file`。使用自定义算子跑MaxCompute FG时必须配置该参数；`pyfg/lib/`开头的官方算子so由MaxCompute FG自行提供并上传，无需配置该参数
 
 - expression: 特征FG所依赖组合字段的来源
 
@@ -767,18 +770,6 @@ feature_configs {
             }
         }
         features {
-            custom_feature {
-                feature_name: "seq_expr"
-                operator_name: "SeqExpr"
-                operator_lib_file: "pyfg/lib/libseq_expr.so"
-                expression: ["user:ulng", "user:ulat", "item:ilng", "item:ilat"]
-                operator_params {
-                    key: "formula"
-                    string_value: "spherical_distance"
-                }
-            }
-        }
-        features {
             lookup_feature {
                 feature_name: "user_cate_cnt"
                 map: "user:kv_cate_cnt"
@@ -805,6 +796,29 @@ feature_configs {
                 num_buckets: 10
                 combiner: "sum"
                 value_map: [{key:"click" value:1.0}, {key:"buy" value:2.0}]
+            }
+        }
+        features {
+            expr_feature {
+                feature_name: "user_item_dist"
+                variables: ["user:ulng", "user:ulat", "item:ilng", "item:ilat"]
+                expression: "sphere_dist(ulng, ulat, ilng, ilat)"
+            }
+        }
+        features {
+            custom_feature {
+                feature_name: "seq_expr"
+                operator_name: "SeqExpr"
+                operator_lib_file: "pyfg/lib/libseq_expr.so"
+                expression: ["user:ulng", "user:ulat", "item:ilng", "item:ilat"]
+                operator_params {
+                    fields {
+                        key: "formula"
+                        value {
+                            string_value: "spherical_distance"
+                        }
+                    }
+                }
             }
         }
     }
@@ -858,6 +872,25 @@ feature_configs {
     }
 }
 feature_configs {
+    sequence_combine_feature {
+        feature_name: "event_list"
+        expression: "user:event"
+        embedding_dim: 16
+        num_buckets: 10
+        combiner: "sum"
+        value_map: [{key:"click" value:1.0}, {key:"buy" value:2.0}]
+        sequence_length: 50
+        sequence_delim: ";"
+    }
+}
+feature_configs {
+    sequence_expr_feature {
+        feature_name: "seq_expr_2"
+        variables: ["user:ulng", "user:ulat", "item:ilng", "item:ilat"]
+        expression: "sphere_dist(ulng, ulat, ilng, ilat)"
+    }
+}
+feature_configs {
     sequence_custom_feature {
         feature_name: "seq_expr_1"
         operator_name: "SeqExpr"
@@ -871,34 +904,6 @@ feature_configs {
                 }
             }
         }
-    }
-}
-feature_configs {
-    sequence_custom_feature {
-        feature_name: "seq_expr_2"
-        operator_name: "SeqExpr"
-        operator_lib_file: "pyfg/lib/libseq_expr.so"
-        expression: ["user:ulng", "user:ulat", "item:ilng", "item:ilat"]
-        operator_params {
-            fields {
-                key: "formula"
-                value {
-                    string_value: "spherical_distance"
-                }
-            }
-        }
-    }
-}
-feature_configs {
-    sequence_combine_feature {
-        feature_name: "event_list"
-        expression: "user:event"
-        embedding_dim: 16
-        num_buckets: 10
-        combiner: "sum"
-        value_map: [{key:"click" value:1.0}, {key:"buy" value:2.0}]
-        sequence_length: 50
-        sequence_delim: ";"
     }
 }
 ```

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -13,9 +13,9 @@ numpy
 packaging
 pandas
 psutil
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
-pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.5-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.6-cp312-cp312-linux_x86_64.whl ; python_version=="3.12"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.6-cp311-cp311-linux_x86_64.whl ; python_version=="3.11"
+pyfg @ https://tzrec.oss-accelerate.aliyuncs.com/third_party/pyfg-1.0.6-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
 pyodps>=0.13.1
 safetensors
 scikit-learn

--- a/tzrec/features/custom_feature.py
+++ b/tzrec/features/custom_feature.py
@@ -24,6 +24,8 @@ from tzrec.features.feature import (
 )
 from tzrec.protos.feature_pb2 import FeatureConfig
 
+_OFFICIAL_OP_LIB_PREFIX = "pyfg/lib/"
+
 
 class CustomFeature(BaseFeature):
     """CustomFeature class.
@@ -173,11 +175,11 @@ class CustomFeature(BaseFeature):
         """Operator library file path."""
         if self.config.HasField("operator_lib_file"):
             operator_lib_file = self.config.operator_lib_file
-            if operator_lib_file.startswith("pyfg/lib/"):
+            if operator_lib_file.startswith(_OFFICIAL_OP_LIB_PREFIX):
                 # official lib
                 pyfg_dir, _ = os.path.split(pyfg.__file__)
                 operator_lib_file = os.path.join(
-                    pyfg_dir, operator_lib_file.replace("pyfg/lib/", "lib/")
+                    pyfg_dir, operator_lib_file.replace(_OFFICIAL_OP_LIB_PREFIX, "lib/")
                 )
             if self.config.HasField("asset_dir"):
                 operator_lib_file = os.path.join(
@@ -191,4 +193,35 @@ class CustomFeature(BaseFeature):
         """Asset file paths."""
         assets = {}
         assets["operator_lib_file"] = self.operator_lib_file
+        if len(self.vocab_file) > 0:
+            assets["vocab_file"] = self.vocab_file
         return assets
+
+    def odps_assets(self) -> Dict[str, str]:
+        """Asset file paths for odps fg."""
+        assets = {}
+        if not self.config.operator_lib_file.startswith(_OFFICIAL_OP_LIB_PREFIX):
+            # odps fg ships and uploads official operator libs itself, an user
+            # compiled one should be built with _GLIBCXX_USE_CXX11_ABI=0.
+            if not self.config.HasField("operator_lib_cxx11abi0_file"):
+                raise ValueError(
+                    f"feature[{self.name}] should set operator_lib_cxx11abi0_file "
+                    "to the operator lib compiled with _GLIBCXX_USE_CXX11_ABI=0, "
+                    "which is required by odps fg."
+                )
+            operator_lib_file = self.config.operator_lib_cxx11abi0_file
+            if self.config.HasField("asset_dir"):
+                operator_lib_file = os.path.join(
+                    self.config.asset_dir, operator_lib_file
+                )
+            assets["operator_lib_file"] = operator_lib_file
+        if len(self.vocab_file) > 0:
+            assets["vocab_file"] = self.vocab_file
+        return assets
+
+    def odps_fg_json(self) -> List[Dict[str, Any]]:
+        """Get fg json config for odps fg."""
+        fg_cfgs = self.fg_json()
+        if self.config.operator_lib_file.startswith(_OFFICIAL_OP_LIB_PREFIX):
+            fg_cfgs[0]["operator_lib_file"] = self.config.operator_lib_file
+        return fg_cfgs

--- a/tzrec/features/custom_feature_test.py
+++ b/tzrec/features/custom_feature_test.py
@@ -50,6 +50,49 @@ class CustomFeatureTest(unittest.TestCase):
         self.assertEqual(parsed_feat.name, "custom_feat")
         np.testing.assert_allclose(parsed_feat.values, np.array([[3]]))
 
+    def _create_custom_feat(self, operator_lib_file, operator_lib_cxx11abi0_file=None):
+        custom_feat_cfg = feature_pb2.CustomFeature(
+            feature_name="custom_feat",
+            operator_name="MyOp",
+            operator_lib_file=operator_lib_file,
+            expression=["user:query", "item:title"],
+        )
+        if operator_lib_cxx11abi0_file:
+            custom_feat_cfg.operator_lib_cxx11abi0_file = operator_lib_cxx11abi0_file
+        return custom_feature_lib.CustomFeature(
+            feature_pb2.FeatureConfig(custom_feature=custom_feat_cfg),
+            fg_mode=FgMode.FG_NORMAL,
+        )
+
+    def test_odps_official_operator_lib(self):
+        custom_feat = self._create_custom_feat("pyfg/lib/libedit_distance.so")
+        # odps fg ships and uploads the official operator lib itself.
+        self.assertEqual(custom_feat.odps_assets(), {})
+        self.assertEqual(
+            custom_feat.odps_fg_json()[0]["operator_lib_file"],
+            "pyfg/lib/libedit_distance.so",
+        )
+        self.assertTrue(
+            custom_feat.fg_json()[0]["operator_lib_file"].endswith(
+                "pyfg/lib/libedit_distance.so"
+            )
+        )
+
+    def test_odps_custom_operator_lib(self):
+        custom_feat = self._create_custom_feat("libcustom.so", "libcustom_abi0.so")
+        self.assertEqual(
+            custom_feat.odps_assets(), {"operator_lib_file": "libcustom_abi0.so"}
+        )
+        self.assertEqual(custom_feat.assets(), {"operator_lib_file": "libcustom.so"})
+        self.assertEqual(
+            custom_feat.odps_fg_json()[0]["operator_lib_file"], "libcustom.so"
+        )
+
+    def test_odps_custom_operator_lib_without_cxx11abi0_file(self):
+        custom_feat = self._create_custom_feat("libcustom.so")
+        with self.assertRaisesRegex(ValueError, "operator_lib_cxx11abi0_file"):
+            custom_feat.odps_assets()
+
     def test_edit_distance_with_boundary(self):
         custom_feat_cfg = feature_pb2.FeatureConfig(
             custom_feature=feature_pb2.CustomFeature(

--- a/tzrec/features/feature.py
+++ b/tzrec/features/feature.py
@@ -1154,6 +1154,14 @@ class BaseFeature(object, metaclass=_meta_cls):
         """Asset file paths."""
         return {}
 
+    def odps_assets(self) -> Dict[str, str]:
+        """Asset file paths for odps fg."""
+        return self.assets()
+
+    def odps_fg_json(self) -> List[Dict[str, Any]]:
+        """Get fg json config for odps fg."""
+        return self.fg_json()
+
     def __del__(self) -> None:
         # pyre-ignore [16]
         if self._fg_op and isinstance(self._fg_op, pyfg.FgArrowHandler):
@@ -1283,14 +1291,16 @@ def _copy_assets(
     feature: BaseFeature,
     asset_dir: Optional[str] = None,
     use_relative_asset_dir: bool = False,
+    for_odps: bool = False,
 ) -> BaseFeature:
-    if asset_dir and len(feature.assets()) > 0:
+    assets = feature.odps_assets() if for_odps else feature.assets()
+    if asset_dir and len(assets) > 0:
         # deepcopy feature config
         feature_config = type(feature.feature_config)()
         feature_config.CopyFrom(feature.feature_config)
         feature = copy(feature)
         feature.feature_config = feature_config
-        for k, v in feature.assets().items():
+        for k, v in assets.items():
             with open(v, "rb") as f:
                 fhash = hashlib.md5(f.read()).hexdigest()
             fprefix, fext = os.path.splitext(os.path.basename(v))
@@ -1355,8 +1365,20 @@ def create_fg_json(
     features: List[BaseFeature],
     asset_dir: Optional[str] = None,
     remove_bucketizer: bool = False,
+    for_odps: bool = False,
 ) -> Dict[str, Any]:
-    """Create feature generate config for features."""
+    """Create feature generate config for features.
+
+    Args:
+        features (list): list of features.
+        asset_dir (str, optional): directory to copy asset files into.
+        remove_bucketizer (bool): remove bucketizer params in fg json or not.
+        for_odps (bool): create fg json for odps fg or not. official pyfg operator
+            libs are supplied by odps fg, we neither copy nor rename them.
+
+    Return:
+        fg json config.
+    """
     referenced_names = set()
     if remove_bucketizer:
         for feature in features:
@@ -1370,7 +1392,12 @@ def create_fg_json(
     results = []
     seq_to_idx = {}
     for feature in features:
-        feature = _copy_assets(feature, asset_dir, use_relative_asset_dir=True)
+        feature = _copy_assets(
+            feature, asset_dir, use_relative_asset_dir=True, for_odps=for_odps
+        )
+        fg_json = feature.odps_fg_json() if for_odps else feature.fg_json()
+        if remove_bucketizer:
+            fg_json = _remove_bucketizer(feature, fg_json, referenced_names)
         if feature.is_grouped_sequence:
             # pyre-ignore [16]
             if feature.sequence_name not in seq_to_idx:
@@ -1384,15 +1411,9 @@ def create_fg_json(
                     }
                 )
                 seq_to_idx[feature.sequence_name] = len(results) - 1
-            fg_json = feature.fg_json()
-            if remove_bucketizer:
-                fg_json = _remove_bucketizer(feature, fg_json, referenced_names)
             idx = seq_to_idx[feature.sequence_name]
             results[idx]["features"].extend(fg_json)
         else:
-            fg_json = feature.fg_json()
-            if remove_bucketizer:
-                fg_json = _remove_bucketizer(feature, fg_json, referenced_names)
             results.extend(fg_json)
     return {"features": results}
 

--- a/tzrec/features/feature_test.py
+++ b/tzrec/features/feature_test.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 
+import hashlib
 import os
 import shutil
 import unittest
@@ -30,6 +31,9 @@ from tzrec.features import feature as feature_lib
 from tzrec.features.feature import FgMode
 from tzrec.protos import feature_pb2
 from tzrec.utils.test_util import make_test_dir, parameterized_name_func
+
+_VOCAB_CONTENT = "a 1\nb 2\n"
+_VOCAB_ASSET_NAME = f"custom_vocab_{hashlib.md5(_VOCAB_CONTENT.encode()).hexdigest()}"
 
 
 class FeatureTest(unittest.TestCase):
@@ -907,6 +911,85 @@ class FeatureTest(unittest.TestCase):
                 by_name["click_seq__lookup_c"].sequence_input_names,
                 ["click_seq__cat_key"],
             )
+
+    def _create_custom_features(self, with_cxx11abi0_file=True):
+        """An official operator lib and a user compiled one written into test_dir."""
+        self.test_dir = test_dir = make_test_dir()
+        lib_file = os.path.join(test_dir, "libcustom.so")
+        with open(lib_file, "wb") as f:
+            f.write(b"custom operator lib")
+        abi0_lib_file = os.path.join(test_dir, "libcustom_abi0.so")
+        with open(abi0_lib_file, "wb") as f:
+            f.write(b"custom operator lib cxx11abi0")
+        vocab_file = os.path.join(test_dir, "custom_vocab")
+        with open(vocab_file, "w") as f:
+            f.write(_VOCAB_CONTENT)
+        custom_cfg = feature_pb2.CustomFeature(
+            feature_name="custom_b",
+            operator_name="MyOp",
+            operator_lib_file=lib_file,
+            expression=["user:query"],
+        )
+        if with_cxx11abi0_file:
+            custom_cfg.operator_lib_cxx11abi0_file = abi0_lib_file
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                custom_feature=feature_pb2.CustomFeature(
+                    feature_name="custom_a",
+                    operator_name="EditDistance",
+                    operator_lib_file="pyfg/lib/libedit_distance.so",
+                    expression=["user:query", "item:title"],
+                    vocab_file=vocab_file,
+                    default_bucketize_value=1,
+                )
+            ),
+            feature_pb2.FeatureConfig(custom_feature=custom_cfg),
+        ]
+        features = feature_lib.create_features(feature_cfgs, fg_mode=FgMode.FG_DAG)
+        asset_dir = os.path.join(test_dir, "fg_output")
+        os.makedirs(asset_dir)
+        return features, asset_dir
+
+    def test_create_fg_json_with_custom_feature(self):
+        features, asset_dir = self._create_custom_features()
+        fg_feats = feature_lib.create_fg_json(features, asset_dir=asset_dir)["features"]
+        official_lib = fg_feats[0]["operator_lib_file"]
+        custom_lib = fg_feats[1]["operator_lib_file"]
+        self.assertTrue(official_lib.startswith("libedit_distance_"))
+        self.assertEqual(
+            custom_lib,
+            f"libcustom_{hashlib.md5(b'custom operator lib').hexdigest()}.so",
+        )
+        self.assertEqual(fg_feats[0]["vocab_file"], _VOCAB_ASSET_NAME)
+        self.assertEqual(
+            sorted(os.listdir(asset_dir)),
+            sorted([official_lib, custom_lib, _VOCAB_ASSET_NAME]),
+        )
+
+    def test_create_fg_json_for_odps(self):
+        features, asset_dir = self._create_custom_features()
+        fg_feats = feature_lib.create_fg_json(
+            features, asset_dir=asset_dir, for_odps=True
+        )["features"]
+        # odps fg ships the official operator lib itself, keep its path as is.
+        self.assertEqual(
+            fg_feats[0]["operator_lib_file"], "pyfg/lib/libedit_distance.so"
+        )
+        abi0_hash = hashlib.md5(b"custom operator lib cxx11abi0").hexdigest()
+        self.assertEqual(
+            fg_feats[1]["operator_lib_file"], f"libcustom_abi0_{abi0_hash}.so"
+        )
+        # the vocab file of an official operator feature is still uploaded.
+        self.assertEqual(fg_feats[0]["vocab_file"], _VOCAB_ASSET_NAME)
+        self.assertEqual(
+            sorted(os.listdir(asset_dir)),
+            sorted([f"libcustom_abi0_{abi0_hash}.so", _VOCAB_ASSET_NAME]),
+        )
+
+    def test_create_fg_json_for_odps_without_cxx11abi0_file(self):
+        features, asset_dir = self._create_custom_features(with_cxx11abi0_file=False)
+        with self.assertRaisesRegex(ValueError, "operator_lib_cxx11abi0_file"):
+            feature_lib.create_fg_json(features, asset_dir=asset_dir, for_odps=True)
 
 
 class ProjectGroupedSequenceFeatureToScalarTest(unittest.TestCase):

--- a/tzrec/protos/feature.proto
+++ b/tzrec/protos/feature.proto
@@ -878,6 +878,9 @@ message CustomFeature {
     optional string asset_dir = 23;
     // dynamic embedding
     optional DynamicEmbedding dynamicemb = 24;
+    // custom operator lib file compiled with _GLIBCXX_USE_CXX11_ABI=0,
+    // only used when create fg json for odps fg.
+    optional string operator_lib_cxx11abi0_file = 25;
 
     // default value when fg_mode = FG_NONE,
     // when use pai-fg, you do not need to set the param.

--- a/tzrec/tools/create_fg_json.py
+++ b/tzrec/tools/create_fg_json.py
@@ -96,7 +96,10 @@ if __name__ == "__main__":
 
     tmp_dir = tempfile.mkdtemp(prefix="tzrec_")
     fg_json = create_fg_json(
-        features, asset_dir=tmp_dir, remove_bucketizer=args.remove_bucketizer
+        features,
+        asset_dir=tmp_dir,
+        remove_bucketizer=args.remove_bucketizer,
+        for_odps=True,
     )
 
     if args.reserves is not None:
@@ -144,6 +147,4 @@ if __name__ == "__main__":
                 logger.info(f"uploading resource [{fname}].")
                 resource = o.create_resource(fname, "file", file_obj=open(fpath, "rb"))
 
-    if tmp_dir is None:
-        if os.path.exists(tmp_dir):
-            shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmp_dir)

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.19"
+__version__ = "1.3.20"


### PR DESCRIPTION
## Why

pyfg 1.0.6 rebuilds the official operator libs bundled in the wheel (`<site-packages>/pyfg/lib/`) with `_GLIBCXX_USE_CXX11_ABI=1`, so that torch/torchrec can load them for custom ops. ODPS FG still runs an `_GLIBCXX_USE_CXX11_ABI=0` toolchain, so a single `.so` can no longer serve both sides.

## What

When creating fg json for ODPS (`tzrec.tools.create_fg_json`):

- an `operator_lib_file` starting with `pyfg/lib/` is an **official** pyfg operator. We no longer copy it into the output dir nor upload it as an ODPS resource, and the generated fg json keeps the literal `pyfg/lib/xxx.so` path. ODPS FG recognizes that prefix, resolves the lib from its own install and uploads it itself (`create_fg_handler.download_resources` / `run_on_odps` / `fg_udtf_template`).
- a user compiled operator lib is taken from the new `CustomFeature.operator_lib_cxx11abi0_file`, which points at the `_GLIBCXX_USE_CXX11_ABI=0` build. The generated fg json still carries it under the `operator_lib_file` key, because ODPS FG treats every `*_file` key as a resource name to look up. Creating fg json for ODPS errors out when a user compiled lib does not declare it, rather than silently uploading an ABI=1 lib that would fail at MaxCompute runtime.

`for_odps` is threaded through `create_fg_json` / `_copy_assets` and dispatches to `odps_assets()` / `odps_fg_json()`, which default to `assets()` / `fg_json()` on `BaseFeature` and are only overridden by `CustomFeature`. Local FG and export are unchanged: they keep resolving `pyfg/lib/` to the installed pyfg directory and keep bundling the `.so` next to the exported model.

The DataWorks wheel in the docs moves from `pyfg104-1.0.4` to `pyfg106-1.0.6` accordingly, and tzrec is bumped to 1.3.20.

### Alternatives considered

Adding a `for_odps` keyword directly to `assets()` / `fg_json()` would have touched ~10 overrides across the feature hierarchy for a fork that concerns one feature class. Handling it entirely inside `create_fg_json` would have put `custom_feature` specific knowledge (the `pyfg/lib/` prefix, the ABI=0 field) into generic code. The two `odps_*` hooks keep the feature specific logic in the feature class and leave every other feature type untouched.

## Nearby bugs fixed

**`CustomFeature.assets()` dropped `vocab_file`.** `CustomFeature` supports `vocab_file` and emits it from `fg_json()`, but — unlike `IdFeature` / `LookupFeature` / `MatchFeature` — never listed it as an asset, so it was neither copied next to `fg.json` nor uploaded as an ODPS resource. Reproduced on a custom feature carrying a vocab file, before the fix:

| | emitted `vocab_file` | files copied |
| --- | --- | --- |
| export | `vocab.txt` (bare name, file absent) | only the `.so` |
| odps | `/tmp/tmpuxckx4gg/vocab.txt` | *(none)* |

The ODPS path leaked the submitting machine's absolute path because `odps_assets()` returned `{}` for an official lib, so `_copy_assets` returned early without deep copying the config and `asset_dir` was never cleared. ODPS FG's `download_resources` would then look for a resource literally named `/tmp/.../vocab.txt`. `vocab_file` is now included in both `assets()` and `odps_assets()`, in the official lib branch too, and both paths emit the hashed name with the file present.

**`create_fg_json` leaked its temp dir.** The cleanup at the end of main was guarded by `if tmp_dir is None:`, which never holds since `tmp_dir` comes from `tempfile.mkdtemp()`, so every run left a `tzrec_*` dir behind. At that point the json has already been copied to `--fg_output_dir` and the resources uploaded, so the guard is dropped for a plain `shutil.rmtree(tmp_dir)`.

### Docs

The sequence feature examples were also reordered so the custom operator example comes last in both sections, and each section gained an expr based equivalent using the `sphere_dist` builtin, which computes the same value as the `SeqExpr` `spherical_distance` operator. Two config examples that did not parse were fixed along the way: a missing closing brace in the IdFeature `vocab_dict` example, and `operator_params` written without the `fields`/`value` wrappers required by `google.protobuf.Struct` in the grouped `custom_feature` example.

## Test Plan

- `nm -D` on pyfg 1.0.6's `libedit_distance.so` / `libseq_expr.so`: undefined `__cxx11` symbols present and zero undefined old-ABI (`Ss`/`Sb`) symbols, confirming the ABI=1 rebuild (1.0.5 had no undefined `__cxx11` symbols at all).
- New unit tests in `tzrec/features/custom_feature_test.py` (`odps_assets()` / `odps_fg_json()` for an official lib, a user lib with the ABI=0 file, and a user lib without it) and in `tzrec/features/feature_test.py` (`create_fg_json` with and without `for_odps`, asserting which files land in the asset dir). The three `create_fg_json` cases now put a vocab file on the official operator feature, so they also guard the `vocab_file` fix.
- End to end: `python -m tzrec.tools.create_fg_json --pipeline_config_path tzrec/tests/configs/multi_tower_din_fg_mock.config --fg_output_dir fg_output` leaves no `.so` in `fg_output`, writes `"operator_lib_file": "pyfg/lib/libedit_distance.so"` alongside the hashed vocab file, and leaves no new `/tmp/tzrec_*` dir behind.
- Both new doc examples were run under pyfg 1.0.6 and produce the same value as the `SeqExpr` operator they sit next to; every `feature_configs { ... }` block in `feature.md` was checked to parse as `EasyRecConfig`.
- `pre-commit run -a` and `pyrefly check` are clean.
- Full suite (`python tzrec/tests/run.py`, 1655 tests) on the final commit in a conda env cloned from the project env with the pyfg 1.0.6 wheel installed: `FAILED (failures=1, skipped=16)`. The single failure is `utils.init_util_test.InitUtilTest.test_trunc_normal_inplace_statistics`, which is unrelated to this PR and pre-existing — `tzrec/utils/init_util*` is untouched here. It draws 1e6 unseeded samples and asserts `|std - 0.0125| <= 1e-4`; locally it fails about 1 run in 40. The cause is that `_inplace_trunc_normal_` clamps to `[a, b]` rather than resampling, so one draw landing on the bound `-2.0` sits 200 sigma from `mean=0.5` at `std=0.0125` and on its own contributes 6.25 to the sum of squared deviations, against the 5.61 excess needed to break the assertion. Worth fixing separately.
- An earlier run of the same suite reported 6 additional failures, all HSTU integration tests failing with `RuntimeError: No parquet files exist in data/test/kuairand-mot-1k-train-c4096-s100.parquet` — the KuaiRand fixtures that `scripts/ci/ci_data.sh` downloads had not been fetched in that checkout. After running that script the same 6 tests pass (`Ran 6 tests ... OK`). None of the five HSTU configs use `custom_feature` or `vocab_file`, and `for_odps` defaults to `False`, so those paths are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gm3S8ZezmBFcpQYugZvEQ
