### PR TITLE
[bugfix] reset train metric when restoring a fine-tune checkpoint

### DIFF
--- a/docs/source/models/evaluation_metrics.md
+++ b/docs/source/models/evaluation_metrics.md
@@ -60,6 +60,8 @@ model_config {
   - decay_rate: 默认为0.9，历史指标的衰减率。
   - decay_step: 默认为100，历史指标每训练多少step会进行一次衰减，配置需要可以被train_config.log_step_count_steps整除。
 
+训练时指标会保存在checkpoint中，使用--continue_train续跑时会一并恢复。从fine_tune_checkpoint恢复时则会重置，避免继承上一个模型的指标，重置后在第一个decay_step之前打印为0。
+
 ______________________________________________________________________
 
 ## 指标详情

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -348,6 +348,7 @@ def _train_and_evaluate(
     eval_result_filename: str = TRAIN_EVAL_RESULT_FILENAME,
     check_all_workers_data_status: bool = False,
     ignore_restore_optimizer: bool = False,
+    restore_from_model_dir: bool = False,
     dataloader_state: Optional[Dict[str, Any]] = None,
     delta_embedding_dumper: Optional[DeltaEmbeddingDumper] = None,
     pipeline_config_path: Optional[str] = None,
@@ -526,6 +527,10 @@ def _train_and_evaluate(
                         train_config.fine_tune_ckpt_param_map,
                         dense_ema=dense_ema,
                     )
+                if not restore_from_model_dir:
+                    # a fine-tune checkpoint's train metric describes the source
+                    # model, not the model this job is training.
+                    _model.reset_train_metric()
                 if delta_embedding_dumper is not None:
                     delta_embedding_dumper.clear()
 
@@ -933,6 +938,7 @@ def train_and_evaluate(
         ckpt_path=ckpt_path,
         check_all_workers_data_status=check_all_workers_data_status,
         ignore_restore_optimizer=ignore_restore_optimizer,
+        restore_from_model_dir=restore_from_model_dir,
         dataloader_state=dataloader_state,
         delta_embedding_dumper=delta_embedding_dumper,
         pipeline_config_path=os.path.join(pipeline_config.model_dir, "pipeline.config"),

--- a/tzrec/metrics/train_metric_wrapper.py
+++ b/tzrec/metrics/train_metric_wrapper.py
@@ -26,6 +26,9 @@ class TrainMetricWrapper(nn.Module):
         decay_step (int): decay step for decay,
     """
 
+    _value: Tensor
+    _step_cnt: Tensor
+
     def __init__(
         self, metric_module: Metric, decay_rate: float = 0.5, decay_step: int = 100
     ) -> None:
@@ -33,11 +36,8 @@ class TrainMetricWrapper(nn.Module):
         self._decay_rate = decay_rate
         self._decay_step = decay_step
         self._metric_module = metric_module
-        self._value = nn.Parameter(torch.tensor(0.0), requires_grad=False)
-        self._step_total_value = nn.Parameter(torch.tensor(0.0), requires_grad=False)
-        self._step_cnt = nn.Parameter(
-            torch.tensor(0, dtype=torch.int), requires_grad=False
-        )
+        self.register_buffer("_value", torch.tensor(0.0))
+        self.register_buffer("_step_cnt", torch.tensor(0, dtype=torch.int))
 
     def update(self, preds: Tensor, target: Tensor) -> None:
         """Update metric module."""
@@ -60,3 +60,9 @@ class TrainMetricWrapper(nn.Module):
     def compute(self) -> Tensor:
         """Get metric value."""
         return self._value.data
+
+    def reset(self) -> None:
+        """Reset metric state."""
+        self._metric_module.reset()
+        self._value.zero_()
+        self._step_cnt.zero_()

--- a/tzrec/metrics/train_metric_wrapper_test.py
+++ b/tzrec/metrics/train_metric_wrapper_test.py
@@ -48,6 +48,33 @@ class TrainMetricWrapperTest(unittest.TestCase):
         value = metric_wrapper.compute()
         torch.testing.assert_close(value, torch.tensor(0.11))
 
+    def test_state_restore_and_reset(self):
+        metric_wrapper = TrainMetricWrapper(
+            torchmetrics.MeanAbsoluteError(), decay_rate=0.9, decay_step=1
+        )
+        preds = torch.tensor([0.1, 0.2])
+        metric_wrapper.update(preds, torch.tensor([0.6, 0.7]))
+        torch.testing.assert_close(metric_wrapper.compute(), torch.tensor(0.5))
+        self.assertEqual(
+            list(metric_wrapper.state_dict().keys()), ["_value", "_step_cnt"]
+        )
+        self.assertEqual(list(metric_wrapper.parameters()), [])
+
+        # continue train restores the running metric of the interrupted job.
+        restored = TrainMetricWrapper(
+            torchmetrics.MeanAbsoluteError(), decay_rate=0.9, decay_step=1
+        )
+        restored.load_state_dict(metric_wrapper.state_dict())
+        torch.testing.assert_close(restored.compute(), torch.tensor(0.5))
+        restored.update(preds, torch.tensor([0.2, 0.3]))
+        torch.testing.assert_close(restored.compute(), torch.tensor(0.46))
+
+        # fine tune resets it, so the next value is not blended with the old one.
+        restored.reset()
+        torch.testing.assert_close(restored.compute(), torch.tensor(0.0))
+        restored.update(preds, torch.tensor([0.2, 0.3]))
+        torch.testing.assert_close(restored.compute(), torch.tensor(0.1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -156,6 +156,11 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
             metric_results[metric_name] = metric.compute()
         return metric_results
 
+    def reset_train_metric(self) -> None:
+        """Reset train metric state."""
+        for metric in self._train_metric_modules.values():
+            metric.reset()
+
     def on_train_end(self) -> None:
         """Hook fired once after the train_eval loop exits.
 

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -639,7 +639,7 @@ def _rewrite_dense_serving_graph(
     dense_graph_config["sequence__ec"] = []
     for node in list(graph.nodes):
         if node.op == "call_function" and node.target == fx_mark_keyed_tensor:
-            name = node.args[0]
+            name = cast(str, node.args[0])
             if node.kwargs.get("is_dense", False):
                 continue
             node_kt = node.args[1]

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
Fixes #646.

## Problem

Starting a job with `--fine_tune_checkpoint` inherits the source checkpoint's training metrics, so the metrics logged by the new job describe the old model.

`TrainMetricWrapper`'s running state is part of `model.state_dict()`, so `save_model` writes it into every checkpoint and `restore_model` loads it straight back — it restores the whole model state dict, and `PartialLoadPlanner` can only rename or skip-missing keys. The restore call site in `main.py` is shared by fine-tune and continue-train, and nothing reset the state afterwards.

Impact depends on the metric:

- `auc` (the `DecayAUC` branch) reports the stale value until the inherited `_step_cnt` reaches the next multiple of `decay_step`.
- Every other train metric is worse: the inherited non-zero `_value` disables the `torch.all(self._value == 0.0)` first-value fast path, so each new value is EMA-blended into the stale one. With the default `decay_rate: 0.9` / `decay_step: 100`, an old value of 0.9 against a true value of 0.0 still reads 0.81 after 100 steps and 0.31 after 1000.

The inner torchmetrics module was never affected — `add_state` defaults to `persistent=False`, so `DecayAUC.confmat` was already correctly absent from the checkpoint. Only the wrapper's own state leaked.

## Fix

Add `TrainMetricWrapper.reset()` and `BaseModel.reset_train_metric()`, and call it after the restore when the checkpoint did not come from this job's own `model_dir`. Continue-train keeps restoring the metric, since there the accumulated value belongs to the job being resumed; only fine-tune resets.

The state also moves from `nn.Parameter(requires_grad=False)` to a registered buffer. It stays persistent, so the `state_dict` keys and continue-train restores are unchanged, but it no longer appears in `named_parameters()`, where it was being collected into `dense_params` and handed to the dense optimizer, `DenseEMA`, and the `parameter` tensorboard summary. The unused `_step_total_value` is dropped; `PartialLoadPlanner` iterates the destination state dict, so that now-extra key in pre-existing checkpoints is ignored.

## Test Plan

Verified on real 2-rank `torchrun` runs, logging the train metric immediately after the restore (instrumentation removed before commit):

- fine-tune (`--fine_tune_checkpoint`): `restore_from_model_dir=False`, `train_metric={'auc': 0.0}` — reset.
- continue-train (`--continue_train`, one epoch left): `restore_from_model_dir=True`, `train_metric={'auc': 0.5003}` — restored from the checkpoint, not reset.
- the checkpoint written by those runs contains `model._train_metric_modules.auc.{_value,_step_cnt}` and no longer `_step_total_value`, so continue-train still has state to restore.

Also:

- New `TrainMetricWrapperTest.test_state_restore_and_reset` covers both halves: `load_state_dict` restores the running value and the next update blends into it (0.46), then `reset()` clears it so the next update takes the raw value (0.1). It also pins the persisted keys and asserts the wrapper exposes no parameters.
- `RankIntegrationTest.test_multi_tower_din_fg_encoded_finetune`, `tzrec.models.rank_model_test` and `tzrec.models.match_model_test` pass.
- `pre-commit run --files ...` clean; `pyrefly check` reports 0 errors across the repo. The buffers carry class-level `Tensor` annotations, matching the existing pattern in `tzrec/modules/sequence.py`.

Bumps `tzrec/version.py` to 1.4.1, following the convention that each merged PR takes the next patch version.

Master is merged in as of c8082ae0. The runs above were done in a torch 2.13.0 / torchrec 1.8.0 environment matching that base.

Also folds in a one-line typing fix that is unrelated to the metric bug: `_rewrite_dense_serving_graph` reads an fx marker name with `node.args[0]`, typed as the broad fx `Argument` union, then uses it to index `sparse_attrs: Dict[str, Any]`, which `pyrefly` rejects as `bad-index` (2 errors on master, arrived with #654). `fx_mark_keyed_tensor` declares the argument as `name: str`, so the read is cast to `str` — the same narrowing already applied to `new_node.kwargs["keys"]` a few lines below. `typing.cast` is a runtime no-op, so there is no behavior change, and only the one branch that feeds a `Dict[str, Any]` lookup is touched. `pyrefly check` goes from 2 errors to 0, and `tzrec.utils.export_util_test` passes (30 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANBJGHmETnZXK4CwqD8Uhr
