### PR TITLE
[bugfix] narrow the fx node name to str in dense graph rewrite

### DIFF
--- a/tzrec/utils/export_util.py
+++ b/tzrec/utils/export_util.py
@@ -639,7 +639,7 @@ def _rewrite_dense_serving_graph(
     dense_graph_config["sequence__ec"] = []
     for node in list(graph.nodes):
         if node.op == "call_function" and node.target == fx_mark_keyed_tensor:
-            name = node.args[0]
+            name = cast(str, node.args[0])
             if node.kwargs.get("is_dense", False):
                 continue
             node_kt = node.args[1]


### PR DESCRIPTION
## Problem

`pyrefly check` fails on master with two errors, both introduced by #654:

```
ERROR Cannot index into `dict[str, Any]` [bad-index]
   --> tzrec/utils/export_util.py:664:46
ERROR Cannot index into `dict[str, Any]` [bad-index]
   --> tzrec/utils/export_util.py:665:56
```

`_rewrite_dense_serving_graph` reads the marker name out of an fx node with `node.args[0]`. That is typed as the broad fx `Argument` union (`SymInt | Tensor | complex | float | int | str | ...`), so `name + "__keys"` carries the same union and is not a valid key for `sparse_attrs: Dict[str, Any]`.

## Fix

`fx_mark_keyed_tensor` declares the argument as `name: str` (`tzrec/utils/fx_util.py:97`), so the value really is a `str` at runtime — the checker just cannot see through `Node.args`. Cast the read to `str`, the same narrowing the surrounding code already applies to `new_node.kwargs["keys"]` a few lines below.

`typing.cast` is a no-op at runtime, so there is no behavior change. Only the one branch that indexes `sparse_attrs` is touched; the other `name = node.args[0]` reads in the file do not feed a `Dict[str, Any]` lookup and are left alone.

## Test Plan

- `pyrefly check` goes from 2 errors to 0 across the repo.
- `tzrec.utils.export_util_test` passes (30 tests) in a torch 2.13.0 / torchrec 1.8.0 environment matching master's declared versions.
- `pre-commit run --files tzrec/utils/export_util.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANBJGHmETnZXK4CwqD8Uhr
