### PR TITLE
[feat] checkpoint success marker and list-column labels

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -378,3 +378,16 @@ pip install -U "pyodps>=0.13.1"
 | `STORAGE_API_SDK_RETRY_TIMES`      | 5              | SDK内部重试次数（仅对连接错误生效）                                     |
 | `STORAGE_API_SESSION_POLL_TIMEOUT` | 600（秒）      | 等待read session离开INIT状态的超时时间                                  |
 | `STORAGE_API_COMPRESSION`          | `LZ4_FRAME`    | 传输压缩方式，可选`ZSTD`/`UNCOMPRESSED`                                 |
+
+**Q18: 如何复现实验**
+
+**解决方法：** TorchEasyRec通过环境变量控制随机性，不需要在模型或启动脚本里自己调用`torch.manual_seed`：
+
+```bash
+export PYTHONHASHSEED=0
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+export PYTHON_RANDOM_SEED=100007
+export NUMPY_MANUAL_SEED=100007
+export TORCH_MANUAL_SEED=100007          # 同时会设置所有CUDA设备的种子
+export USE_DETERMINISTIC_ALGORITHMS=1    # 已包含cudnn的确定性行为
+```

--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -320,6 +320,11 @@ pipeline.global-job-parameters: |
     label_fields: "buy"
   ```
 
+- label列的类型是数组时（例如上游表的类型为`array<bigint>`），会被解析成jagged label。
+  模型侧统一用`BaseModel.get_label`读取label，会自动取出其中的values，因此这类label
+  可以和普通label一样使用。自定义模型中读取label时也应使用`self.get_label(batch, label_name)`
+  而不是`batch.labels[label_name]`。
+
 ### sample_weight_fields
 
 - 训练样本的样本权重列名

--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -320,10 +320,8 @@ pipeline.global-job-parameters: |
     label_fields: "buy"
   ```
 
-- label列的类型是数组时（例如上游表的类型为`array<bigint>`），会被解析成jagged label。
-  模型侧统一用`BaseModel.get_label`读取label，会自动取出其中的values，因此这类label
-  可以和普通label一样使用。自定义模型中读取label时也应使用`self.get_label(batch, label_name)`
-  而不是`batch.labels[label_name]`。
+- label列的类型是数组时（例如上游表的类型为`array<bigint>`），会被解析成jagged label，
+  取其中的values后和普通label一样使用，无需额外配置
 
 ### sample_weight_fields
 

--- a/docs/source/models/user_define.md
+++ b/docs/source/models/user_define.md
@@ -142,6 +142,9 @@ python -m grpc_tools.protoc -I . -I "${TZREC_PATH}" \
 
 **模型模块必须在顶层 `import` 自己的 `*_pb2`。**
 
+读取 label 时使用 `self.get_label(batch, label_name)`，不要直接用 `batch.labels[label_name]`。
+数组类型的 label 会被解析成 jagged label，`get_label` 会自动取出其中的 values。
+
 以排序模型为例
 
 ```python

--- a/docs/source/models/user_define.md
+++ b/docs/source/models/user_define.md
@@ -142,8 +142,8 @@ python -m grpc_tools.protoc -I . -I "${TZREC_PATH}" \
 
 **模型模块必须在顶层 `import` 自己的 `*_pb2`。**
 
-读取 label 时使用 `self.get_label(batch, label_name)`，不要直接用 `batch.labels[label_name]`。
-数组类型的 label 会被解析成 jagged label，`get_label` 会自动取出其中的 values。
+读取 label 时使用 `self.get_label(batch, label_name)`，不要直接用 `batch.labels[label_name]`，
+否则数组类型的 label 会取不到。
 
 以排序模型为例
 

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -25,6 +25,22 @@ torchrun --master_addr=localhost --master_port=32555 \
 
 - ODPS_ENDPOINT: 在PAI-DLC/PAI-DSW环境，数据为MaxCompute表的情况下需设置，详见[文档](../feature/data.md)的OdpsDataset章节
 - ODPS_CONFIG_FILE_PATH: 在本地环境，数据为MaxCompute表的情况下需设置为odps_conf的路径，详见[文档](../feature/data.md)的OdpsDataset章节
+- CHECKPOINT_TAG: 给checkpoint打一个自定义标记，记录在`meta`中（见下面的checkpoint信息），便于外部调度识别是哪一次调度产出的checkpoint。默认为空，不做任何限制
+
+## Checkpoint信息与完成标记
+
+checkpoint目录下的`meta`记录该checkpoint的信息：
+
+- `step`: 步数
+- `data_ts`: 已消费数据的事件时间（秒），数据源不带timestamp时（如ParquetDataset）不写该字段
+- `tag`: `CHECKPOINT_TAG`的值，未设置时不写该字段
+
+`_SUCCESS`是最后生成的空文件，外部调度看到它即表示该checkpoint的所有文件都已写完：
+
+```bash
+test -e ${MODEL_DIR}/model.ckpt-1000/_SUCCESS && cat ${MODEL_DIR}/model.ckpt-1000/meta
+# {"step": 1000, "data_ts": 1755000000.0, "tag": "20260828"}
+```
 
 ## 训练配置
 
@@ -66,7 +82,6 @@ LR策略可以支持按epoch更新或者按step更新
 - save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
 - save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的 Unix 时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
 - save_checkpoints_timestamp_quorum: 分布式训练下各rank消费的分区不同，事件时间也不同；当至少该比例（取值(0,1\]，默认0.5）的rank已消费越过边界/时间点时才触发保存。1.0表示所有rank都越过才保存（最保守），越小越激进（最小可仅需一个rank）；默认值对单个异常/超前的timestamp具有鲁棒性
-- save_checkpoints_timestamp_quorum还决定了checkpoint中记录的数据时间水位：每次保存checkpoint时，各rank已消费数据的事件时间会按该比例对齐成一个全局值，写入checkpoint目录下的`dataloader_state.json`，key为`__data_ts_watermark__`。按步数或Epoch保存时同样会记录，数据源不带timestamp时（如ParquetDataset）不写该字段。外部调度可以据此判断一个checkpoint覆盖到了哪个时间点的数据
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -66,6 +66,7 @@ LR策略可以支持按epoch更新或者按step更新
 - save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
 - save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的 Unix 时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
 - save_checkpoints_timestamp_quorum: 分布式训练下各rank消费的分区不同，事件时间也不同；当至少该比例（取值(0,1\]，默认0.5）的rank已消费越过边界/时间点时才触发保存。1.0表示所有rank都越过才保存（最保守），越小越激进（最小可仅需一个rank）；默认值对单个异常/超前的timestamp具有鲁棒性
+- save_checkpoints_timestamp_quorum还决定了checkpoint中记录的数据时间水位：每次保存checkpoint时，各rank已消费数据的事件时间会按该比例对齐成一个全局值，写入checkpoint目录下的`dataloader_state.json`，key为`__data_ts_watermark__`。按步数或Epoch保存时同样会记录，数据源不带timestamp时（如ParquetDataset）不写该字段。外部调度可以据此判断一个checkpoint覆盖到了哪个时间点的数据
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -154,6 +154,37 @@ class DataParserTest(unittest.TestCase):
         )
         torch.testing.assert_close(batch.labels["label"], expected_label)
 
+    def test_list_label(self):
+        """A label stored as a list column is parsed into a jagged label."""
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a", embedding_dim=16, num_buckets=100
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+
+        data_parser = DataParser(features=features, labels=["label", "list_label"])
+
+        data = data_parser.parse(
+            input_data={
+                "cat_a": pa.array([1, 2, 3]),
+                "label": pa.array([0, 0, 1], pa.int32()),
+                "list_label": pa.array([[4], [5], [6]], pa.list_(pa.int32())),
+            }
+        )
+        batch = data_parser.to_batch(data)
+
+        torch.testing.assert_close(
+            batch.labels["label"], torch.tensor([0, 0, 1], dtype=torch.int64)
+        )
+        self.assertNotIn("list_label", batch.labels)
+        torch.testing.assert_close(
+            batch.jagged_labels["list_label"].values(),
+            torch.tensor([4, 5, 6], dtype=torch.int64),
+        )
+
     def test_fg_encoded_id_with_weight(self):
         feature_cfgs = [
             feature_pb2.FeatureConfig(

--- a/tzrec/models/match_model.py
+++ b/tzrec/models/match_model.py
@@ -343,7 +343,10 @@ class MatchModel(BaseModel):
         for loss_cfg in self._base_model_config.losses:
             losses.update(
                 self._loss_impl(
-                    predictions, batch, batch.labels[self._label_name], loss_cfg
+                    predictions,
+                    batch,
+                    self.get_label(batch, self._label_name),
+                    loss_cfg,
                 )
             )
         losses.update(self._loss_collection)
@@ -446,12 +449,12 @@ class MatchModel(BaseModel):
         """
         for metric_cfg in self._base_model_config.metrics:
             self._update_metric_impl(
-                predictions, batch, batch.labels[self._label_name], metric_cfg
+                predictions, batch, self.get_label(batch, self._label_name), metric_cfg
             )
         if losses is not None:
             for loss_cfg in self._base_model_config.losses:
                 self._update_loss_metric_impl(
-                    losses, batch, batch.labels[self._label_name], loss_cfg
+                    losses, batch, self.get_label(batch, self._label_name), loss_cfg
                 )
 
     def update_train_metric(
@@ -467,7 +470,7 @@ class MatchModel(BaseModel):
         """
         for metric_cfg in self._base_model_config.train_metrics:
             self._update_train_metric_impl(
-                predictions, batch, batch.labels[self._label_name], metric_cfg
+                predictions, batch, self.get_label(batch, self._label_name), metric_cfg
             )
 
 

--- a/tzrec/models/match_model_test.py
+++ b/tzrec/models/match_model_test.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List
 
 import torch
 from parameterized import parameterized
-from torchrec import KeyedTensor
+from torchrec import JaggedTensor, KeyedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, NEG_DATA_GROUP, Batch
 from tzrec.features.feature import BaseFeature
@@ -125,6 +125,63 @@ class MatchModelTest(unittest.TestCase):
                 expected_recall,
                 rtol=1e-4,
                 atol=1e-4,
+            )
+
+    @parameterized.expand(
+        [
+            [TestGraphType.NORMAL],
+            [TestGraphType.FX_TRACE],
+        ]
+    )
+    def test_match_model_with_jagged_label(self, graph_type):
+        """A label stored as a list column is used like an ordinary label."""
+        model_config = model_pb2.ModelConfig(
+            losses=[
+                loss_pb2.LossConfig(
+                    softmax_cross_entropy=loss_pb2.SoftmaxCrossEntropy()
+                )
+            ],
+            metrics=[
+                metric_pb2.MetricConfig(recall_at_k=metric_pb2.RecallAtK(top_k=2))
+            ],
+        )
+        model = _TestMatchModel(
+            model_config=model_config,
+            features=[],
+            labels=["label"],
+            sampler_type="negative_sampler",
+        )
+        model = TrainWrapper(model)
+        model = create_test_model(model, graph_type)
+
+        dense_feature = KeyedTensor.from_tensor_list(
+            keys=["int_a"], tensors=[torch.tensor([[0.2], [0.3]])]
+        )
+        dense_feature_neg = KeyedTensor.from_tensor_list(
+            keys=["int_b"], tensors=[torch.tensor([[0.2], [0.3], [0.4]])]
+        )
+        batch = Batch(
+            dense_features={
+                BASE_DATA_GROUP: dense_feature,
+                NEG_DATA_GROUP: dense_feature_neg,
+            },
+            sparse_features={},
+            jagged_labels={
+                "label": JaggedTensor(
+                    values=torch.tensor([1, 1]), lengths=torch.tensor([1, 1])
+                )
+            },
+        )
+        total_loss, (losses, predictions, batch) = model(batch)
+
+        torch.testing.assert_close(
+            total_loss, torch.tensor(0.71080), rtol=1e-4, atol=1e-4
+        )
+        if graph_type == TestGraphType.NORMAL:
+            model.model.update_metric(predictions, batch)
+            metric_result = model.model.compute_metric()
+            torch.testing.assert_close(
+                metric_result["recall@2"], torch.tensor(1.0), rtol=1e-4, atol=1e-4
             )
 
 

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -33,7 +33,10 @@ from tzrec.modules.utils import BaseModule
 from tzrec.protos.loss_pb2 import LossConfig
 from tzrec.protos.model_pb2 import FeatureGroupConfig, ModelConfig
 from tzrec.utils import config_util
+from tzrec.utils.fx_util import fx_get_label
 from tzrec.utils.load_class import get_register_class_meta
+
+torch.fx.wrap(fx_get_label)
 
 _MODEL_CLASS_MAP = {}
 _meta_cls = get_register_class_meta(_MODEL_CLASS_MAP)
@@ -88,6 +91,21 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
     def feature_groups(self) -> List[FeatureGroupConfig]:
         """Model's feature_groups (default forward to ``self._feature_groups``)."""
         return self._feature_groups
+
+    def get_label(self, batch: Batch, label_name: str) -> torch.Tensor:
+        """Get a label of the batch.
+
+        A label stored as a list column is parsed into a jagged label, take its
+        values so that fixed-length list labels can be used as ordinary labels.
+
+        Args:
+            batch (Batch): input batch data.
+            label_name (str): name of the label.
+
+        Return:
+            label (Tensor): label tensor.
+        """
+        return fx_get_label(batch.labels, batch.jagged_labels, label_name)
 
     def predict(self, batch: Batch) -> Dict[str, torch.Tensor]:
         """Predict the model.

--- a/tzrec/models/multi_task_rank.py
+++ b/tzrec/models/multi_task_rank.py
@@ -108,12 +108,13 @@ class MultiTaskRank(RankModel):
                     loss_weight = batch.sample_weights[sample_weight]
                 else:
                     loss_weight = torch.Tensor([1.0]).to(
-                        batch.labels[label_name].device
+                        self.get_label(batch, label_name).device
                     )
 
                 if task_tower_cfg.HasField("task_space_indicator_label"):
                     in_task_space = (
-                        batch.labels[task_tower_cfg.task_space_indicator_label] > 0
+                        self.get_label(batch, task_tower_cfg.task_space_indicator_label)
+                        > 0
                     ).float()
                     loss_weight = loss_weight * (
                         task_tower_cfg.in_task_space_weight * in_task_space
@@ -131,7 +132,7 @@ class MultiTaskRank(RankModel):
                     self._loss_impl(
                         predictions,
                         batch,
-                        batch.labels[label_name],
+                        self.get_label(batch, label_name),
                         loss_weight,
                         loss_cfg,
                         num_class=task_tower_cfg.num_class,
@@ -180,7 +181,7 @@ class MultiTaskRank(RankModel):
                 self._update_metric_impl(
                     predictions,
                     batch,
-                    batch.labels[label_name],
+                    self.get_label(batch, label_name),
                     metric_cfg,
                     num_class=task_tower_cfg.num_class,
                     suffix=f"_{tower_name}",
@@ -190,7 +191,7 @@ class MultiTaskRank(RankModel):
                     self._update_loss_metric_impl(
                         losses,
                         batch,
-                        batch.labels[label_name],
+                        self.get_label(batch, label_name),
                         loss_cfg,
                         suffix=f"_{tower_name}",
                     )
@@ -213,7 +214,7 @@ class MultiTaskRank(RankModel):
                 self._update_train_metric_impl(
                     predictions,
                     batch,
-                    batch.labels[label_name],
+                    self.get_label(batch, label_name),
                     metric_cfg,
                     num_class=task_tower_cfg.num_class,
                     suffix=f"_{tower_name}",

--- a/tzrec/models/rank_model.py
+++ b/tzrec/models/rank_model.py
@@ -277,7 +277,7 @@ class RankModel(BaseModel):
                 self._loss_impl(
                     predictions,
                     batch,
-                    batch.labels[self._label_name],
+                    self.get_label(batch, self._label_name),
                     loss_weight,
                     loss_cfg,
                     num_class=self._num_class,
@@ -492,14 +492,14 @@ class RankModel(BaseModel):
             self._update_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
             )
         if losses is not None:
             for loss_cfg in self._base_model_config.losses:
                 self._update_loss_metric_impl(
-                    losses, batch, batch.labels[self._label_name], loss_cfg
+                    losses, batch, self.get_label(batch, self._label_name), loss_cfg
                 )
 
     def update_train_metric(
@@ -517,7 +517,7 @@ class RankModel(BaseModel):
             self._update_train_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
             )

--- a/tzrec/models/rank_model_test.py
+++ b/tzrec/models/rank_model_test.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 
 import torch
 from parameterized import parameterized
-from torchrec import KeyedJaggedTensor, KeyedTensor
+from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, Batch
 from tzrec.features.feature import BaseFeature
@@ -145,6 +145,54 @@ class RankModelTest(unittest.TestCase):
             )
             torch.testing.assert_close(
                 metric_result["accuracy"], expected_acc, rtol=1e-4, atol=1e-4
+            )
+
+    @parameterized.expand(
+        [
+            [TestGraphType.NORMAL],
+            [TestGraphType.FX_TRACE],
+        ]
+    )
+    def test_binary_classification_model_with_jagged_label(self, graph_type):
+        """A label stored as a list column is used like an ordinary label."""
+        model_config = model_pb2.ModelConfig(
+            losses=[
+                loss_pb2.LossConfig(binary_cross_entropy=loss_pb2.BinaryCrossEntropy())
+            ],
+            metrics=[metric_pb2.MetricConfig(auc=metric_pb2.AUC())],
+        )
+        model = _TestClassficationModel(
+            model_config=model_config, features=[], labels=["label"]
+        )
+        model = TrainWrapper(model)
+        model = create_test_model(model, graph_type)
+
+        dense_feature = KeyedTensor.from_tensor_list(
+            keys=["int_a"], tensors=[torch.tensor([[0.2], [0.3]])]
+        )
+        batch = Batch(
+            dense_features={BASE_DATA_GROUP: dense_feature},
+            sparse_features={},
+            jagged_labels={
+                "label": JaggedTensor(
+                    values=torch.tensor([0, 1]), lengths=torch.tensor([1, 1])
+                )
+            },
+        )
+        total_loss, (losses, predictions, batch) = model(batch)
+
+        torch.testing.assert_close(
+            total_loss, torch.tensor(0.6762), rtol=1e-4, atol=1e-4
+        )
+        torch.testing.assert_close(
+            predictions["probs"], torch.tensor([0.5498, 0.5744]), rtol=1e-4, atol=1e-4
+        )
+
+        if graph_type == TestGraphType.NORMAL:
+            model.model.update_metric(predictions, batch)
+            metric_result = model.model.compute_metric()
+            torch.testing.assert_close(
+                metric_result["auc"], torch.tensor(1.0), rtol=1e-4, atol=1e-4
             )
 
     @parameterized.expand(

--- a/tzrec/models/rocket_launching.py
+++ b/tzrec/models/rocket_launching.py
@@ -220,7 +220,7 @@ class RocketLaunching(RankModel):
                     self._loss_impl(
                         predictions,
                         batch,
-                        batch.labels[self._label_name],
+                        self.get_label(batch, self._label_name),
                         loss_weight,
                         loss_cfg,
                         num_class=self._num_class,
@@ -231,7 +231,7 @@ class RocketLaunching(RankModel):
                 self._loss_impl(
                     predictions,
                     batch,
-                    batch.labels[self._label_name],
+                    self.get_label(batch, self._label_name),
                     loss_weight,
                     loss_cfg,
                     num_class=self._num_class,
@@ -262,7 +262,7 @@ class RocketLaunching(RankModel):
                 self._update_metric_impl(
                     predictions,
                     batch,
-                    batch.labels[self._label_name],
+                    self.get_label(batch, self._label_name),
                     metric_cfg,
                     num_class=self._num_class,
                     suffix="_booster",
@@ -270,7 +270,7 @@ class RocketLaunching(RankModel):
             self._update_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
                 suffix="_light",
@@ -281,14 +281,14 @@ class RocketLaunching(RankModel):
                     self._update_loss_metric_impl(
                         losses,
                         batch,
-                        batch.labels[self._label_name],
+                        self.get_label(batch, self._label_name),
                         loss_cfg,
                         suffix="_booster",
                     )
                 self._update_loss_metric_impl(
                     losses,
                     batch,
-                    batch.labels[self._label_name],
+                    self.get_label(batch, self._label_name),
                     loss_cfg,
                     suffix="_light",
                 )
@@ -308,7 +308,7 @@ class RocketLaunching(RankModel):
             self._update_train_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
                 suffix="_booster",
@@ -316,7 +316,7 @@ class RocketLaunching(RankModel):
             self._update_train_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
                 suffix="_light",

--- a/tzrec/tests/custom_model_integration_test.py
+++ b/tzrec/tests/custom_model_integration_test.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import glob
+import json
 import os
 import shutil
 import subprocess
@@ -200,7 +201,10 @@ class CustomModelIntegrationTest(unittest.TestCase):
         pythonpath = f".:{project_dir}"
 
         self.success = utils.test_train_eval(
-            config_path, self.test_dir, pythonpath=pythonpath
+            config_path,
+            self.test_dir,
+            pythonpath=pythonpath,
+            env_str="CHECKPOINT_TAG=ci-tag",
         )
         self.assertTrue(self.success)
 
@@ -212,11 +216,18 @@ class CustomModelIntegrationTest(unittest.TestCase):
         ckpt_dirs = glob.glob(os.path.join(self.test_dir, "train", "model.ckpt-*"))
         self.assertTrue(ckpt_dirs)
         for ckpt_dir in ckpt_dirs:
-            self.assertTrue(
-                os.path.exists(
-                    os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
-                )
+            # the marker is empty and written last, so its presence means the
+            # meta beside it is complete
+            marker_path = os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+            self.assertTrue(os.path.exists(marker_path))
+            self.assertEqual(os.path.getsize(marker_path), 0)
+            meta_path = os.path.join(ckpt_dir, checkpoint_util.CKPT_META_FILENAME)
+            with open(meta_path) as f:
+                meta = json.load(f)
+            self.assertEqual(
+                meta["step"], checkpoint_util._get_checkpoint_step(ckpt_dir)
             )
+            self.assertEqual(meta["tag"], "ci-tag")
         self.success = utils.test_eval(
             saved_config_path, self.test_dir, pythonpath=pythonpath
         )

--- a/tzrec/tests/custom_model_integration_test.py
+++ b/tzrec/tests/custom_model_integration_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ import unittest
 
 import tzrec
 from tzrec.tests import utils
+from tzrec.utils import checkpoint_util
 from tzrec.utils.test_util import make_test_dir
 
 _PROTO = """syntax = "proto2";
@@ -206,6 +208,15 @@ class CustomModelIntegrationTest(unittest.TestCase):
         # process, class_path alone has to resolve the model there
         saved_config_path = os.path.join(self.test_dir, "train/pipeline.config")
         self.assertTrue(os.path.exists(saved_config_path))
+        # every saved checkpoint is marked complete for external schedulers
+        ckpt_dirs = glob.glob(os.path.join(self.test_dir, "train", "model.ckpt-*"))
+        self.assertTrue(ckpt_dirs)
+        for ckpt_dir in ckpt_dirs:
+            self.assertTrue(
+                os.path.exists(
+                    os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+                )
+            )
         self.success = utils.test_eval(
             saved_config_path, self.test_dir, pythonpath=pythonpath
         )

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -566,12 +566,14 @@ class CheckpointManager:
         if data_ts is not None:
             # advance the watermark on every save so resume is exact
             self._last_data_ts = data_ts
-        # The marker reports what data the checkpoint covers whether or not the
-        # event-time triggers are on. Reconciling here rather than above keeps it
-        # one collective per saved checkpoint, and the save decision is identical
-        # on every rank so the gather stays in lockstep.
+        # The checkpoint records what data it covers whether or not the event-time
+        # triggers are on. With the triggers on the gather above already produced
+        # that value, and repeating it would return the same result, so gather
+        # only when they are off: at most one gather per saved checkpoint, none
+        # per step. Doing it after the save decision is safe because that
+        # decision is identical on every rank, so the gather stays in lockstep.
         report_ts = data_ts
-        if report_ts is None:
+        if report_ts is None and not self.needs_worker_timestamps():
             report_ts = self._reconcile_event_time(data_timestamp, force=True)
         self.save(step, model, optimizer, dataloader_state, dense_ema, report_ts)
         return True

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -395,6 +395,7 @@ class CheckpointManager:
         save_model(ckpt_dir, model, optimizer, dense_ema)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
+        save_success_marker(ckpt_dir)
         self._last_ckpt_dir = ckpt_dir
         self.prune()
         return ckpt_dir
@@ -1161,12 +1162,33 @@ def save_model(
 
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
+CKPT_SUCCESS_FILENAME = "_SUCCESS"
 # reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
 # no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"
 # reserved dataloader_state key: number of completed data passes; resume
 # continues the epoch budget from here. no ":" so per-source consumers skip it.
 EPOCHS_COMPLETED = "__epochs_completed__"
+
+
+def save_success_marker(checkpoint_dir: str) -> None:
+    """Mark a checkpoint as completely written.
+
+    Schedulers that poll a model directory need to tell a finished checkpoint
+    from one still being written. Write the marker only after every rank has
+    finished writing its shards.
+
+    Args:
+        checkpoint_dir: directory of the checkpoint to mark.
+    """
+    if dist.is_initialized():
+        dist.barrier()
+    if int(os.environ.get("RANK", 0)) == 0:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        marker_path = os.path.join(checkpoint_dir, CKPT_SUCCESS_FILENAME)
+        with open(marker_path, "w"):
+            pass
+        logger.info(f"Saved checkpoint success marker to {marker_path}")
 
 
 def save_dataloader_state(

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -423,9 +423,10 @@ class CheckpointManager:
         """Configure when ``maybe_save`` fires (train path only).
 
         Sets cadence config only (never the ``_last_*`` state), so a watermark
-        seeded on resume survives. When timestamp triggers are active under a
-        distributed run, also creates the dedicated CPU (gloo) group used for the
-        per-step event-time gather -- a collective, so all ranks must call this.
+        seeded on resume survives. Under a distributed run, also creates the
+        dedicated CPU (gloo) group used to gather event-times -- a collective, so
+        all ranks must call this. The group is created even when the timestamp
+        triggers are off, because a save still records the event-time watermark.
 
         Args:
             save_steps: step interval; 0 disables the step trigger.
@@ -434,7 +435,7 @@ class CheckpointManager:
             ts_targets: absolute event-time targets (Unix-epoch seconds).
             ts_quorum: fraction of workers (0, 1] past a boundary to trigger a save.
         """
-        if (ts_interval_s > 0 or len(ts_targets) > 0) and not (0.0 < ts_quorum <= 1.0):
+        if not (0.0 < ts_quorum <= 1.0):
             raise ValueError(
                 f"save_checkpoints_timestamp_quorum must be in (0, 1], got {ts_quorum}."
             )
@@ -443,7 +444,7 @@ class CheckpointManager:
         self._ts_interval = ts_interval_s
         self._ts_targets = ts_targets
         self._ts_quorum = ts_quorum
-        if self.needs_worker_timestamps() and dist.is_initialized():
+        if dist.is_initialized():
             self._ts_group = cast(
                 Optional[dist.ProcessGroup], dist.new_group(backend="gloo")
             )
@@ -452,7 +453,9 @@ class CheckpointManager:
         """Return whether the policy needs per-worker event-times gathered."""
         return self._ts_interval > 0 or len(self._ts_targets) > 0
 
-    def _reconcile_event_time(self, data_timestamp: float) -> Optional[float]:
+    def _reconcile_event_time(
+        self, data_timestamp: float, force: bool = False
+    ) -> Optional[float]:
         """Quorum-reconcile this rank's event-time across workers.
 
         Gathers over the CPU group from ``set_save_policy``. Each worker without a
@@ -462,11 +465,13 @@ class CheckpointManager:
 
         Args:
             data_timestamp: this rank's consumed event-time (seconds), -1.0 if none.
+            force: gather even when the timestamp triggers are off. Only safe once
+                the save decision is made, which is identical on every rank.
 
         Returns:
             The quorum event-time (seconds), or None.
         """
-        if not self.needs_worker_timestamps():
+        if not force and not self.needs_worker_timestamps():
             return None
         if dist.is_initialized():
             worker_ts: List[float] = [0.0] * dist.get_world_size(self._ts_group)
@@ -512,11 +517,6 @@ class CheckpointManager:
             True if a checkpoint was saved.
         """
         data_ts = self._reconcile_event_time(data_timestamp)
-        # copy so the watermark isn't leaked back into the train loop's state
-        if dataloader_state is not None:
-            dataloader_state = dict(dataloader_state)
-            if data_ts is not None:
-                dataloader_state[DATA_TS_WATERMARK] = data_ts
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
@@ -539,6 +539,21 @@ class CheckpointManager:
 
         if not want:
             return False
+
+        # A step/epoch/final save records the watermark too, so a consumer can
+        # tell what data a checkpoint covers without the timestamp triggers being
+        # on. Gathering here rather than above keeps it one collective per saved
+        # checkpoint, and the save decision is identical on every rank so the
+        # gather stays in lockstep. It cannot affect the trigger, which was
+        # already decided.
+        if data_ts is None:
+            data_ts = self._reconcile_event_time(data_timestamp, force=True)
+        # copy so the watermark isn't leaked back into the train loop's state
+        if dataloader_state is not None:
+            dataloader_state = dict(dataloader_state)
+            if data_ts is not None:
+                dataloader_state[DATA_TS_WATERMARK] = data_ts
+
         if step == self._last_ckpt_step:
             # a boundary save dedup'd against an already-saved step: refresh
             # that checkpoint's state so the cleared + bumped bookkeeping is

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -43,6 +43,7 @@ from tzrec.acc.utils import is_input_tile_emb
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.optim.ema import DenseEMA
 from tzrec.protos import export_pb2
+from tzrec.utils import env_util
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
 
@@ -389,12 +390,15 @@ class CheckpointManager:
         optimizer: Optional[optim.Optimizer] = None,
         dataloader_state: Optional[Dict[str, Any]] = None,
         dense_ema: Optional[DenseEMA] = None,
+        data_ts: Optional[float] = None,
     ) -> str:
         """Save a checkpoint at the given step, then request an async prune."""
         ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
         save_model(ckpt_dir, model, optimizer, dense_ema)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
+        save_meta(ckpt_dir, step, data_ts)
+        # last, so its presence means every file above is complete
         save_success_marker(ckpt_dir)
         self._last_ckpt_dir = ckpt_dir
         self.prune()
@@ -517,6 +521,11 @@ class CheckpointManager:
             True if a checkpoint was saved.
         """
         data_ts = self._reconcile_event_time(data_timestamp)
+        # copy so the watermark isn't leaked back into the train loop's state
+        if dataloader_state is not None:
+            dataloader_state = dict(dataloader_state)
+            if data_ts is not None:
+                dataloader_state[DATA_TS_WATERMARK] = data_ts
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
@@ -540,20 +549,6 @@ class CheckpointManager:
         if not want:
             return False
 
-        # A step/epoch/final save records the watermark too, so a consumer can
-        # tell what data a checkpoint covers without the timestamp triggers being
-        # on. Gathering here rather than above keeps it one collective per saved
-        # checkpoint, and the save decision is identical on every rank so the
-        # gather stays in lockstep. It cannot affect the trigger, which was
-        # already decided.
-        if data_ts is None:
-            data_ts = self._reconcile_event_time(data_timestamp, force=True)
-        # copy so the watermark isn't leaked back into the train loop's state
-        if dataloader_state is not None:
-            dataloader_state = dict(dataloader_state)
-            if data_ts is not None:
-                dataloader_state[DATA_TS_WATERMARK] = data_ts
-
         if step == self._last_ckpt_step:
             # a boundary save dedup'd against an already-saved step: refresh
             # that checkpoint's state so the cleared + bumped bookkeeping is
@@ -571,7 +566,14 @@ class CheckpointManager:
         if data_ts is not None:
             # advance the watermark on every save so resume is exact
             self._last_data_ts = data_ts
-        self.save(step, model, optimizer, dataloader_state, dense_ema)
+        # The marker reports what data the checkpoint covers whether or not the
+        # event-time triggers are on. Reconciling here rather than above keeps it
+        # one collective per saved checkpoint, and the save decision is identical
+        # on every rank so the gather stays in lockstep.
+        report_ts = data_ts
+        if report_ts is None:
+            report_ts = self._reconcile_event_time(data_timestamp, force=True)
+        self.save(step, model, optimizer, dataloader_state, dense_ema, report_ts)
         return True
 
     def prune(self) -> None:
@@ -986,7 +988,7 @@ def restore_model(
     if not os.path.exists(checkpoint_dir):
         raise RuntimeError(f"checkpoint_dir[{checkpoint_dir}] not exists.")
 
-    meta_path = os.path.join(checkpoint_dir, "meta")
+    meta_path = os.path.join(checkpoint_dir, CKPT_META_FILENAME)
     model_ckpt_path = os.path.join(checkpoint_dir, "model")
     optim_ckpt_path = os.path.join(checkpoint_dir, "optimizer")
     dense_ema_ckpt_path = os.path.join(checkpoint_dir, "dense_ema")
@@ -1178,6 +1180,7 @@ def save_model(
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
 CKPT_SUCCESS_FILENAME = "_SUCCESS"
+CKPT_META_FILENAME = "meta"
 # reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
 # no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"
@@ -1186,12 +1189,42 @@ DATA_TS_WATERMARK = "__data_ts_watermark__"
 EPOCHS_COMPLETED = "__epochs_completed__"
 
 
+def save_meta(
+    checkpoint_dir: str,
+    step: int,
+    data_ts: Optional[float] = None,
+) -> None:
+    """Describe a checkpoint in its meta file.
+
+    Records the step, the consumed event-time when the data source has one, and
+    the CHECKPOINT_TAG label when set, alongside whatever restore-relevant keys
+    a converted checkpoint already carries.
+
+    Args:
+        checkpoint_dir: directory of the checkpoint.
+        step: step of the checkpoint.
+        data_ts: quorum event-time (seconds) of the consumed data, if any.
+    """
+    if int(os.environ.get("RANK", 0)) == 0:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        meta: Dict[str, Any] = {"step": step}
+        if data_ts is not None:
+            meta["data_ts"] = data_ts
+        tag = env_util.checkpoint_tag()
+        if tag:
+            meta["tag"] = tag
+        with open(os.path.join(checkpoint_dir, CKPT_META_FILENAME), "w") as f:
+            json.dump(meta, f)
+
+
 def save_success_marker(checkpoint_dir: str) -> None:
     """Mark a checkpoint as completely written.
 
     Schedulers that poll a model directory need to tell a finished checkpoint
-    from one still being written. Write the marker only after every rank has
-    finished writing its shards.
+    from one still being written. The marker is empty and written last, after
+    every rank has finished its shards and after every other file in the
+    checkpoint, so its presence alone means the whole checkpoint is readable --
+    do not write anything into it, and do not move this call earlier.
 
     Args:
         checkpoint_dir: directory of the checkpoint to mark.

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 
+import json
 import multiprocessing as mp
 import os
 import shutil
@@ -724,8 +725,58 @@ class DataloaderCheckpointTest(unittest.TestCase):
         restored_state = checkpoint_util.restore_dataloader_state(self.test_dir)
         self.assertEqual(restored_state, checkpoint_state)
 
+    def _read_meta(self, ckpt_dir):
+        with open(os.path.join(ckpt_dir, checkpoint_util.CKPT_META_FILENAME)) as f:
+            return json.load(f)
+
+    def test_save_meta(self):
+        """A checkpoint records which step it is."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            checkpoint_util.save_meta(self.test_dir, 300)
+
+        self.assertEqual(self._read_meta(self.test_dir), {"step": 300})
+
+    def test_save_meta_data_ts(self):
+        """The consumed event-time is recorded when the source has one."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            checkpoint_util.save_meta(self.test_dir, 300, data_ts=1755000000.0)
+
+        self.assertEqual(
+            self._read_meta(self.test_dir), {"step": 300, "data_ts": 1755000000.0}
+        )
+
+    def test_save_meta_tag(self):
+        """CHECKPOINT_TAG labels the checkpoint for an external scheduler."""
+        with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": "20260828"}):
+            checkpoint_util.save_meta(self.test_dir, 300)
+
+        self.assertEqual(
+            self._read_meta(self.test_dir), {"step": 300, "tag": "20260828"}
+        )
+
+    def test_save_meta_non_zero_rank_skips(self):
+        """Only rank 0 writes the meta."""
+        with mock.patch.dict(os.environ, {"RANK": "1"}):
+            checkpoint_util.save_meta(self.test_dir, 300)
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.test_dir, checkpoint_util.CKPT_META_FILENAME)
+            )
+        )
+
+    def test_save_meta_keeps_restore_defaults(self):
+        """The recorded info leaves the restore-relevant keys at their defaults."""
+        with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": "t"}):
+            checkpoint_util.save_meta(self.test_dir, 300, data_ts=1.0)
+
+        meta = self._read_meta(self.test_dir)
+        self.assertTrue(meta.get("load_model", True))
+        self.assertTrue(meta.get("load_optim", True))
+        self.assertIsNone(meta.get("dynamicemb_load_table_names", None))
+
     def test_save_success_marker(self):
-        """A completed checkpoint is marked so schedulers can poll for it."""
+        """The marker is empty; its presence is the whole signal."""
         checkpoint_util.save_success_marker(self.test_dir)
 
         marker_path = os.path.join(self.test_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
@@ -1019,8 +1070,8 @@ class DataloaderCheckpointTest(unittest.TestCase):
         saved_state = mgr.save.call_args.args[3]
         self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
 
-    def test_maybe_save_stamps_watermark_on_step_trigger(self):
-        """A step-triggered save records the watermark, triggers off."""
+    def test_maybe_save_reports_event_time_on_step_trigger(self):
+        """A step-triggered save reports its event-time, with triggers off."""
         mgr = self._policy_manager(save_steps=10)
         state = {"topic:0": 5}
         self.assertTrue(
@@ -1028,12 +1079,14 @@ class DataloaderCheckpointTest(unittest.TestCase):
                 10, model=None, dataloader_state=state, data_timestamp=3600.0
             )
         )
-        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, state)
+        # the trigger is off, so no resume watermark is stamped
         saved_state = mgr.save.call_args.args[3]
-        self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, saved_state)
+        # but the checkpoint still reports which data it covers
+        self.assertEqual(mgr.save.call_args.args[5], 3600.0)
 
-    def test_maybe_save_no_watermark_without_event_time(self):
-        """A source without event-times leaves the watermark out entirely."""
+    def test_maybe_save_no_event_time_reports_none(self):
+        """A source without event-times reports nothing to the marker."""
         mgr = self._policy_manager(save_steps=10)
         state = {"file:0": 5}
         self.assertTrue(
@@ -1041,6 +1094,7 @@ class DataloaderCheckpointTest(unittest.TestCase):
         )
         saved_state = mgr.save.call_args.args[3]
         self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, saved_state)
+        self.assertIsNone(mgr.save.call_args.args[5])
 
     def test_set_save_policy_rejects_bad_quorum_without_triggers(self):
         """The quorum is used by every save now, so it is always validated."""

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -724,6 +724,36 @@ class DataloaderCheckpointTest(unittest.TestCase):
         restored_state = checkpoint_util.restore_dataloader_state(self.test_dir)
         self.assertEqual(restored_state, checkpoint_state)
 
+    def test_save_success_marker(self):
+        """A completed checkpoint is marked so schedulers can poll for it."""
+        checkpoint_util.save_success_marker(self.test_dir)
+
+        marker_path = os.path.join(self.test_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+        self.assertTrue(os.path.exists(marker_path))
+        self.assertEqual(os.path.getsize(marker_path), 0)
+
+    def test_save_success_marker_creates_dir(self):
+        """The marker can be written before the directory exists."""
+        ckpt_dir = os.path.join(self.test_dir, "model.ckpt-10")
+        checkpoint_util.save_success_marker(ckpt_dir)
+
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+            )
+        )
+
+    def test_save_success_marker_non_zero_rank_skips(self):
+        """Only rank 0 writes the marker."""
+        with mock.patch.dict(os.environ, {"RANK": "1"}):
+            checkpoint_util.save_success_marker(self.test_dir)
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.test_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+            )
+        )
+
     def test_restore_dataloader_state_not_found(self):
         """Test restore returns None when no checkpoint exists."""
         restored_state = checkpoint_util.restore_dataloader_state(self.test_dir)

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -148,6 +148,39 @@ def _save_restore_worker(test_dir, rank, world_size, port):
     checkpoint_util.restore_model(test_dir, model, optimizer)
 
 
+def _report_ts_worker(
+    test_dir, rank, world_size, port, data_timestamp, ts_interval_s, ts_quorum
+):
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group(backend="gloo")
+
+    gathers = []
+    orig_all_gather_object = dist.all_gather_object
+
+    def _counting_all_gather_object(obj_list, obj, group=None):
+        gathers.append(1)
+        return orig_all_gather_object(obj_list, obj, group=group)
+
+    checkpoint_util.dist.all_gather_object = _counting_all_gather_object
+
+    mgr = checkpoint_util.CheckpointManager(test_dir)
+    mgr.set_save_policy(
+        save_steps=10,
+        save_epochs=0,
+        ts_interval_s=ts_interval_s,
+        ts_targets=[],
+        ts_quorum=ts_quorum,
+    )
+    # save is mocked, so the only gathers are the event-time reconciles
+    mgr.save = mock.MagicMock(return_value="ckpt")
+    mgr.maybe_save(10, model=None, data_timestamp=data_timestamp)
+    with open(os.path.join(test_dir, f"report_ts.{rank}"), "w") as f:
+        f.write(f"{mgr.save.call_args.args[5]!r} {len(gathers)}")
+
+
 def _partial_restore_worker(test_dir, rank, world_size, port):
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
@@ -360,6 +393,65 @@ class CheckpointUtilTest(unittest.TestCase):
             checkpoint_util.best_checkpoint(self.test_dir, export_config),
         )
         self.assertEqual(manager.best_checkpoint()[1], 10)
+
+    def test_dist_report_ts_agrees_across_ranks(self):
+        """Ranks at different event-times record the same one on the checkpoint.
+
+        The directory a checkpoint is written to, and the event-time recorded in
+        its meta, have to be identical on every rank; the save is collective, so
+        a rank-local event-time would split one checkpoint across directories.
+        """
+        # triggers off: the reconcile happens once, only because a save fired
+        reported = self._run_report_ts_workers(
+            data_timestamps=[3600.0, 3660.0], ts_interval_s=0, ts_quorum=0.5
+        )
+        self.assertEqual(reported[0], reported[1])
+        # quorum 0.5 over [3600, 3660]: largest T with at least 1 value >= T
+        self.assertEqual(reported[0], f"{3660.0!r} 1")
+
+    def test_dist_report_ts_reuses_the_trigger_gather(self):
+        """With the triggers on, reporting must not gather a second time.
+
+        The trigger already reconciled this step; repeating it returns the same
+        value, so a second all_gather_object is pure waste. Quorum 1.0 with one
+        rank lacking a timestamp leaves the trigger unmet, which is the path
+        where the redundant gather used to happen.
+        """
+        reported = self._run_report_ts_workers(
+            data_timestamps=[3600.0, -1.0], ts_interval_s=3600, ts_quorum=1.0
+        )
+        self.assertEqual(reported[0], reported[1])
+        # quorum unmet -> nothing to report, and exactly one gather
+        self.assertEqual(reported[0], "None 1")
+
+    def _run_report_ts_workers(self, data_timestamps, ts_interval_s, ts_quorum):
+        port = misc_util.get_free_port()
+        procs = []
+        ctx = mp.get_context("spawn")
+        for i, data_timestamp in enumerate(data_timestamps):
+            p = ctx.Process(
+                target=_report_ts_worker,
+                args=(
+                    self.test_dir,
+                    i,
+                    len(data_timestamps),
+                    port,
+                    data_timestamp,
+                    ts_interval_s,
+                    ts_quorum,
+                ),
+            )
+            p.start()
+            procs.append(p)
+        for i, p in enumerate(procs):
+            p.join()
+            if p.exitcode != 0:
+                raise RuntimeError(f"worker-{i} failed.")
+        reported = []
+        for i in range(len(data_timestamps)):
+            with open(os.path.join(self.test_dir, f"report_ts.{i}")) as f:
+                reported.append(f.read())
+        return reported
 
     def test_dist_save_restore_model(self):
         port = misc_util.get_free_port()

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -1019,6 +1019,41 @@ class DataloaderCheckpointTest(unittest.TestCase):
         saved_state = mgr.save.call_args.args[3]
         self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
 
+    def test_maybe_save_stamps_watermark_on_step_trigger(self):
+        """A step-triggered save records the watermark, triggers off."""
+        mgr = self._policy_manager(save_steps=10)
+        state = {"topic:0": 5}
+        self.assertTrue(
+            mgr.maybe_save(
+                10, model=None, dataloader_state=state, data_timestamp=3600.0
+            )
+        )
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, state)
+        saved_state = mgr.save.call_args.args[3]
+        self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+
+    def test_maybe_save_no_watermark_without_event_time(self):
+        """A source without event-times leaves the watermark out entirely."""
+        mgr = self._policy_manager(save_steps=10)
+        state = {"file:0": 5}
+        self.assertTrue(
+            mgr.maybe_save(10, model=None, dataloader_state=state, data_timestamp=-1.0)
+        )
+        saved_state = mgr.save.call_args.args[3]
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, saved_state)
+
+    def test_set_save_policy_rejects_bad_quorum_without_triggers(self):
+        """The quorum is used by every save now, so it is always validated."""
+        mgr = checkpoint_util.CheckpointManager(self.test_dir)
+        with self.assertRaisesRegex(ValueError, "must be in"):
+            mgr.set_save_policy(
+                save_steps=10,
+                save_epochs=0,
+                ts_interval_s=0,
+                ts_targets=[],
+                ts_quorum=0,
+            )
+
     def test_reconcile_event_time_single_process(self):
         # not distributed: this rank's value passes through (quorum of one); -1.0
         # (no timestamp) -> None; disabled policy -> None

--- a/tzrec/utils/env_util.py
+++ b/tzrec/utils/env_util.py
@@ -16,6 +16,11 @@ import torch
 from tzrec.utils.logging_util import logger
 
 
+def checkpoint_tag() -> str:
+    """Label recorded in each checkpoint's success marker, empty when unset."""
+    return os.environ.get("CHECKPOINT_TAG", "")
+
+
 def use_hash_node_id() -> bool:
     """Use hash node id or not."""
     return os.environ.get("USE_HASH_NODE_ID", "0") == "1"

--- a/tzrec/utils/fx_util.py
+++ b/tzrec/utils/fx_util.py
@@ -47,6 +47,18 @@ def symbolic_trace(
 
 
 @torch.fx.wrap
+def fx_get_label(
+    labels: Dict[str, torch.Tensor],
+    jagged_labels: Dict[str, JaggedTensor],
+    label_name: str,
+) -> torch.Tensor:
+    """Fx trace wrapper for reading a label that may be stored as a list column."""
+    if label_name in labels:
+        return labels[label_name]
+    return jagged_labels[label_name].values()
+
+
+@torch.fx.wrap
 def fx_arange(len: int, device: torch.device) -> torch.Tensor:
     """Fx trace wrapper for arange."""
     return torch.arange(len, device=device)


### PR DESCRIPTION
## Summary

Three gaps that show up when driving TorchEasyRec from an external scheduler, and from tables whose label columns are arrays.

- write a `_SUCCESS` marker into a checkpoint directory once the save completes, and record what that checkpoint is in its `meta`
- read labels through `BaseModel.get_label`, so a label stored as a list column is usable like an ordinary one
- document the determinism environment variables

## Motivation

**Checkpoint completion and identity.** A scheduler polling a model directory cannot tell a finished checkpoint from one still being written, so it either races the writer or guesses with a timeout. Having waited, it then needs to know *what the checkpoint is* — which step, and which data it covers. Neither was available: the only signals were the directory name, which several tools and user scripts parse and which is therefore not a safe place to add information, and the dataloader resume state, which is internal.

**List-column labels.** A label column of an array type (e.g. `array<bigint>` upstream) is parsed into a jagged label, and no model could consume one — every model reads `batch.labels[name]`, which does not contain it. The only way to train on such a column was to patch `DataParser` and flatten the label there.

## Design

### Completion and identity

A checkpoint now says what it is, and says when it is safe to read, using two files written in a deliberate order:

```
1. shards                  (collective, all ranks)
2. dataloader_state.json
3. meta                    <- step, data_ts, tag   (rank 0)
4. _SUCCESS                <- empty, last          (rank 0)
```

`meta` gains three descriptive keys beside the ones a converted checkpoint already carries:

```json
{"step": 1000, "data_ts": 1755000000.0, "tag": "20260828"}
```

- `step` — always present
- `data_ts` — the consumed event-time, **quorum-reconciled** so every rank records the same number. Omitted when the source has no event-time column, rather than a misleading sentinel. It is reconciled *after* the save decision, which is identical on every rank, so the gather stays in lockstep; it cannot affect the trigger, which was already decided. When the event-time triggers are on they have already reconciled this step, so the reporting path reuses that value: at most one gather per saved checkpoint, never one per step.
- `tag` — the optional `CHECKPOINT_TAG` environment variable, labelling which run produced a checkpoint. Omitted when unset.

`restore` is unaffected: it reads `meta` with `get("load_model", True)`, `get("load_optim", True)` and `get("dynamicemb_load_table_names", None)`, so the new keys are ignored and absent ones keep their defaults. A test asserts this.

`_SUCCESS` stays **empty** and is written **last**, by rank 0 behind a barrier — `CheckpointManager.save` runs on every rank and `save_model` is a collective `torch.distributed.checkpoint.save`, so the barrier is what stops the marker appearing before the last rank has finished its shards. Being empty and last is what makes it a reliable signal: its presence means every file beside it, `meta` and `dataloader_state.json` included, is complete. That removes any torn-read window without an atomic rename — which matters, because the fsspec monkeypatch does not cover `os.replace` and rename is not atomic on object stores, while `model_dir` is routinely `oss://` or `dfs://`. The ordering is load-bearing and the docstring says so.

The checkpoint directory name is deliberately left alone. Putting this information there was tried and abandoned (#653): the name is parsed by `_get_checkpoint_step`, `best_checkpoint`, pruning, several tools and users' own globs, and a `.` in a tag silently yields step 0 via `os.path.splitext`.

`__data_ts_watermark__` in `dataloader_state.json` is unchanged and still written only when an event-time trigger is configured. It serves a different purpose — continuing the save cadence across a restart, so a boundary or target in the gap is neither skipped nor repeated. Data resumption depends only on the per-source offsets and never used it.

### Labels

`BaseModel.get_label(batch, label_name)` returns `batch.labels[label_name]` when present and `batch.jagged_labels[label_name].values()` otherwise. Every model that reads a label for loss or metric now goes through it: `rank_model.py`, `multi_task_rank.py`, `rocket_launching.py` and `match_model.py`. `RocketLaunching` matters in particular — it is a `RankModel` subclass that overrides `loss` and `update_metric` with direct reads, so it would otherwise fail on a label its own base class handles.

Two direct reads are left deliberately: `dssm_v2.py` derives a batch size from the label's first dimension and `pepnet.py` reads a domain routing index. For a fixed-length list label, `values().size(0)` is `batch * length`, so routing those through the helper would replace today's `KeyError` with a quietly wrong number.

The lookup lives in `fx_util.fx_get_label` behind `@torch.fx.wrap`: a plain `label_name in batch.labels` breaks symbolic tracing, because `batch.labels` is a `Proxy` and `in` iterates it. That follows the existing pattern in `tzrec/modules/sequence.py`, which imports an `fx_*` helper and re-wraps it in the consuming module.

### Determinism

No code change was needed. Measured on torch 2.12.1+cu129: `torch.manual_seed` already seeds all CUDA devices, `cudnn.benchmark` already defaults to `False`, and with `cudnn.deterministic` left `False` the existing `USE_DETERMINISTIC_ALGORITHMS=1` alone gives bitwise-identical Conv1d backward over 30 runs. The environment variables are simply documented in the FAQ.

## Test Plan

- `tzrec/utils/checkpoint_util_test.py` — `meta` content for step, `data_ts` and `tag`, each omitted when absent, and leaving the restore-relevant keys at their defaults; the marker is empty; both skip on a non-zero rank; a step-triggered save records its event-time while leaving the resume watermark alone; a source without event-times records nothing
- `tzrec/datasets/data_parser_test.py` — a list-typed label column lands in `jagged_labels`, a scalar one in `labels` (this leg had no coverage before)
- `tzrec/models/rank_model_test.py`, `tzrec/models/match_model_test.py` — on both the rank and match paths, a jagged label drives loss and the metric to the same values as the equivalent dense label, in NORMAL and FX_TRACE modes
- `tzrec/tests/custom_model_integration_test.py` — the existing out-of-tree train_eval → eval → export run sets `CHECKPOINT_TAG` and, for every checkpoint, asserts the marker is zero bytes and that `meta` carries a `step` matching the directory plus the round-tripped tag
- `pre-commit run -a`, `pyrefly check` (0 errors)
- `tzrec/utils/checkpoint_util_test.py`, spawned two-rank tests counting `all_gather_object` — ranks consuming *different* event-times record the *same* one (the property that keeps a collective save in one directory), and the triggers-on path gathers once. The second fails `'None 2' != 'None 1'` without the reuse.
- full unit test suite on 1.4.0 (torch 2.13.0 / torchrec 1.8.0): **1673 tests, 0 failures**

## Upgrade note

`save_checkpoints_timestamp_quorum` is now validated whenever a save policy is set, not only when an event-time trigger is configured, because the reporting path uses the quorum as well. An explicit `save_checkpoints_timestamp_quorum: 0` therefore fails at startup where it was previously accepted and ignored. `docs/source/usage/train.md` already documents the valid range as `(0,1]`, so this enforces what was documented — worth a release note so it is not met at upgrade time.
