### PR TITLE
[feat] support a user-defined tag in the checkpoint name

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -378,3 +378,16 @@ pip install -U "pyodps>=0.13.1"
 | `STORAGE_API_SDK_RETRY_TIMES`      | 5              | SDK内部重试次数（仅对连接错误生效）                                     |
 | `STORAGE_API_SESSION_POLL_TIMEOUT` | 600（秒）      | 等待read session离开INIT状态的超时时间                                  |
 | `STORAGE_API_COMPRESSION`          | `LZ4_FRAME`    | 传输压缩方式，可选`ZSTD`/`UNCOMPRESSED`                                 |
+
+**Q18: 如何复现实验**
+
+**解决方法：** TorchEasyRec通过环境变量控制随机性，不需要在模型或启动脚本里自己调用`torch.manual_seed`：
+
+```bash
+export PYTHONHASHSEED=0
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+export PYTHON_RANDOM_SEED=100007
+export NUMPY_MANUAL_SEED=100007
+export TORCH_MANUAL_SEED=100007          # 同时会设置所有CUDA设备的种子
+export USE_DETERMINISTIC_ALGORITHMS=1    # 已包含cudnn的确定性行为
+```

--- a/docs/source/feature/data.md
+++ b/docs/source/feature/data.md
@@ -320,6 +320,11 @@ pipeline.global-job-parameters: |
     label_fields: "buy"
   ```
 
+- label列的类型是数组时（例如上游表的类型为`array<bigint>`），会被解析成jagged label。
+  模型侧统一用`BaseModel.get_label`读取label，会自动取出其中的values，因此这类label
+  可以和普通label一样使用。自定义模型中读取label时也应使用`self.get_label(batch, label_name)`
+  而不是`batch.labels[label_name]`。
+
 ### sample_weight_fields
 
 - 训练样本的样本权重列名

--- a/docs/source/models/user_define.md
+++ b/docs/source/models/user_define.md
@@ -142,6 +142,9 @@ python -m grpc_tools.protoc -I . -I "${TZREC_PATH}" \
 
 **模型模块必须在顶层 `import` 自己的 `*_pb2`。**
 
+读取 label 时使用 `self.get_label(batch, label_name)`，不要直接用 `batch.labels[label_name]`。
+数组类型的 label 会被解析成 jagged label，`get_label` 会自动取出其中的 values。
+
 以排序模型为例
 
 ```python

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -66,6 +66,7 @@ LR策略可以支持按epoch更新或者按step更新
 - save_checkpoints_timestamp_interval: 按数据时间（如Kafka消息的timestamp）保存模型的间隔秒数，每当已消费数据的事件时间跨过一个间隔边界时保存一次。默认0表示关闭。仅对带timestamp的数据源（如KafkaDataset）生效
 - save_checkpoints_timestamps: 按数据时间保存模型的绝对时间点列表（单位为秒的 Unix 时间戳），已消费数据的事件时间每跨过一个时间点保存一次，默认为空表示关闭
 - save_checkpoints_timestamp_quorum: 分布式训练下各rank消费的分区不同，事件时间也不同；当至少该比例（取值(0,1\]，默认0.5）的rank已消费越过边界/时间点时才触发保存。1.0表示所有rank都越过才保存（最保守），越小越激进（最小可仅需一个rank）；默认值对单个异常/超前的timestamp具有鲁棒性
+- save_checkpoints_timestamp_quorum还决定了checkpoint中记录的数据时间水位：每次保存checkpoint时，各rank已消费数据的事件时间会按该比例对齐成一个全局值，写入checkpoint目录下的`dataloader_state.json`，key为`__data_ts_watermark__`。按步数或Epoch保存时同样会记录，数据源不带timestamp时（如ParquetDataset）不写该字段。外部调度可以据此判断一个checkpoint覆盖到了哪个时间点的数据
 - keep_checkpoint_max: 最多保留的最近checkpoint数量，超出后会异步删除最旧的checkpoint，默认0表示全部保留；当exporter_type为best时，会额外保留指标最优的checkpoint
 - fine_tune_checkpoint: 增量训练的checkpoint路径，也可以设置checkpoint目录，将会使用目录下最新的checkpoint
 - fine_tune_ckpt_var_map: 需要restore的参数列表文件路径，文件的每一行是{variable_name in current model}\\t{variable name in old model ckpt}

--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -25,6 +25,11 @@ torchrun --master_addr=localhost --master_port=32555 \
 
 - ODPS_ENDPOINT: 在PAI-DLC/PAI-DSW环境，数据为MaxCompute表的情况下需设置，详见[文档](../feature/data.md)的OdpsDataset章节
 - ODPS_CONFIG_FILE_PATH: 在本地环境，数据为MaxCompute表的情况下需设置为odps_conf的路径，详见[文档](../feature/data.md)的OdpsDataset章节
+- CHECKPOINT_TAG: 在checkpoint目录名中加入一个自定义标记，命名为`model.ckpt-<tag>-<step>`，便于外部调度按日期、数据分区等定位checkpoint。默认为空，即保持`model.ckpt-<step>`
+  - **CHECKPOINT_TAG=20260828**：`model.ckpt-20260828-<step>`
+  - **CHECKPOINT_TAG='20260828-{data_ts}'**：`{data_ts}`会被替换为该checkpoint已消费数据的事件时间（秒），即`dataloader_state.json`中的`__data_ts_watermark__`，各rank对齐后的同一个值。数据源不带timestamp时（如ParquetDataset）取0
+  - 只能包含字母、数字、`_`、`-`和`{data_ts}`。含`.`会导致step无法解析，启动时即报错
+  - step始终在最后，因此checkpoint的查找、排序、清理逻辑不受影响。注意标记只用于**定位**checkpoint，排序仍然按step，热启动到新的`model_dir`时step会从头计数
 
 ## 训练配置
 

--- a/tzrec/datasets/data_parser_test.py
+++ b/tzrec/datasets/data_parser_test.py
@@ -154,6 +154,37 @@ class DataParserTest(unittest.TestCase):
         )
         torch.testing.assert_close(batch.labels["label"], expected_label)
 
+    def test_list_label(self):
+        """A label stored as a list column is parsed into a jagged label."""
+        feature_cfgs = [
+            feature_pb2.FeatureConfig(
+                id_feature=feature_pb2.IdFeature(
+                    feature_name="cat_a", embedding_dim=16, num_buckets=100
+                )
+            ),
+        ]
+        features = create_features(feature_cfgs)
+
+        data_parser = DataParser(features=features, labels=["label", "list_label"])
+
+        data = data_parser.parse(
+            input_data={
+                "cat_a": pa.array([1, 2, 3]),
+                "label": pa.array([0, 0, 1], pa.int32()),
+                "list_label": pa.array([[4], [5], [6]], pa.list_(pa.int32())),
+            }
+        )
+        batch = data_parser.to_batch(data)
+
+        torch.testing.assert_close(
+            batch.labels["label"], torch.tensor([0, 0, 1], dtype=torch.int64)
+        )
+        self.assertNotIn("list_label", batch.labels)
+        torch.testing.assert_close(
+            batch.jagged_labels["list_label"].values(),
+            torch.tensor([4, 5, 6], dtype=torch.int64),
+        )
+
     def test_fg_encoded_id_with_weight(self):
         feature_cfgs = [
             feature_pb2.FeatureConfig(

--- a/tzrec/models/model.py
+++ b/tzrec/models/model.py
@@ -33,7 +33,10 @@ from tzrec.modules.utils import BaseModule
 from tzrec.protos.loss_pb2 import LossConfig
 from tzrec.protos.model_pb2 import FeatureGroupConfig, ModelConfig
 from tzrec.utils import config_util
+from tzrec.utils.fx_util import fx_get_label
 from tzrec.utils.load_class import get_register_class_meta
+
+torch.fx.wrap(fx_get_label)
 
 _MODEL_CLASS_MAP = {}
 _meta_cls = get_register_class_meta(_MODEL_CLASS_MAP)
@@ -88,6 +91,21 @@ class BaseModel(BaseModule, metaclass=_meta_cls):
     def feature_groups(self) -> List[FeatureGroupConfig]:
         """Model's feature_groups (default forward to ``self._feature_groups``)."""
         return self._feature_groups
+
+    def get_label(self, batch: Batch, label_name: str) -> torch.Tensor:
+        """Get a label of the batch.
+
+        A label stored as a list column is parsed into a jagged label, take its
+        values so that fixed-length list labels can be used as ordinary labels.
+
+        Args:
+            batch (Batch): input batch data.
+            label_name (str): name of the label.
+
+        Return:
+            label (Tensor): label tensor.
+        """
+        return fx_get_label(batch.labels, batch.jagged_labels, label_name)
 
     def predict(self, batch: Batch) -> Dict[str, torch.Tensor]:
         """Predict the model.

--- a/tzrec/models/multi_task_rank.py
+++ b/tzrec/models/multi_task_rank.py
@@ -108,12 +108,13 @@ class MultiTaskRank(RankModel):
                     loss_weight = batch.sample_weights[sample_weight]
                 else:
                     loss_weight = torch.Tensor([1.0]).to(
-                        batch.labels[label_name].device
+                        self.get_label(batch, label_name).device
                     )
 
                 if task_tower_cfg.HasField("task_space_indicator_label"):
                     in_task_space = (
-                        batch.labels[task_tower_cfg.task_space_indicator_label] > 0
+                        self.get_label(batch, task_tower_cfg.task_space_indicator_label)
+                        > 0
                     ).float()
                     loss_weight = loss_weight * (
                         task_tower_cfg.in_task_space_weight * in_task_space
@@ -131,7 +132,7 @@ class MultiTaskRank(RankModel):
                     self._loss_impl(
                         predictions,
                         batch,
-                        batch.labels[label_name],
+                        self.get_label(batch, label_name),
                         loss_weight,
                         loss_cfg,
                         num_class=task_tower_cfg.num_class,
@@ -180,7 +181,7 @@ class MultiTaskRank(RankModel):
                 self._update_metric_impl(
                     predictions,
                     batch,
-                    batch.labels[label_name],
+                    self.get_label(batch, label_name),
                     metric_cfg,
                     num_class=task_tower_cfg.num_class,
                     suffix=f"_{tower_name}",
@@ -190,7 +191,7 @@ class MultiTaskRank(RankModel):
                     self._update_loss_metric_impl(
                         losses,
                         batch,
-                        batch.labels[label_name],
+                        self.get_label(batch, label_name),
                         loss_cfg,
                         suffix=f"_{tower_name}",
                     )
@@ -213,7 +214,7 @@ class MultiTaskRank(RankModel):
                 self._update_train_metric_impl(
                     predictions,
                     batch,
-                    batch.labels[label_name],
+                    self.get_label(batch, label_name),
                     metric_cfg,
                     num_class=task_tower_cfg.num_class,
                     suffix=f"_{tower_name}",

--- a/tzrec/models/rank_model.py
+++ b/tzrec/models/rank_model.py
@@ -277,7 +277,7 @@ class RankModel(BaseModel):
                 self._loss_impl(
                     predictions,
                     batch,
-                    batch.labels[self._label_name],
+                    self.get_label(batch, self._label_name),
                     loss_weight,
                     loss_cfg,
                     num_class=self._num_class,
@@ -492,14 +492,14 @@ class RankModel(BaseModel):
             self._update_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
             )
         if losses is not None:
             for loss_cfg in self._base_model_config.losses:
                 self._update_loss_metric_impl(
-                    losses, batch, batch.labels[self._label_name], loss_cfg
+                    losses, batch, self.get_label(batch, self._label_name), loss_cfg
                 )
 
     def update_train_metric(
@@ -517,7 +517,7 @@ class RankModel(BaseModel):
             self._update_train_metric_impl(
                 predictions,
                 batch,
-                batch.labels[self._label_name],
+                self.get_label(batch, self._label_name),
                 metric_cfg,
                 num_class=self._num_class,
             )

--- a/tzrec/models/rank_model_test.py
+++ b/tzrec/models/rank_model_test.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 
 import torch
 from parameterized import parameterized
-from torchrec import KeyedJaggedTensor, KeyedTensor
+from torchrec import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 from tzrec.datasets.utils import BASE_DATA_GROUP, Batch
 from tzrec.features.feature import BaseFeature
@@ -145,6 +145,54 @@ class RankModelTest(unittest.TestCase):
             )
             torch.testing.assert_close(
                 metric_result["accuracy"], expected_acc, rtol=1e-4, atol=1e-4
+            )
+
+    @parameterized.expand(
+        [
+            [TestGraphType.NORMAL],
+            [TestGraphType.FX_TRACE],
+        ]
+    )
+    def test_binary_classification_model_with_jagged_label(self, graph_type):
+        """A label stored as a list column is used like an ordinary label."""
+        model_config = model_pb2.ModelConfig(
+            losses=[
+                loss_pb2.LossConfig(binary_cross_entropy=loss_pb2.BinaryCrossEntropy())
+            ],
+            metrics=[metric_pb2.MetricConfig(auc=metric_pb2.AUC())],
+        )
+        model = _TestClassficationModel(
+            model_config=model_config, features=[], labels=["label"]
+        )
+        model = TrainWrapper(model)
+        model = create_test_model(model, graph_type)
+
+        dense_feature = KeyedTensor.from_tensor_list(
+            keys=["int_a"], tensors=[torch.tensor([[0.2], [0.3]])]
+        )
+        batch = Batch(
+            dense_features={BASE_DATA_GROUP: dense_feature},
+            sparse_features={},
+            jagged_labels={
+                "label": JaggedTensor(
+                    values=torch.tensor([0, 1]), lengths=torch.tensor([1, 1])
+                )
+            },
+        )
+        total_loss, (losses, predictions, batch) = model(batch)
+
+        torch.testing.assert_close(
+            total_loss, torch.tensor(0.6762), rtol=1e-4, atol=1e-4
+        )
+        torch.testing.assert_close(
+            predictions["probs"], torch.tensor([0.5498, 0.5744]), rtol=1e-4, atol=1e-4
+        )
+
+        if graph_type == TestGraphType.NORMAL:
+            model.model.update_metric(predictions, batch)
+            metric_result = model.model.compute_metric()
+            torch.testing.assert_close(
+                metric_result["auc"], torch.tensor(1.0), rtol=1e-4, atol=1e-4
             )
 
     @parameterized.expand(

--- a/tzrec/tests/custom_model_integration_test.py
+++ b/tzrec/tests/custom_model_integration_test.py
@@ -200,7 +200,10 @@ class CustomModelIntegrationTest(unittest.TestCase):
         pythonpath = f".:{project_dir}"
 
         self.success = utils.test_train_eval(
-            config_path, self.test_dir, pythonpath=pythonpath
+            config_path,
+            self.test_dir,
+            pythonpath=pythonpath,
+            env_str="CHECKPOINT_TAG=ci-{data_ts}",
         )
         self.assertTrue(self.success)
 
@@ -208,8 +211,10 @@ class CustomModelIntegrationTest(unittest.TestCase):
         # process, class_path alone has to resolve the model there
         saved_config_path = os.path.join(self.test_dir, "train/pipeline.config")
         self.assertTrue(os.path.exists(saved_config_path))
-        # every saved checkpoint is marked complete for external schedulers
-        ckpt_dirs = glob.glob(os.path.join(self.test_dir, "train", "model.ckpt-*"))
+        # CHECKPOINT_TAG names the checkpoints, and every one is marked complete
+        # for external schedulers. The parquet source carries no event-time, so
+        # {data_ts} renders 0.
+        ckpt_dirs = glob.glob(os.path.join(self.test_dir, "train", "model.ckpt-ci-0-*"))
         self.assertTrue(ckpt_dirs)
         for ckpt_dir in ckpt_dirs:
             self.assertTrue(

--- a/tzrec/tests/custom_model_integration_test.py
+++ b/tzrec/tests/custom_model_integration_test.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ import unittest
 
 import tzrec
 from tzrec.tests import utils
+from tzrec.utils import checkpoint_util
 from tzrec.utils.test_util import make_test_dir
 
 _PROTO = """syntax = "proto2";
@@ -206,6 +208,15 @@ class CustomModelIntegrationTest(unittest.TestCase):
         # process, class_path alone has to resolve the model there
         saved_config_path = os.path.join(self.test_dir, "train/pipeline.config")
         self.assertTrue(os.path.exists(saved_config_path))
+        # every saved checkpoint is marked complete for external schedulers
+        ckpt_dirs = glob.glob(os.path.join(self.test_dir, "train", "model.ckpt-*"))
+        self.assertTrue(ckpt_dirs)
+        for ckpt_dir in ckpt_dirs:
+            self.assertTrue(
+                os.path.exists(
+                    os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+                )
+            )
         self.success = utils.test_eval(
             saved_config_path, self.test_dir, pythonpath=pythonpath
         )

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -395,6 +395,7 @@ class CheckpointManager:
         save_model(ckpt_dir, model, optimizer, dense_ema)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
+        save_success_marker(ckpt_dir)
         self._last_ckpt_dir = ckpt_dir
         self.prune()
         return ckpt_dir
@@ -1161,12 +1162,33 @@ def save_model(
 
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
+CKPT_SUCCESS_FILENAME = "_SUCCESS"
 # reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
 # no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"
 # reserved dataloader_state key: number of completed data passes; resume
 # continues the epoch budget from here. no ":" so per-source consumers skip it.
 EPOCHS_COMPLETED = "__epochs_completed__"
+
+
+def save_success_marker(checkpoint_dir: str) -> None:
+    """Mark a checkpoint as completely written.
+
+    Schedulers that poll a model directory need to tell a finished checkpoint
+    from one still being written. Write the marker only after every rank has
+    finished writing its shards.
+
+    Args:
+        checkpoint_dir: directory of the checkpoint to mark.
+    """
+    if dist.is_initialized():
+        dist.barrier()
+    if int(os.environ.get("RANK", 0)) == 0:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        marker_path = os.path.join(checkpoint_dir, CKPT_SUCCESS_FILENAME)
+        with open(marker_path, "w"):
+            pass
+        logger.info(f"Saved checkpoint success marker to {marker_path}")
 
 
 def save_dataloader_state(

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -43,6 +43,7 @@ from tzrec.acc.utils import is_input_tile_emb
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.optim.ema import DenseEMA
 from tzrec.protos import export_pb2
+from tzrec.utils import env_util
 from tzrec.utils.dynamicemb_util import has_dynamicemb
 from tzrec.utils.logging_util import logger
 
@@ -216,6 +217,23 @@ class PartialLoadPlanner(DefaultLoadPlanner):
         return plan
 
 
+def _validate_checkpoint_tag(tag: str) -> str:
+    """Check a checkpoint tag renders into a name whose step is still parseable.
+
+    Args:
+        tag: raw tag, may contain the {data_ts} placeholder.
+
+    Return:
+        the tag, unchanged.
+    """
+    if tag and not re.fullmatch(r"[A-Za-z0-9_-]*", tag.replace(CKPT_TAG_DATA_TS, "")):
+        raise ValueError(
+            f"CHECKPOINT_TAG [{tag}] may only contain letters, digits, '_', '-' "
+            f"and {CKPT_TAG_DATA_TS}. A '.' makes the checkpoint step unparsable."
+        )
+    return tag
+
+
 def _get_checkpoint_step(ckpt_path: str) -> int:
     """Get checkpoint step from ckpt_path.
 
@@ -366,6 +384,9 @@ class CheckpointManager:
             (by eval metric) is always retained even if older than the kept window.
         eval_result_filename: eval result file (relative to ``model_dir``) used to
             locate the best checkpoint.
+
+    The ``CHECKPOINT_TAG`` environment variable names checkpoints
+    ``model.ckpt-<tag>-<step>``; the step stays last so it remains parseable.
     """
 
     def __init__(
@@ -376,6 +397,7 @@ class CheckpointManager:
         eval_result_filename: str = TRAIN_EVAL_RESULT_FILENAME,
     ) -> None:
         self._model_dir = model_dir
+        self._checkpoint_tag = _validate_checkpoint_tag(env_util.checkpoint_tag())
         self._keep_checkpoint_max = keep_checkpoint_max
         self._export_config = export_config
         self._eval_result_filename = eval_result_filename
@@ -399,6 +421,20 @@ class CheckpointManager:
         self._last_ckpt_dir: Optional[str] = None
         self._last_data_ts: Optional[float] = None
 
+    def _render_checkpoint_tag(self, data_ts: Optional[float]) -> str:
+        """Substitute the consumed event-time into the configured tag.
+
+        Args:
+            data_ts: quorum event-time (seconds), None when the data source
+                carries no event-time.
+
+        Return:
+            the rendered tag, empty when no tag is configured.
+        """
+        return self._checkpoint_tag.replace(
+            CKPT_TAG_DATA_TS, str(int(data_ts)) if data_ts is not None else "0"
+        )
+
     def save(
         self,
         step: int,
@@ -406,9 +442,13 @@ class CheckpointManager:
         optimizer: Optional[optim.Optimizer] = None,
         dataloader_state: Optional[Dict[str, Any]] = None,
         dense_ema: Optional[DenseEMA] = None,
+        data_ts: Optional[float] = None,
     ) -> str:
         """Save a checkpoint at the given step, then request an async prune."""
-        ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
+        tag = self._render_checkpoint_tag(data_ts)
+        # the step stays last so _get_checkpoint_step keeps working
+        ckpt_name = f"model.ckpt-{tag}-{step}" if tag else f"model.ckpt-{step}"
+        ckpt_dir = os.path.join(self._model_dir, ckpt_name)
         save_model(ckpt_dir, model, optimizer, dense_ema)
         if dataloader_state is not None:
             save_dataloader_state(ckpt_dir, dataloader_state)
@@ -588,7 +628,7 @@ class CheckpointManager:
         if data_ts is not None:
             # advance the watermark on every save so resume is exact
             self._last_data_ts = data_ts
-        self.save(step, model, optimizer, dataloader_state, dense_ema)
+        self.save(step, model, optimizer, dataloader_state, dense_ema, data_ts)
         return True
 
     def prune(self) -> None:
@@ -1195,6 +1235,8 @@ def save_model(
 
 DATALOADER_CKPT_FILENAME = "dataloader_state.json"
 CKPT_SUCCESS_FILENAME = "_SUCCESS"
+# placeholder in CHECKPOINT_TAG, replaced by the consumed event-time (seconds).
+CKPT_TAG_DATA_TS = "{data_ts}"
 # reserved dataloader_state key: last checkpoint's event-time watermark (seconds);
 # no ":" so per-source consumers skip it.
 DATA_TS_WATERMARK = "__data_ts_watermark__"

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -423,9 +423,10 @@ class CheckpointManager:
         """Configure when ``maybe_save`` fires (train path only).
 
         Sets cadence config only (never the ``_last_*`` state), so a watermark
-        seeded on resume survives. When timestamp triggers are active under a
-        distributed run, also creates the dedicated CPU (gloo) group used for the
-        per-step event-time gather -- a collective, so all ranks must call this.
+        seeded on resume survives. Under a distributed run, also creates the
+        dedicated CPU (gloo) group used to gather event-times -- a collective, so
+        all ranks must call this. The group is created even when the timestamp
+        triggers are off, because a save still records the event-time watermark.
 
         Args:
             save_steps: step interval; 0 disables the step trigger.
@@ -434,7 +435,7 @@ class CheckpointManager:
             ts_targets: absolute event-time targets (Unix-epoch seconds).
             ts_quorum: fraction of workers (0, 1] past a boundary to trigger a save.
         """
-        if (ts_interval_s > 0 or len(ts_targets) > 0) and not (0.0 < ts_quorum <= 1.0):
+        if not (0.0 < ts_quorum <= 1.0):
             raise ValueError(
                 f"save_checkpoints_timestamp_quorum must be in (0, 1], got {ts_quorum}."
             )
@@ -443,7 +444,7 @@ class CheckpointManager:
         self._ts_interval = ts_interval_s
         self._ts_targets = ts_targets
         self._ts_quorum = ts_quorum
-        if self.needs_worker_timestamps() and dist.is_initialized():
+        if dist.is_initialized():
             self._ts_group = cast(
                 Optional[dist.ProcessGroup], dist.new_group(backend="gloo")
             )
@@ -452,7 +453,9 @@ class CheckpointManager:
         """Return whether the policy needs per-worker event-times gathered."""
         return self._ts_interval > 0 or len(self._ts_targets) > 0
 
-    def _reconcile_event_time(self, data_timestamp: float) -> Optional[float]:
+    def _reconcile_event_time(
+        self, data_timestamp: float, force: bool = False
+    ) -> Optional[float]:
         """Quorum-reconcile this rank's event-time across workers.
 
         Gathers over the CPU group from ``set_save_policy``. Each worker without a
@@ -462,11 +465,13 @@ class CheckpointManager:
 
         Args:
             data_timestamp: this rank's consumed event-time (seconds), -1.0 if none.
+            force: gather even when the timestamp triggers are off. Only safe once
+                the save decision is made, which is identical on every rank.
 
         Returns:
             The quorum event-time (seconds), or None.
         """
-        if not self.needs_worker_timestamps():
+        if not force and not self.needs_worker_timestamps():
             return None
         if dist.is_initialized():
             worker_ts: List[float] = [0.0] * dist.get_world_size(self._ts_group)
@@ -512,11 +517,6 @@ class CheckpointManager:
             True if a checkpoint was saved.
         """
         data_ts = self._reconcile_event_time(data_timestamp)
-        # copy so the watermark isn't leaked back into the train loop's state
-        if dataloader_state is not None:
-            dataloader_state = dict(dataloader_state)
-            if data_ts is not None:
-                dataloader_state[DATA_TS_WATERMARK] = data_ts
 
         want = final
         if self._save_steps > 0 and step > 0 and step % self._save_steps == 0:
@@ -539,6 +539,21 @@ class CheckpointManager:
 
         if not want:
             return False
+
+        # A step/epoch/final save records the watermark too, so a consumer can
+        # tell what data a checkpoint covers without the timestamp triggers being
+        # on. Gathering here rather than above keeps it one collective per saved
+        # checkpoint, and the save decision is identical on every rank so the
+        # gather stays in lockstep. It cannot affect the trigger, which was
+        # already decided.
+        if data_ts is None:
+            data_ts = self._reconcile_event_time(data_timestamp, force=True)
+        # copy so the watermark isn't leaked back into the train loop's state
+        if dataloader_state is not None:
+            dataloader_state = dict(dataloader_state)
+            if data_ts is not None:
+                dataloader_state[DATA_TS_WATERMARK] = data_ts
+
         if step == self._last_ckpt_step:
             # a boundary save dedup'd against an already-saved step: refresh
             # that checkpoint's state so the cleared + bumped bookkeeping is

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -237,6 +237,23 @@ def _get_checkpoint_step(ckpt_path: str) -> int:
     return ckpt_step
 
 
+def _find_checkpoint_by_step(model_dir: str, step: int) -> Optional[str]:
+    """Find the checkpoint directory of a step, whatever name it carries.
+
+    Args:
+        model_dir: model directory.
+        step: step of the wanted checkpoint.
+
+    Return:
+        the checkpoint path, or None when no checkpoint has that step.
+    """
+    for ckpt_path in glob.glob(os.path.join(model_dir, "model.ckpt-*" + os.path.sep)):
+        ckpt_path = ckpt_path.rstrip(os.path.sep)
+        if _get_checkpoint_step(ckpt_path) == step:
+            return ckpt_path
+    return None
+
+
 def latest_checkpoint(model_dir: str) -> Tuple[Optional[str], int]:
     """Find latest checkpoint under a directory.
 
@@ -318,14 +335,14 @@ def best_checkpoint(
                 step_metric.items(), key=lambda x: x[1], reverse=False
             )
         max_metric_step = sorted_mertic[0][0]
-        best_ckpt_path = os.path.join(model_dir, f"model.ckpt-{max_metric_step}")
-        if os.path.exists(best_ckpt_path):
+        best_ckpt_path = _find_checkpoint_by_step(model_dir, max_metric_step)
+        if best_ckpt_path is not None:
             logger.info(f"find best checkpoint is {best_ckpt_path}")
             return best_ckpt_path, max_metric_step
         else:
             raise ValueError(
                 f"find best metric is {max_metric_step} step,"
-                f"but not find {best_ckpt_path}."
+                f" but not find its checkpoint in {model_dir}."
             )
     else:
         logger.info(f"not find {eval_result_filename}, will search latest checkpoint")

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -724,6 +724,36 @@ class DataloaderCheckpointTest(unittest.TestCase):
         restored_state = checkpoint_util.restore_dataloader_state(self.test_dir)
         self.assertEqual(restored_state, checkpoint_state)
 
+    def test_save_success_marker(self):
+        """A completed checkpoint is marked so schedulers can poll for it."""
+        checkpoint_util.save_success_marker(self.test_dir)
+
+        marker_path = os.path.join(self.test_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+        self.assertTrue(os.path.exists(marker_path))
+        self.assertEqual(os.path.getsize(marker_path), 0)
+
+    def test_save_success_marker_creates_dir(self):
+        """The marker can be written before the directory exists."""
+        ckpt_dir = os.path.join(self.test_dir, "model.ckpt-10")
+        checkpoint_util.save_success_marker(ckpt_dir)
+
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(ckpt_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+            )
+        )
+
+    def test_save_success_marker_non_zero_rank_skips(self):
+        """Only rank 0 writes the marker."""
+        with mock.patch.dict(os.environ, {"RANK": "1"}):
+            checkpoint_util.save_success_marker(self.test_dir)
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.test_dir, checkpoint_util.CKPT_SUCCESS_FILENAME)
+            )
+        )
+
     def test_restore_dataloader_state_not_found(self):
         """Test restore returns None when no checkpoint exists."""
         restored_state = checkpoint_util.restore_dataloader_state(self.test_dir)

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -224,6 +224,27 @@ class CheckpointUtilTest(unittest.TestCase):
         self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt-0"))
         self.assertEqual(step, 0)
 
+    def test_best_checkpoint_tagged_dir(self):
+        """The best checkpoint is found by step, not by rebuilding its name."""
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-d1-0"))
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-d1-10"))
+        with open(os.path.join(self.test_dir, TRAIN_EVAL_RESULT_FILENAME), "w+") as f:
+            f.write('{"global_step":0, "auc": 0.633}\n')
+            f.write('{"global_step":10, "auc": 0.640}\n')
+        config = ExportConfig(exporter_type="best", best_exporter_metric="auc")
+        ckpt_path, step = checkpoint_util.best_checkpoint(self.test_dir, config)
+        self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt-d1-10"))
+        self.assertEqual(step, 10)
+
+    def test_best_checkpoint_missing_step(self):
+        """A metric step with no checkpoint on disk is an error."""
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-0"))
+        with open(os.path.join(self.test_dir, TRAIN_EVAL_RESULT_FILENAME), "w+") as f:
+            f.write('{"global_step":10, "auc": 0.640}\n')
+        config = ExportConfig(exporter_type="best", best_exporter_metric="auc")
+        with self.assertRaisesRegex(ValueError, "not find its checkpoint"):
+            checkpoint_util.best_checkpoint(self.test_dir, config)
+
     def test_latest_checkpoint_with_custom_dir(self):
         os.makedirs(os.path.join(self.test_dir, "custom/model"))
         ckpt_path, step = checkpoint_util.latest_checkpoint(

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -224,6 +224,53 @@ class CheckpointUtilTest(unittest.TestCase):
         self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt-0"))
         self.assertEqual(step, 0)
 
+    def test_checkpoint_tag_name(self):
+        """A tag is inserted before the step, which stays parseable."""
+        with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": "20260828"}):
+            mgr = checkpoint_util.CheckpointManager(self.test_dir)
+        self.assertEqual(mgr._render_checkpoint_tag(None), "20260828")
+        name = f"model.ckpt-{mgr._render_checkpoint_tag(None)}-300"
+        self.assertEqual(name, "model.ckpt-20260828-300")
+        self.assertEqual(
+            checkpoint_util._get_checkpoint_step(os.path.join("d", name)), 300
+        )
+
+    def test_checkpoint_tag_unset_keeps_name(self):
+        """No tag leaves the name exactly as before."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            mgr = checkpoint_util.CheckpointManager(self.test_dir)
+        self.assertEqual(mgr._render_checkpoint_tag(1755000000.0), "")
+
+    def test_checkpoint_tag_data_ts(self):
+        """{data_ts} carries the event-time; 0 when the source has none."""
+        with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": "d-{data_ts}"}):
+            mgr = checkpoint_util.CheckpointManager(self.test_dir)
+        self.assertEqual(mgr._render_checkpoint_tag(1755000000.0), "d-1755000000")
+        self.assertEqual(mgr._render_checkpoint_tag(None), "d-0")
+        name = f"model.ckpt-{mgr._render_checkpoint_tag(1755000000.0)}-300"
+        self.assertEqual(
+            checkpoint_util._get_checkpoint_step(os.path.join("d", name)), 300
+        )
+
+    def test_checkpoint_tag_validation(self):
+        """A tag that would break step parsing is rejected at construction."""
+        for tag in ["v1.2", "1.4.0", "a/b", "a b"]:
+            with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": tag}):
+                with self.assertRaisesRegex(ValueError, "CHECKPOINT_TAG"):
+                    checkpoint_util.CheckpointManager(self.test_dir)
+        for tag in ["20260828", "2026-08-28", "v1_2", "d-{data_ts}"]:
+            with mock.patch.dict(os.environ, {"CHECKPOINT_TAG": tag}):
+                checkpoint_util.CheckpointManager(self.test_dir)
+
+    def test_latest_checkpoint_mixed_tagged_and_untagged(self):
+        """Tagged and untagged checkpoints coexist and order by step."""
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-5"))
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-d1-10"))
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-d1-2"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(self.test_dir)
+        self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt-d1-10"))
+        self.assertEqual(step, 10)
+
     def test_best_checkpoint_tagged_dir(self):
         """The best checkpoint is found by step, not by rebuilding its name."""
         os.makedirs(os.path.join(self.test_dir, "model.ckpt-d1-0"))
@@ -297,6 +344,29 @@ class CheckpointUtilTest(unittest.TestCase):
             manager.prune()
             manager.close()  # drains the async worker -> deterministic
         self.assertEqual(self._remaining_ckpt_steps(), expected_steps)
+
+    def test_checkpoint_manager_prune_tagged(self):
+        """Pruning tagged checkpoints keeps the newest by step, and the best."""
+        for step in [0, 10, 20, 30]:
+            os.makedirs(os.path.join(self.test_dir, f"model.ckpt-d1-{step}"))
+        with open(os.path.join(self.test_dir, TRAIN_EVAL_RESULT_FILENAME), "w") as f:
+            f.write('{"global_step":0, "auc":0.50}\n')
+            f.write('{"global_step":10, "auc":0.99}\n')  # best, outside recent-2
+            f.write('{"global_step":20, "auc":0.60}\n')
+            f.write('{"global_step":30, "auc":0.70}\n')
+        manager = checkpoint_util.CheckpointManager(
+            self.test_dir,
+            keep_checkpoint_max=2,
+            export_config=ExportConfig(
+                exporter_type="best",
+                best_exporter_metric="auc",
+                metric_larger_is_better=True,
+            ),
+        )
+        with mock.patch.dict(os.environ, {"RANK": "0"}):
+            manager.prune()
+            manager.close()
+        self.assertEqual(self._remaining_ckpt_steps(), [10, 20, 30])
 
     def test_checkpoint_manager_prune_non_rank_zero(self):
         for step in [0, 10, 20, 30]:

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -1019,6 +1019,41 @@ class DataloaderCheckpointTest(unittest.TestCase):
         saved_state = mgr.save.call_args.args[3]
         self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
 
+    def test_maybe_save_stamps_watermark_on_step_trigger(self):
+        """A step-triggered save records the watermark, triggers off."""
+        mgr = self._policy_manager(save_steps=10)
+        state = {"topic:0": 5}
+        self.assertTrue(
+            mgr.maybe_save(
+                10, model=None, dataloader_state=state, data_timestamp=3600.0
+            )
+        )
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, state)
+        saved_state = mgr.save.call_args.args[3]
+        self.assertEqual(saved_state[checkpoint_util.DATA_TS_WATERMARK], 3600.0)
+
+    def test_maybe_save_no_watermark_without_event_time(self):
+        """A source without event-times leaves the watermark out entirely."""
+        mgr = self._policy_manager(save_steps=10)
+        state = {"file:0": 5}
+        self.assertTrue(
+            mgr.maybe_save(10, model=None, dataloader_state=state, data_timestamp=-1.0)
+        )
+        saved_state = mgr.save.call_args.args[3]
+        self.assertNotIn(checkpoint_util.DATA_TS_WATERMARK, saved_state)
+
+    def test_set_save_policy_rejects_bad_quorum_without_triggers(self):
+        """The quorum is used by every save now, so it is always validated."""
+        mgr = checkpoint_util.CheckpointManager(self.test_dir)
+        with self.assertRaisesRegex(ValueError, "must be in"):
+            mgr.set_save_policy(
+                save_steps=10,
+                save_epochs=0,
+                ts_interval_s=0,
+                ts_targets=[],
+                ts_quorum=0,
+            )
+
     def test_reconcile_event_time_single_process(self):
         # not distributed: this rank's value passes through (quorum of one); -1.0
         # (no timestamp) -> None; disabled policy -> None

--- a/tzrec/utils/env_util.py
+++ b/tzrec/utils/env_util.py
@@ -16,6 +16,15 @@ import torch
 from tzrec.utils.logging_util import logger
 
 
+def checkpoint_tag() -> str:
+    """Tag put into the checkpoint dir name, as model.ckpt-<tag>-<step>.
+
+    Supports the {data_ts} placeholder, replaced by the event-time of the data
+    the checkpoint covers.
+    """
+    return os.environ.get("CHECKPOINT_TAG", "")
+
+
 def use_hash_node_id() -> bool:
     """Use hash node id or not."""
     return os.environ.get("USE_HASH_NODE_ID", "0") == "1"

--- a/tzrec/utils/fx_util.py
+++ b/tzrec/utils/fx_util.py
@@ -47,6 +47,18 @@ def symbolic_trace(
 
 
 @torch.fx.wrap
+def fx_get_label(
+    labels: Dict[str, torch.Tensor],
+    jagged_labels: Dict[str, JaggedTensor],
+    label_name: str,
+) -> torch.Tensor:
+    """Fx trace wrapper for reading a label that may be stored as a list column."""
+    if label_name in labels:
+        return labels[label_name]
+    return jagged_labels[label_name].values()
+
+
+@torch.fx.wrap
 def fx_arange(len: int, device: torch.device) -> torch.Tensor:
     """Fx trace wrapper for arange."""
     return torch.arange(len, device=device)


### PR DESCRIPTION
> **Stacked on #652 — merge that first.** This branch is cut from #652's head, so the diff below also
> contains its four commits. **Only the last two are this PR:**
> - `c56abe5d` `[bugfix] find the best checkpoint by step instead of rebuilding its name`
> - `82a7afed` `[feat] support a user-defined tag in the checkpoint name`
>
> Once #652 merges I will rebase onto master and the diff will shrink to those two.

## Summary

Let an external scheduler address a checkpoint by something other than the step.

- `CHECKPOINT_TAG` names checkpoints `model.ckpt-<tag>-<step>`
- the tag may contain `{data_ts}`, replaced by the event-time of the data the checkpoint covers
- fix `best_checkpoint`, which rebuilt a checkpoint's name from its step instead of looking it up

## Motivation

A scheduler often needs to find a checkpoint by the date of the data it covers, or by a run label. The
only ways today are to encode it in `--model_dir` or to rename the checkpoint directory — and renaming
breaks the step parsing that restore, pruning and best-export all depend on.

## Design

**The step stays last.** `_get_checkpoint_step` reads the last dash-separated token, so
`model.ckpt-<tag>-<step>` needs no parser change, sorting stays correct, and the tag may itself contain
dashes. Every consumer of the name was checked: the `latest_checkpoint` glob and sort, `_run_prune`,
and `_get_checkpoint_step` are all unaffected. Putting the tag *after* the step would break all of them.

**Configuration is an environment variable**, read in `CheckpointManager.__init__` via a new
`env_util.checkpoint_tag()` — so there is no proto field, no plumbing, and no change to `main.py`. It
also has to be rank-invariant, because the directory name is used by a collective write, and `torchrun`
propagates the environment to every rank.

**`{data_ts}` is taken from the quorum-reconciled watermark**, never the rank-local `data_timestamp`.
`maybe_save` already has the reconciled value in scope, so this is one optional argument rather than
new plumbing. Using the raw per-rank value would let ranks build divergent directory names on a
partitioned source, splitting a distributed checkpoint across directories. `{data_ts}` renders `0` on
sources with no event-time column.

**Tags that would break step parsing are rejected at startup.** A `.` in the tag silently yields step
`0`, because `_get_checkpoint_step` runs `os.path.splitext` first and a later dot stops `ext` matching
`.ckpt-`:

| tag | directory | parsed step |
|---|---|---|
| `20260828` | `model.ckpt-20260828-300` | 300 |
| `2026-08-28` | `model.ckpt-2026-08-28-300` | 300 |
| `v1.2` | `model.ckpt-v1.2-300` | **0** |

So the template is validated in `__init__` against `[A-Za-z0-9_-]` plus the literal `{data_ts}`. Since
that placeholder renders to digits, validating the template is sufficient and the failure is immediate
rather than at the first save. Loosening the parser instead was rejected: its `splitext` branch is
load-bearing for names carrying a trailing extension, and it is shared by restore, prune and export.

**`best_checkpoint`** read the best step from the eval-result file and then rebuilt
`model.ckpt-{step}`, which only works while every checkpoint is named exactly that. It now looks the
directory up by parsing each candidate's step — more robust even with no tag in play, and a
prerequisite for this feature.

## Test Plan

- `tzrec/utils/checkpoint_util_test.py` — naming with and without a tag; `{data_ts}` rendering and its
  `0` fallback; validation rejects `v1.2` / `1.4.0` / `a/b` / `a b` and accepts `20260828` /
  `2026-08-28` / `v1_2` / `d-{data_ts}`; `latest_checkpoint` orders a directory holding both tagged and
  untagged checkpoints; `_run_prune` keeps the newest N tagged plus the best; `best_checkpoint`
  resolves a tagged directory and errors when a metric step has no checkpoint. 72 tests pass.
- `tzrec/tests/custom_model_integration_test.py` — the existing two-rank train_eval → eval → export run
  now sets `CHECKPOINT_TAG` and asserts the tagged name, so this covers both that `torchrun` emits one
  directory (not one per rank) and that the restore path consumes it.
- `pre-commit run -a`, `pyrefly check` (0 errors)
- full unit test suite: running at the time of writing

## Caveat

The tag makes checkpoints **addressable, not sortable**. Ordering still comes from the step, which
restarts when a run warm-starts into a fresh `model_dir`, so "newest by step" remains meaningless
across date-partitioned directories. For "find the latest completed checkpoint", the `_SUCCESS` marker
plus mtime is the answer. Documented in `docs/source/usage/train.md`.
