### PR TITLE
[bugfix] bake config-order dense keys in distributed embedding export

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -492,12 +492,21 @@ def _resolve_keyed_tensor_source_module(
 
 
 def _get_embedding_bag_configs(module: torch.nn.Module) -> Optional[List[Any]]:
-    """Get EmbeddingBag configs from EBC or MC_EBC modules by duck typing."""
+    """Get EmbeddingBag configs from EBC or MC_EBC modules by duck typing.
+
+    Handles unsharded and sharded modules: torchrec's
+    ``ShardedEmbeddingBagCollection`` keeps the original-order configs only in
+    the private ``_embedding_bag_configs`` attribute, and (sharded) MC-EBC
+    modules nest their embedding module under ``_embedding_module``.
+    """
     if hasattr(module, "embedding_bag_configs"):
         return list(module.embedding_bag_configs())
+    configs = getattr(module, "_embedding_bag_configs", None)
+    if configs is not None:
+        return list(configs)
     inner = getattr(module, "_embedding_module", None)
-    if inner is not None and hasattr(inner, "embedding_bag_configs"):
-        return list(inner.embedding_bag_configs())
+    if inner is not None:
+        return _get_embedding_bag_configs(inner)
     return None
 
 
@@ -521,6 +530,67 @@ def _infer_keyed_tensor_attrs_from_module(
         keys.extend(embedding_names)
         length_per_key.extend([config.embedding_dim] * len(embedding_names))
     return keys, length_per_key
+
+
+def _canonicalize_keyed_tensor_attrs(
+    source_module: Optional[torch.nn.Module],
+    name: str,
+    runtime_keys: List[str],
+    runtime_length_per_key: List[int],
+) -> Tuple[List[str], List[int]]:
+    """Return canonical config-order keys/length_per_key for a marked KeyedTensor.
+
+    A sharded EmbeddingBagCollection emits its output KeyedTensor grouped by
+    sharding type / compute kernel, so the runtime key order depends on the
+    sharding plan (e.g. dynamicemb tables get regrouped to the tail). The
+    exported dense graph and dense_meta.json must instead use the
+    plan-independent config order that the online dense export derives
+    statically, otherwise the serving processor rejects hot dense updates
+    with dense_meta_mismatch.
+
+    Args:
+        source_module: embedding module that produced the KeyedTensor.
+        name: fx-marked KeyedTensor name, for diagnostics.
+        runtime_keys: keys captured from the sharded runtime output.
+        runtime_length_per_key: length_per_key captured from the runtime.
+
+    Returns:
+        Tuple of (keys, length_per_key) in canonical config order; falls back
+        to the runtime order when static inference is unsupported.
+    """
+    inferred = (
+        _infer_keyed_tensor_attrs_from_module(source_module)
+        if source_module is not None
+        else None
+    )
+    if inferred is None:
+        logger.warning(
+            f"cannot statically infer KeyedTensor attrs for [{name}]; falling "
+            "back to the sharded runtime key order, which may not match the "
+            "online dense export order."
+        )
+        return runtime_keys, runtime_length_per_key
+    keys, length_per_key = inferred
+    if sorted(zip(keys, length_per_key)) != sorted(
+        zip(runtime_keys, runtime_length_per_key)
+    ):
+        raise RuntimeError(
+            f"statically inferred KeyedTensor attrs for [{name}] disagree with "
+            f"the runtime output: inferred={list(zip(keys, length_per_key))} "
+            f"runtime={list(zip(runtime_keys, runtime_length_per_key))}"
+        )
+    return keys, length_per_key
+
+
+def _permute_keyed_tensor_values(
+    values: torch.Tensor,
+    src_keys: List[str],
+    src_length_per_key: List[int],
+    dst_keys: List[str],
+) -> torch.Tensor:
+    """Reorder pooled KeyedTensor values along dim 1 from src to dst key order."""
+    chunks = dict(zip(src_keys, torch.split(values, src_length_per_key, dim=1)))
+    return torch.cat([chunks[k] for k in dst_keys], dim=1)
 
 
 def _is_fx_node(value: Any) -> bool:
@@ -1613,17 +1683,34 @@ def export_distributed_embedding(
                     values_node = graph.call_method(
                         "tile", args=(getitem_node, tile_size_node, 1)
                     )
+                runtime_keys = cast(List[str], sparse_attrs[name + "__keys"])
+                runtime_length_per_key = cast(
+                    List[int], sparse_attrs[name + "__length_per_key"]
+                )
+                keys, length_per_key = _canonicalize_keyed_tensor_attrs(
+                    _resolve_keyed_tensor_source_module(unwrap_model, node_kt),
+                    name,
+                    runtime_keys,
+                    runtime_length_per_key,
+                )
+                if keys != runtime_keys:
+                    # keep the rank-zero smoke-run inputs aligned with the
+                    # canonical layout baked into the dense graph
+                    sparse_output[name] = _permute_keyed_tensor_values(
+                        sparse_output[name],
+                        runtime_keys,
+                        runtime_length_per_key,
+                        keys,
+                    )
                 new_node = graph.call_function(
                     KeyedTensor,
                     kwargs={
-                        "keys": sparse_attrs[name + "__keys"],
-                        "length_per_key": sparse_attrs[name + "__length_per_key"],
+                        "keys": keys,
+                        "length_per_key": length_per_key,
                         "values": values_node,
                     },
                 )
-                dense_graph_config[name] = [
-                    k + "__ebc" for k in cast(List[str], new_node.kwargs["keys"])
-                ]
+                dense_graph_config[name] = [k + "__ebc" for k in keys]
                 node_kt.replace_all_uses_with(new_node)
         elif node.op == "call_function" and node.target == fx_mark_seq_ec_jt:
             name = node.args[0]

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -595,6 +595,110 @@ def _permute_keyed_tensor_values(
     return torch.cat([chunks[k] for k in dst_keys], dim=1)
 
 
+def _rewrite_dense_serving_graph(
+    full_graph: torch.fx.Graph,
+    root: torch.nn.Module,
+    sparse_attrs: Dict[str, Any],
+    device: torch.device,
+) -> Tuple[torch.fx.GraphModule, Dict[str, Any]]:
+    """Rewrite a traced full graph into the serving-style dense graph module.
+
+    Replaces every fx-marked sparse KeyedTensor / sequence JaggedTensor with a
+    reconstruction from serving-fed input placeholders using the provided
+    keys/length_per_key attrs, prunes the now-unused embedding parameters, and
+    freshly initializes the module on ``device``; the caller loads the real
+    weights. Shared by the distributed-embedding export and the CPU dense
+    export so their dense graphs and dense_meta cannot drift apart.
+
+    Args:
+        full_graph: pre-surgery traced graph; deep-copied, not modified.
+        root: module owning the traced submodules and parameters.
+        sparse_attrs: ``<name>__keys`` / ``<name>__length_per_key`` attrs to
+            bake into the reconstructed KeyedTensor per marked name.
+        device: device the rewritten graph module lives on.
+
+    Returns:
+        Tuple of (gm, dense_graph_config): the rewritten dense graph module
+        and the dense_meta config mapping placeholder names to serving
+        embedding names.
+    """
+    graph = copy.deepcopy(full_graph)
+    output_keys = []
+    output_values = []
+    dense_graph_config = defaultdict()
+    for node in graph.nodes:
+        if node.op == "output":
+            for k, v in sorted(node.args[0].items()):
+                if k == TARGET_REPEAT_INTERLEAVE_KEY:
+                    continue
+                output_keys.append(k)
+                output_values.append(v)
+            graph.erase_node(node)
+    input_node = next(node for node in graph.nodes if node.op == "placeholder")
+
+    dense_graph_config["sequence__ec"] = []
+    for node in list(graph.nodes):
+        if node.op == "call_function" and node.target == fx_mark_keyed_tensor:
+            name = node.args[0]
+            if node.kwargs.get("is_dense", False):
+                continue
+            node_kt = node.args[1]
+            with graph.inserting_before(node_kt):
+                getitem_node = graph.call_function(
+                    operator.getitem, args=(input_node, name)
+                )
+                values_node = getitem_node
+                if _is_input_tile_user_keyed_tensor(name):
+                    batch_size_node = graph.call_function(
+                        operator.getitem, args=(input_node, "batch_size")
+                    )
+                    tile_size_node = graph.call_function(
+                        _tile_size, args=(batch_size_node,)
+                    )
+                    values_node = graph.call_method(
+                        "tile", args=(getitem_node, tile_size_node, 1)
+                    )
+                new_node = graph.call_function(
+                    KeyedTensor,
+                    kwargs={
+                        "keys": sparse_attrs[name + "__keys"],
+                        "length_per_key": sparse_attrs[name + "__length_per_key"],
+                        "values": values_node,
+                    },
+                )
+                dense_graph_config[name] = [
+                    k + "__ebc" for k in cast(List[str], new_node.kwargs["keys"])
+                ]
+                node_kt.replace_all_uses_with(new_node)
+        elif node.op == "call_function" and node.target == fx_mark_seq_ec_jt:
+            name = node.args[0]
+            node_jt = node.args[1]
+            with graph.inserting_before(node_jt):
+                getitem_node = graph.call_function(
+                    operator.getitem, args=(input_node, name)
+                )
+                getitem_lengths = graph.call_function(
+                    operator.getitem, args=(input_node, name + "__lengths")
+                )
+                new_node = graph.call_function(
+                    JaggedTensor,
+                    kwargs={"values": getitem_node, "lengths": getitem_lengths},
+                )
+            node_jt.replace_all_uses_with(new_node)
+            emb_name = name + "__ec"
+            dense_graph_config["sequence__ec"].append(emb_name)
+            dense_graph_config["sequence__ec"].append(name + "__lengths")
+
+    graph.output(dict(zip(output_keys, output_values)))
+    gm = torch.fx.GraphModule(root, graph)
+    gm.graph.eliminate_dead_code()
+    gm = _prune_unused_param_and_buffer(gm)
+
+    init_parameters(gm, device)
+    gm.to(device)
+    return gm, dense_graph_config
+
+
 def _is_fx_node(value: Any) -> bool:
     """Whether value is an FX node from the traced graph."""
     return getattr(value, "op", None) is not None and hasattr(value, "target")
@@ -1649,101 +1753,34 @@ def export_distributed_embedding(
 
     # Extract Dense Model
     logger.info("exporting dense model...")
-    graph = copy.deepcopy(full_graph)
-    output_keys = []
-    output_values = []
-    dense_graph_config = defaultdict()
-    for node in graph.nodes:
-        if node.op == "output":
-            for k, v in sorted(node.args[0].items()):
-                if k == TARGET_REPEAT_INTERLEAVE_KEY:
-                    continue
-                output_keys.append(k)
-                output_values.append(v)
-            graph.erase_node(node)
-    input_node = next(node for node in graph.nodes if node.op == "placeholder")
+    for node in full_graph.nodes:
+        if node.op != "call_function" or node.target != fx_mark_keyed_tensor:
+            continue
+        name = node.args[0]
+        if node.kwargs.get("is_dense", False):
+            continue
+        runtime_keys = cast(List[str], sparse_attrs[name + "__keys"])
+        runtime_length_per_key = cast(
+            List[int], sparse_attrs[name + "__length_per_key"]
+        )
+        keys, length_per_key = _canonicalize_keyed_tensor_attrs(
+            _resolve_keyed_tensor_source_module(unwrap_model, node.args[1]),
+            name,
+            runtime_keys,
+            runtime_length_per_key,
+        )
+        if keys != runtime_keys:
+            # keep the rank-zero smoke-run inputs aligned with the
+            # canonical layout baked into the dense graph
+            sparse_output[name] = _permute_keyed_tensor_values(
+                sparse_output[name], runtime_keys, runtime_length_per_key, keys
+            )
+        sparse_attrs[name + "__keys"] = keys
+        sparse_attrs[name + "__length_per_key"] = length_per_key
 
-    dense_graph_config["sequence__ec"] = []
-    for node in list(graph.nodes):
-        if node.op == "call_function" and node.target == fx_mark_keyed_tensor:
-            name = node.args[0]
-            if node.kwargs.get("is_dense", False):
-                continue
-            node_kt = node.args[1]
-            with graph.inserting_before(node_kt):
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(input_node, name)
-                )
-                values_node = getitem_node
-                if _is_input_tile_user_keyed_tensor(name):
-                    batch_size_node = graph.call_function(
-                        operator.getitem, args=(input_node, "batch_size")
-                    )
-                    tile_size_node = graph.call_function(
-                        _tile_size, args=(batch_size_node,)
-                    )
-                    values_node = graph.call_method(
-                        "tile", args=(getitem_node, tile_size_node, 1)
-                    )
-                runtime_keys = cast(List[str], sparse_attrs[name + "__keys"])
-                runtime_length_per_key = cast(
-                    List[int], sparse_attrs[name + "__length_per_key"]
-                )
-                keys, length_per_key = _canonicalize_keyed_tensor_attrs(
-                    _resolve_keyed_tensor_source_module(unwrap_model, node_kt),
-                    name,
-                    runtime_keys,
-                    runtime_length_per_key,
-                )
-                if keys != runtime_keys:
-                    # keep the rank-zero smoke-run inputs aligned with the
-                    # canonical layout baked into the dense graph
-                    sparse_output[name] = _permute_keyed_tensor_values(
-                        sparse_output[name],
-                        runtime_keys,
-                        runtime_length_per_key,
-                        keys,
-                    )
-                new_node = graph.call_function(
-                    KeyedTensor,
-                    kwargs={
-                        "keys": keys,
-                        "length_per_key": length_per_key,
-                        "values": values_node,
-                    },
-                )
-                dense_graph_config[name] = [k + "__ebc" for k in keys]
-                node_kt.replace_all_uses_with(new_node)
-        elif node.op == "call_function" and node.target == fx_mark_seq_ec_jt:
-            name = node.args[0]
-            node_jt = node.args[1]
-
-            with graph.inserting_before(node_jt):
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(input_node, name)
-                )
-                getitem_lengths = graph.call_function(
-                    operator.getitem, args=(input_node, name + "__lengths")
-                )
-                new_node = graph.call_function(
-                    JaggedTensor,
-                    kwargs={
-                        "values": getitem_node,
-                        "lengths": getitem_lengths,
-                    },
-                )
-            node_jt.replace_all_uses_with(new_node)
-            emb_name = name + "__ec"
-            dense_graph_config["sequence__ec"].append(emb_name)
-            dense_graph_config["sequence__ec"].append(name + "__lengths")
-
-    graph.output(dict(zip(output_keys, output_values)))
-    gm = torch.fx.GraphModule(unwrap_model, graph)
-    gm.graph.eliminate_dead_code()
-    gm = _prune_unused_param_and_buffer(gm)
-
-    init_parameters(gm, device)
-    gm.to(device)
+    gm, dense_graph_config = _rewrite_dense_serving_graph(
+        full_graph, unwrap_model, sparse_attrs, device
+    )
     checkpoint_util.restore_model(
         checkpoint_path,
         gm,
@@ -2106,80 +2143,9 @@ def build_dense_graph_module(
         sparse_attrs[name + "__length_per_key"] = length_per_key
 
     logger.info("exporting dense model on CPU...")
-    graph = copy.deepcopy(full_graph)
-    output_keys = []
-    output_values = []
-    dense_graph_config = defaultdict()
-    for node in graph.nodes:
-        if node.op == "output":
-            for k, v in sorted(node.args[0].items()):
-                if k == TARGET_REPEAT_INTERLEAVE_KEY:
-                    continue
-                output_keys.append(k)
-                output_values.append(v)
-            graph.erase_node(node)
-    input_node = next(node for node in graph.nodes if node.op == "placeholder")
-
-    dense_graph_config["sequence__ec"] = []
-    for node in list(graph.nodes):
-        if node.op == "call_function" and node.target == fx_mark_keyed_tensor:
-            name = node.args[0]
-            if node.kwargs.get("is_dense", False):
-                continue
-            node_kt = node.args[1]
-            with graph.inserting_before(node_kt):
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(input_node, name)
-                )
-                values_node = getitem_node
-                if _is_input_tile_user_keyed_tensor(name):
-                    batch_size_node = graph.call_function(
-                        operator.getitem, args=(input_node, "batch_size")
-                    )
-                    tile_size_node = graph.call_function(
-                        _tile_size, args=(batch_size_node,)
-                    )
-                    values_node = graph.call_method(
-                        "tile", args=(getitem_node, tile_size_node, 1)
-                    )
-                new_node = graph.call_function(
-                    KeyedTensor,
-                    kwargs={
-                        "keys": sparse_attrs[name + "__keys"],
-                        "length_per_key": sparse_attrs[name + "__length_per_key"],
-                        "values": values_node,
-                    },
-                )
-                dense_graph_config[name] = [
-                    k + "__ebc" for k in cast(List[str], new_node.kwargs["keys"])
-                ]
-                node_kt.replace_all_uses_with(new_node)
-        elif node.op == "call_function" and node.target == fx_mark_seq_ec_jt:
-            name = node.args[0]
-            node_jt = node.args[1]
-            with graph.inserting_before(node_jt):
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(input_node, name)
-                )
-                getitem_lengths = graph.call_function(
-                    operator.getitem, args=(input_node, name + "__lengths")
-                )
-                new_node = graph.call_function(
-                    JaggedTensor,
-                    kwargs={"values": getitem_node, "lengths": getitem_lengths},
-                )
-            node_jt.replace_all_uses_with(new_node)
-            emb_name = name + "__ec"
-            dense_graph_config["sequence__ec"].append(emb_name)
-            dense_graph_config["sequence__ec"].append(name + "__lengths")
-
-    graph.output(dict(zip(output_keys, output_values)))
-    gm = torch.fx.GraphModule(model, graph)
-    gm.graph.eliminate_dead_code()
-    gm = _prune_unused_param_and_buffer(gm)
-
-    init_parameters(gm, device)
-    gm.to(device)
+    gm, dense_graph_config = _rewrite_dense_serving_graph(
+        full_graph, model, sparse_attrs, device
+    )
     return gm, full_graph, dense_graph_config
 
 

--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -555,8 +555,11 @@ def _canonicalize_keyed_tensor_attrs(
         runtime_length_per_key: length_per_key captured from the runtime.
 
     Returns:
-        Tuple of (keys, length_per_key) in canonical config order; falls back
-        to the runtime order when static inference is unsupported.
+        Tuple of (keys, length_per_key) in canonical config order.
+
+    Raises:
+        RuntimeError: if static inference is unsupported for the source
+            module, or the inferred attrs disagree with the runtime output.
     """
     inferred = (
         _infer_keyed_tensor_attrs_from_module(source_module)
@@ -564,12 +567,11 @@ def _canonicalize_keyed_tensor_attrs(
         else None
     )
     if inferred is None:
-        logger.warning(
-            f"cannot statically infer KeyedTensor attrs for [{name}]; falling "
-            "back to the sharded runtime key order, which may not match the "
-            "online dense export order."
+        raise RuntimeError(
+            f"cannot statically infer KeyedTensor attrs for [{name}]; the "
+            "dense export must not bake the plan-dependent sharded runtime "
+            "key order, which would mismatch the online dense export."
         )
-        return runtime_keys, runtime_length_per_key
     keys, length_per_key = inferred
     if sorted(zip(keys, length_per_key)) != sorted(
         zip(runtime_keys, runtime_length_per_key)

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from torch import distributed as dist
 from torchrec import KeyedJaggedTensor, KeyedTensor
+from torchrec.distributed.model_parallel import ShardedModule
 from torchrec.distributed.train_pipeline.utils import Tracer
 from torchrec.modules.embedding_configs import (
     EmbeddingBagConfig,
@@ -59,12 +60,15 @@ from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.utils import checkpoint_util, config_util, export_util, misc_util
 from tzrec.utils.export_util import (
     _add_module_by_dotted_path,
+    _canonicalize_keyed_tensor_attrs,
     _dedup_key_files_by_realpath,
     _get_dense_embedding_leaf_module_names,
+    _get_embedding_bag_configs,
     _get_sparse_embedding_tensor,
     _infer_keyed_tensor_attrs_from_module,
     _isolate_kafka_export_group,
     _merge_sharded_embedding_json,
+    _permute_keyed_tensor_values,
     _prepare_single_rank_distributed_embedding_export,
     _prune_unused_param_and_buffer,
     _shrink_sparse_embedding_tables,
@@ -74,8 +78,13 @@ from tzrec.utils.export_util import (
     export_distributed_embedding,
     finalize_dense_export,
 )
+from tzrec.utils.fx_util import fx_mark_keyed_tensor
 from tzrec.utils.state_dict_util import init_parameters
 from tzrec.utils.test_util import make_test_dir
+
+# register the mark for fx tracing from this module's call sites, as
+# tzrec/modules/embedding.py does for its own
+torch.fx.wrap(fx_mark_keyed_tensor)
 
 
 def _restore_env(old_env):
@@ -459,6 +468,226 @@ class ExportUtilTest(unittest.TestCase):
             )
             exported_feature_store_config = exported_dump_config.feature_store_config
             self.assertEqual(exported_feature_store_config.project_name, "project_a")
+        finally:
+            _restore_env(old_env)
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_distributed_embedding_export_bakes_config_order_keyed_tensor(
+        self,
+    ) -> None:
+        """The dense export must bake config-order keys, not sharded runtime order.
+
+        A sharded EBC emits its KeyedTensor grouped by sharding type / compute
+        kernel (e.g. dynamicemb tables move to the tail), while the online
+        dense export derives keys statically in config order; baking the
+        runtime order makes the serving processor reject every hot dense
+        update with dense_meta_mismatch. The fake sharded EBC below outputs
+        keys rotated to (f_b, f_c, f_a) whereas its ``_embedding_bag_configs``
+        order is (f_a, f_b, f_c).
+        """
+        tables = [
+            EmbeddingBagConfig(
+                name="t_a", embedding_dim=4, num_embeddings=10, feature_names=["f_a"]
+            ),
+            EmbeddingBagConfig(
+                name="t_b", embedding_dim=8, num_embeddings=10, feature_names=["f_b"]
+            ),
+            EmbeddingBagConfig(
+                name="t_c", embedding_dim=4, num_embeddings=10, feature_names=["f_c"]
+            ),
+        ]
+
+        class FakeShardedEBC(ShardedModule):
+            def __init__(self, tables):  # type: ignore[no-untyped-def]
+                super().__init__()
+                self._embedding_bag_configs = tables
+
+            def forward(self, features):  # type: ignore[no-untyped-def]
+                batch_size = features.size(0)
+                values = torch.cat(
+                    [
+                        torch.full((batch_size, 8), 2.0),
+                        torch.full((batch_size, 4), 3.0),
+                        torch.full((batch_size, 4), 1.0),
+                    ],
+                    dim=1,
+                )
+                return KeyedTensor(
+                    keys=["f_b", "f_c", "f_a"],
+                    length_per_key=[8, 4, 4],
+                    values=values,
+                )
+
+            def create_context(self):  # type: ignore[no-untyped-def]
+                return None
+
+            def input_dist(self, ctx, *inputs, **kwargs):  # type: ignore[no-untyped-def]
+                raise NotImplementedError
+
+            def compute(self, ctx, dist_input):  # type: ignore[no-untyped-def]
+                raise NotImplementedError
+
+            def output_dist(self, ctx, output):  # type: ignore[no-untyped-def]
+                raise NotImplementedError
+
+            @property
+            def unsharded_module_type(self):  # type: ignore[no-untyped-def]
+                return EmbeddingBagCollection
+
+        class TinyModel(torch.nn.Module):
+            def __init__(self):  # type: ignore[no-untyped-def]
+                super().__init__()
+                self.features = []
+                self.ebc = FakeShardedEBC(tables)
+
+            def set_is_inference(self, is_inference):  # type: ignore[no-untyped-def]
+                self.is_inference = is_inference
+
+            def forward(self, data, device=None):  # type: ignore[no-untyped-def]
+                kt = self.ebc(data["x"])
+                fx_mark_keyed_tensor("grp__ebc", kt)
+                grouped = KeyedTensor.regroup_as_dict(
+                    [kt], [["f_a"], ["f_b", "f_c"]], ["y_a", "y_bc"]
+                )
+                return {
+                    "y_a": grouped["y_a"].sum(dim=1),
+                    "y_bc": grouped["y_bc"].sum(dim=1),
+                }
+
+        # the same dict flows through warm-up, sparse run and the dense
+        # smoke run, so it exposes the permuted smoke-run input afterwards
+        data = {"x": torch.ones(2, 3)}
+
+        class FakeBatch:
+            def to(self, device):  # type: ignore[no-untyped-def]
+                return self
+
+            def to_dict(self, sparse_dtype):  # type: ignore[no-untyped-def]
+                return data
+
+        class FakeDataloader:
+            dataset = SimpleNamespace(sampled_batch_size=2)
+
+            def __iter__(self):  # type: ignore[no-untyped-def]
+                return iter([FakeBatch()])
+
+        class FakeDMP(torch.nn.Module):
+            def __init__(self, module, *args, **kwargs):  # type: ignore[no-untyped-def]
+                super().__init__()
+                self.module = module
+
+            def forward(self, data, device=None):  # type: ignore[no-untyped-def]
+                return self.module(data, device=device)
+
+        tmp = make_test_dir()
+        old_env = {
+            key: os.environ.get(key)
+            for key in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "LOCAL_WORLD_SIZE")
+        }
+        try:
+            os.environ["RANK"] = "0"
+            os.environ["LOCAL_RANK"] = "0"
+            os.environ["WORLD_SIZE"] = "1"
+            os.environ["LOCAL_WORLD_SIZE"] = "1"
+            pipeline_config = EasyRecConfig(
+                train_input_path="train_input",
+                eval_input_path="eval_input",
+                model_dir="model_dir",
+            )
+            captured = {}
+
+            def _capture_symbolic_trace(gm):  # type: ignore[no-untyped-def]
+                captured["gm"] = gm
+                return SimpleNamespace(code="def forward(self):\n    pass\n")
+
+            with (
+                mock.patch(
+                    "tzrec.utils.export_util.init_process_group",
+                    return_value=(torch.device("cpu"), None),
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util._get_sparse_table_to_embedding_info",
+                    return_value=({}, {}),
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.create_dataloader",
+                    return_value=FakeDataloader(),
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.create_planner",
+                    return_value=SimpleNamespace(collective_plan=lambda *args: None),
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.get_default_sharders", return_value=[]
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.DistributedModelParallel",
+                    side_effect=lambda *args, **kwargs: FakeDMP(kwargs["module"]),
+                ),
+                mock.patch("tzrec.utils.export_util.checkpoint_util.restore_model"),
+                mock.patch("tzrec.utils.export_util.init_parameters"),
+                mock.patch(
+                    "tzrec.utils.export_util._get_sparse_embedding_tensor",
+                    return_value=({}, {}, {}, {}),
+                ),
+                mock.patch("tzrec.utils.export_util.config_util.save_message"),
+                mock.patch(
+                    "tzrec.utils.export_util.create_fg_json",
+                    return_value={"features": []},
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.symbolic_trace",
+                    side_effect=_capture_symbolic_trace,
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.torch.jit.script",
+                    return_value=mock.Mock(),
+                ),
+                mock.patch(
+                    "tzrec.utils.export_util.acc_utils.export_acc_config",
+                    return_value={},
+                ),
+            ):
+                export_distributed_embedding(
+                    pipeline_config, TinyModel(), "checkpoint_dir", tmp
+                )
+
+            # dense_meta.json lists the marked group in config order
+            with open(os.path.join(tmp, "dense_meta.json")) as f:
+                dense_meta = json.load(f)
+            self.assertEqual(
+                dense_meta["grp__ebc"], ["f_a__ebc", "f_b__ebc", "f_c__ebc"]
+            )
+            self.assertEqual(dense_meta["sequence__ec"], [])
+
+            # the dense graph bakes the canonical keys/length_per_key
+            gm = captured["gm"]
+            kt_nodes = [
+                node
+                for node in gm.graph.nodes
+                if node.op == "call_function" and node.target is KeyedTensor
+            ]
+            self.assertEqual(len(kt_nodes), 1)
+            self.assertEqual(kt_nodes[0].kwargs["keys"], ["f_a", "f_b", "f_c"])
+            self.assertEqual(kt_nodes[0].kwargs["length_per_key"], [4, 8, 4])
+
+            # the smoke-run input was permuted from the runtime layout
+            # (f_b=2.0 x8, f_c=3.0 x4, f_a=1.0 x4) to the canonical layout
+            canonical_values = torch.cat(
+                [
+                    torch.full((2, 4), 1.0),
+                    torch.full((2, 8), 2.0),
+                    torch.full((2, 4), 3.0),
+                ],
+                dim=1,
+            )
+            torch.testing.assert_close(data["grp__ebc"], canonical_values)
+
+            # the exported dense graph regroups a canonical-layout input by
+            # key name into the right slices
+            out = gm({"grp__ebc": canonical_values.clone()}, torch.device("cpu"))
+            torch.testing.assert_close(out["y_a"], torch.full((2,), 4.0))
+            torch.testing.assert_close(out["y_bc"], torch.full((2,), 28.0))
         finally:
             _restore_env(old_env)
             shutil.rmtree(tmp, ignore_errors=True)
@@ -1377,6 +1606,91 @@ class ExportUtilTest(unittest.TestCase):
         self.assertEqual(
             _infer_keyed_tensor_attrs_from_module(mc_like), (keys, length_per_key)
         )
+
+    def test_get_embedding_bag_configs_reads_private_and_nested_attrs(self) -> None:
+        """Sharded modules expose configs only via private attributes.
+
+        ``ShardedEmbeddingBagCollection`` keeps the original-order configs in
+        ``_embedding_bag_configs`` without a public accessor, and sharded
+        MC-EBC modules nest that holder under ``_embedding_module``.
+        """
+        configs = [
+            EmbeddingBagConfig(
+                name="t_a", embedding_dim=4, num_embeddings=10, feature_names=["f_a"]
+            ),
+            EmbeddingBagConfig(
+                name="t_b", embedding_dim=8, num_embeddings=10, feature_names=["f_b"]
+            ),
+        ]
+
+        sharded_ebc_like = SimpleNamespace(_embedding_bag_configs=configs)
+        self.assertEqual(_get_embedding_bag_configs(sharded_ebc_like), configs)
+
+        sharded_mc_ebc_like = SimpleNamespace(
+            _embedding_module=SimpleNamespace(_embedding_bag_configs=configs)
+        )
+        self.assertEqual(_get_embedding_bag_configs(sharded_mc_ebc_like), configs)
+
+        ebc = EmbeddingBagCollection(tables=configs, device=torch.device("cpu"))
+        self.assertEqual(_get_embedding_bag_configs(ebc), configs)
+
+        self.assertIsNone(_get_embedding_bag_configs(torch.nn.Module()))
+
+    def _make_canonicalize_test_ebc(self) -> EmbeddingBagCollection:
+        tables = [
+            EmbeddingBagConfig(
+                name="t_a", embedding_dim=4, num_embeddings=10, feature_names=["f_a"]
+            ),
+            EmbeddingBagConfig(
+                name="t_b", embedding_dim=8, num_embeddings=10, feature_names=["f_b"]
+            ),
+            EmbeddingBagConfig(
+                name="t_c", embedding_dim=4, num_embeddings=10, feature_names=["f_c"]
+            ),
+        ]
+        return EmbeddingBagCollection(tables=tables, device=torch.device("cpu"))
+
+    def test_canonicalize_keyed_tensor_attrs_returns_config_order(self) -> None:
+        """Sharding-plan-dependent runtime key order maps back to config order."""
+        ebc = self._make_canonicalize_test_ebc()
+        keys, length_per_key = _canonicalize_keyed_tensor_attrs(
+            ebc, "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 4]
+        )
+        self.assertEqual(keys, ["f_a", "f_b", "f_c"])
+        self.assertEqual(length_per_key, [4, 8, 4])
+
+    def test_canonicalize_keyed_tensor_attrs_rejects_runtime_mismatch(self) -> None:
+        ebc = self._make_canonicalize_test_ebc()
+        # a runtime dim that disagrees with the config
+        with self.assertRaisesRegex(RuntimeError, "disagree"):
+            _canonicalize_keyed_tensor_attrs(
+                ebc, "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 8]
+            )
+        # a renamed runtime key
+        with self.assertRaisesRegex(RuntimeError, "disagree"):
+            _canonicalize_keyed_tensor_attrs(
+                ebc, "grp__ebc", ["f_b", "f_c", "f_x"], [8, 4, 4]
+            )
+        # a missing runtime key
+        with self.assertRaisesRegex(RuntimeError, "disagree"):
+            _canonicalize_keyed_tensor_attrs(ebc, "grp__ebc", ["f_b", "f_c"], [8, 4])
+
+    def test_canonicalize_keyed_tensor_attrs_falls_back_without_module(self) -> None:
+        keys, length_per_key = _canonicalize_keyed_tensor_attrs(
+            None, "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 4]
+        )
+        self.assertEqual(keys, ["f_b", "f_c", "f_a"])
+        self.assertEqual(length_per_key, [8, 4, 4])
+
+    def test_permute_keyed_tensor_values_reorders_dim1_blocks(self) -> None:
+        values = torch.arange(2 * 16, dtype=torch.float32).reshape(2, 16)
+        permuted = _permute_keyed_tensor_values(
+            values, ["f_b", "f_c", "f_a"], [8, 4, 4], ["f_a", "f_b", "f_c"]
+        )
+        # src layout: f_b = cols 0:8, f_c = cols 8:12, f_a = cols 12:16
+        expected = torch.cat([values[:, 12:16], values[:, 0:8], values[:, 8:12]], dim=1)
+        self.assertEqual(permuted.shape, values.shape)
+        torch.testing.assert_close(permuted, expected)
 
     def test_isolate_kafka_export_group_swaps_group_id(self) -> None:
         """Isolate the export Kafka consumer from the live training group."""

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -483,7 +483,10 @@ class ExportUtilTest(unittest.TestCase):
         runtime order makes the serving processor reject every hot dense
         update with dense_meta_mismatch. The fake sharded EBC below outputs
         keys rotated to (f_b, f_c, f_a) whereas its ``_embedding_bag_configs``
-        order is (f_a, f_b, f_c).
+        order is (f_a, f_b, f_c). The INPUT_TILE=3 user side is also covered:
+        its marked KeyedTensor carries kwargs-sourced keys and tiled values,
+        while the sparse extraction captures the raw batch=1 values, so the
+        smoke-run permute must handle the pre-tile layout.
         """
         tables = [
             EmbeddingBagConfig(
@@ -496,25 +499,40 @@ class ExportUtilTest(unittest.TestCase):
                 name="t_c", embedding_dim=4, num_embeddings=10, feature_names=["f_c"]
             ),
         ]
+        user_tables = [
+            EmbeddingBagConfig(
+                name="t_ua", embedding_dim=4, num_embeddings=10, feature_names=["u_a"]
+            ),
+            EmbeddingBagConfig(
+                name="t_ub", embedding_dim=8, num_embeddings=10, feature_names=["u_b"]
+            ),
+        ]
 
         class FakeShardedEBC(ShardedModule):
-            def __init__(self, tables):  # type: ignore[no-untyped-def]
+            def __init__(self, tables, keys, fills):  # type: ignore[no-untyped-def]
                 super().__init__()
                 self._embedding_bag_configs = tables
+                dims = {
+                    f: cfg.embedding_dim for cfg in tables for f in cfg.feature_names
+                }
+                self._runtime_keys = keys
+                self._runtime_length_per_key = [dims[k] for k in keys]
+                self._runtime_fills = fills
 
             def forward(self, features):  # type: ignore[no-untyped-def]
                 batch_size = features.size(0)
                 values = torch.cat(
                     [
-                        torch.full((batch_size, 8), 2.0),
-                        torch.full((batch_size, 4), 3.0),
-                        torch.full((batch_size, 4), 1.0),
+                        torch.full((batch_size, dim), fill)
+                        for dim, fill in zip(
+                            self._runtime_length_per_key, self._runtime_fills
+                        )
                     ],
                     dim=1,
                 )
                 return KeyedTensor(
-                    keys=["f_b", "f_c", "f_a"],
-                    length_per_key=[8, 4, 4],
+                    keys=self._runtime_keys,
+                    length_per_key=self._runtime_length_per_key,
                     values=values,
                 )
 
@@ -538,7 +556,10 @@ class ExportUtilTest(unittest.TestCase):
             def __init__(self):  # type: ignore[no-untyped-def]
                 super().__init__()
                 self.features = []
-                self.ebc = FakeShardedEBC(tables)
+                self.ebc = FakeShardedEBC(
+                    tables, ["f_b", "f_c", "f_a"], [2.0, 3.0, 1.0]
+                )
+                self.ebc_user = FakeShardedEBC(user_tables, ["u_b", "u_a"], [5.0, 4.0])
 
             def set_is_inference(self, is_inference):  # type: ignore[no-untyped-def]
                 self.is_inference = is_inference
@@ -546,17 +567,33 @@ class ExportUtilTest(unittest.TestCase):
             def forward(self, data, device=None):  # type: ignore[no-untyped-def]
                 kt = self.ebc(data["x"])
                 fx_mark_keyed_tensor("grp__ebc", kt)
+                # mirror EmbeddingGroupImpl's INPUT_TILE=3 user side: raw
+                # batch=1 lookup, kwargs from the raw KT, tiled values
+                kt_user_raw = self.ebc_user(data["x_user"])
+                kt_user = KeyedTensor(
+                    keys=kt_user_raw.keys(),
+                    length_per_key=kt_user_raw.length_per_key(),
+                    values=kt_user_raw.values().tile(2, 1),
+                )
+                fx_mark_keyed_tensor("grp__ebc_user", kt_user)
                 grouped = KeyedTensor.regroup_as_dict(
-                    [kt], [["f_a"], ["f_b", "f_c"]], ["y_a", "y_bc"]
+                    [kt, kt_user],
+                    [["f_a"], ["f_b", "f_c"], ["u_a", "u_b"]],
+                    ["y_a", "y_bc", "y_u"],
                 )
                 return {
                     "y_a": grouped["y_a"].sum(dim=1),
                     "y_bc": grouped["y_bc"].sum(dim=1),
+                    "y_u": grouped["y_u"].sum(dim=1),
                 }
 
         # the same dict flows through warm-up, sparse run and the dense
-        # smoke run, so it exposes the permuted smoke-run input afterwards
-        data = {"x": torch.ones(2, 3)}
+        # smoke run, so it exposes the permuted smoke-run inputs afterwards
+        data = {
+            "x": torch.ones(2, 3),
+            "x_user": torch.ones(1, 3),
+            "batch_size": torch.tensor(2),
+        }
 
         class FakeBatch:
             def to(self, device):  # type: ignore[no-untyped-def]
@@ -658,18 +695,25 @@ class ExportUtilTest(unittest.TestCase):
             self.assertEqual(
                 dense_meta["grp__ebc"], ["f_a__ebc", "f_b__ebc", "f_c__ebc"]
             )
+            self.assertEqual(dense_meta["grp__ebc_user"], ["u_a__ebc", "u_b__ebc"])
             self.assertEqual(dense_meta["sequence__ec"], [])
 
             # the dense graph bakes the canonical keys/length_per_key
             gm = captured["gm"]
-            kt_nodes = [
-                node
+            kt_nodes = {
+                tuple(node.kwargs["keys"]): node
                 for node in gm.graph.nodes
                 if node.op == "call_function" and node.target is KeyedTensor
-            ]
-            self.assertEqual(len(kt_nodes), 1)
-            self.assertEqual(kt_nodes[0].kwargs["keys"], ["f_a", "f_b", "f_c"])
-            self.assertEqual(kt_nodes[0].kwargs["length_per_key"], [4, 8, 4])
+            }
+            self.assertEqual(len(kt_nodes), 2)
+            self.assertEqual(
+                kt_nodes[("f_a", "f_b", "f_c")].kwargs["length_per_key"], [4, 8, 4]
+            )
+            user_node = kt_nodes[("u_a", "u_b")]
+            self.assertEqual(user_node.kwargs["length_per_key"], [4, 8])
+            # the user-side reconstruction tiles the raw batch=1 values itself
+            self.assertEqual(user_node.kwargs["values"].op, "call_method")
+            self.assertEqual(user_node.kwargs["values"].target, "tile")
 
             # the smoke-run input was permuted from the runtime layout
             # (f_b=2.0 x8, f_c=3.0 x4, f_a=1.0 x4) to the canonical layout
@@ -682,12 +726,26 @@ class ExportUtilTest(unittest.TestCase):
                 dim=1,
             )
             torch.testing.assert_close(data["grp__ebc"], canonical_values)
+            # the raw batch=1 user values were permuted pre-tile from
+            # (u_b=5.0 x8, u_a=4.0 x4) to the canonical (u_a, u_b) layout
+            canonical_user_values = torch.cat(
+                [torch.full((1, 4), 4.0), torch.full((1, 8), 5.0)], dim=1
+            )
+            torch.testing.assert_close(data["grp__ebc_user"], canonical_user_values)
 
-            # the exported dense graph regroups a canonical-layout input by
-            # key name into the right slices
-            out = gm({"grp__ebc": canonical_values.clone()}, torch.device("cpu"))
+            # the exported dense graph regroups canonical-layout inputs by
+            # key name into the right slices, tiling the user side itself
+            out = gm(
+                {
+                    "grp__ebc": canonical_values.clone(),
+                    "grp__ebc_user": canonical_user_values.clone(),
+                    "batch_size": torch.tensor(2),
+                },
+                torch.device("cpu"),
+            )
             torch.testing.assert_close(out["y_a"], torch.full((2,), 4.0))
             torch.testing.assert_close(out["y_bc"], torch.full((2,), 28.0))
+            torch.testing.assert_close(out["y_u"], torch.full((2,), 56.0))
         finally:
             _restore_env(old_env)
             shutil.rmtree(tmp, ignore_errors=True)

--- a/tzrec/utils/export_util_test.py
+++ b/tzrec/utils/export_util_test.py
@@ -1675,12 +1675,16 @@ class ExportUtilTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "disagree"):
             _canonicalize_keyed_tensor_attrs(ebc, "grp__ebc", ["f_b", "f_c"], [8, 4])
 
-    def test_canonicalize_keyed_tensor_attrs_falls_back_without_module(self) -> None:
-        keys, length_per_key = _canonicalize_keyed_tensor_attrs(
-            None, "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 4]
-        )
-        self.assertEqual(keys, ["f_b", "f_c", "f_a"])
-        self.assertEqual(length_per_key, [8, 4, 4])
+    def test_canonicalize_keyed_tensor_attrs_raises_without_module(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "statically infer"):
+            _canonicalize_keyed_tensor_attrs(
+                None, "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 4]
+            )
+        # a resolved module without embedding bag configs must also fail fast
+        with self.assertRaisesRegex(RuntimeError, "statically infer"):
+            _canonicalize_keyed_tensor_attrs(
+                torch.nn.Linear(2, 2), "grp__ebc", ["f_b", "f_c", "f_a"], [8, 4, 4]
+            )
 
     def test_permute_keyed_tensor_values_reorders_dim1_blocks(self) -> None:
         values = torch.arange(2 * 16, dtype=torch.float32).reshape(2, 16)


### PR DESCRIPTION
## Summary

`export_distributed_embedding` baked the fused EmbeddingBagCollection `keys` / `length_per_key` into the exported dense graph and `dense_meta.json` from the sharded runtime KeyedTensor. torchrec's sharded EBC emits its output keys grouped by sharding type / compute kernel, so the order depends on the sharding plan — e.g. dynamicemb tables form their own group and move to the tail. The online dense export instead derives keys statically from the unsharded module configs (feature-group config order). With any dynamicemb table not already at the tail of the config, the base and hot `dense_meta.json` list the same features in different orders, and the serving processor's ordered `DenseMetaEquals` check permanently blacklists every hot dense update with `dense_meta_mismatch` (observed in a production online-learning deployment).

Fix:

- The distributed export now canonicalizes each marked KeyedTensor to the plan-independent config order using the same static inference as the online/CPU dense export (`_infer_keyed_tensor_attrs_from_module`); `_get_embedding_bag_configs` learns to resolve sharded EBC / MC-EBC modules through their original-order `_embedding_bag_configs`.
- Canonical attrs are validated against the runtime output ((key, dim) multisets must match), and the rank-zero smoke-run inputs are permuted to the canonical layout. When static inference is unsupported the export fails fast, mirroring the CPU path, instead of silently baking the plan-dependent order.
- The previously duplicated dense graph surgery of the distributed and CPU export paths is now one shared `_rewrite_dense_serving_graph` helper, so the two paths cannot drift apart again.

This is safe for serving because the dense graph consumes the reconstructed KeyedTensor only through `KeyedTensor.regroup_as_dict`, which regroups by key name at runtime (verified on exported `gm_dense.code` artifacts).

Alternative considered: relaxing the processor-side ordered comparison and rewiring embeddings by name on hot swap. Rejected for now — it requires per-version input-assembly state in the serving processor, while canonicalizing the exporter also removes the export's hidden dependency on GPU count / sharding plan.

Migration: re-run the full export from the same checkpoint with this build and restart the serving processor once; subsequent online dense hot versions then validate against the new base.

## Test plan

- New unit tests in `tzrec/utils/export_util_test.py`:
  - `_get_embedding_bag_configs` on sharded-shaped modules (private `_embedding_bag_configs`, nested `_embedding_module`) and on a real EBC.
  - `_canonicalize_keyed_tensor_attrs`: rotated runtime order maps back to config order; RuntimeError on dim-mismatched / renamed / missing keys and on uninferable modules.
  - `_permute_keyed_tensor_values`: exact dim-1 block reorder.
  - End-to-end regression driving `export_distributed_embedding` with fake sharded EBCs whose runtime KeyedTensor order differs from config order, covering both the plain `__ebc` and the INPUT_TILE=3 `__ebc_user` (kwargs-sourced keys, pre-tile batch=1 smoke values, re-tiled reconstruction); asserts canonical `dense_meta.json`, canonical baked kwargs, permuted smoke inputs, and correct regrouped outputs of the exported graph.
- `tzrec.utils.export_util_test` (30 tests) and `tzrec.utils.online_dense_export_util_test` (28 tests) pass in the tzrec-devel container (torch 2.12.1+cu129).
- `pre-commit run` (ruff lint/format, codespell, etc.) clean on the changed files; `pyrefly` was unavailable locally, relying on CI for the type gate.