### PR TITLE
[ci] make the claude review tool allowlist binding and raise its timeout

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -68,10 +68,13 @@
 # If auth goes stale, re-run `codex login --device-auth` on the runner.
 # If the runner lacks direct OpenAI egress, set HTTPS_PROXY for the runner service.
 #
-# Trust model: the collaborator-added label gates every run (review before labeling).
-# Model commands run in a no-network sandbox; only the gh pr view/diff/comment
-# allowlist (scripts/ci/codex_review.rules) runs outside it — as with the claude
-# job's --allowedTools, a PR comment is the only exfil path for injected content.
+# Trust model: the collaborator-added label gates every run (review before labeling);
+# adding a label needs triage permission, so non-collaborators cannot trigger either job.
+# Codex confines model commands to a no-network sandbox, with only the gh pr
+# view/diff/comment allowlist (scripts/ci/codex_review.rules) running outside it. The
+# claude job reaches the same allowlist via --permission-mode manual, which is what makes
+# --allowedTools binding. A PR comment is the only exfil path out of either job, and
+# --add-dir / leaves everything readable on the runner reachable from that path.
 # ---- End Codex Setup ----
 
 name: Code Review
@@ -89,7 +92,7 @@ jobs:
   review:
     if: github.event.label.name == 'claude-review'
     runs-on: tzrec-codereview-runner
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -145,9 +148,14 @@ jobs:
 
           MCP_CONFIG="{\"mcpServers\":{\"github_inline_comment\":{\"command\":\"${BUN_PATH}\",\"args\":[\"run\",\"/opt/claude-code-action/src/mcp/github-inline-comment-server.ts\"]}}}"
 
+          # --permission-mode manual makes --allowedTools binding; without it the
+          # runner's stored settings apply and every Bash command is permitted.
+          # --add-dir / keeps the cross-repo reads the reviewers depend on.
           claude -p \
             --output-format stream-json \
             --verbose \
+            --permission-mode manual \
+            --add-dir / \
             --settings '{"disableRemoteControl": true}' \
             --mcp-config "$MCP_CONFIG" \
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent" \


### PR DESCRIPTION
## Summary

The `review` job passed `--allowedTools "…,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent"` on the assumption that it confined the session to those tools. It did not. `--allowedTools` is additive — it grants permissions, it does not revoke the rest — and unmatched calls fall through to the session's permission mode, which came from the runner's stored settings (`defaultMode: bypassPermissions`). Every Bash command the model produced ran unconditionally.

In the last review run, all 36 Bash calls succeeded, including `grep -rn`, `sed -n`, `python -c "import torchrec…"` and `git check-ignore` — none of which match the allowlist. The file's own trust-model comment asserted that a PR comment was the only exfil path for injected content; with arbitrary shell available that was not true.

`--permission-mode manual` is passed on the command line, which outranks settings files, so the allowlist becomes binding regardless of what the runner has stored. Because `manual` also confines reads to the working directory, `--add-dir /` restores the cross-repo reads the reviewers use — in the PR 648 run both the orchestrator and the code-quality reviewer read installed torchrec source to confirm that `weights()` raises on a weightless JT and that eager EBC gates on `is_weighted`, which produced two of the better-grounded findings.

The timeout goes to 60 minutes for the claude job only. Two runs have hit the 30 minute cap and been cancelled with nothing posted; the codex job has never exceeded 21 minutes, so it stays at 30.

## Test Plan

The flags were verified against a local reproduction of the runner (a settings file with `defaultMode: bypassPermissions`), driving headless `claude -p` the same way the job does.

- Without the flag, `curl https://example.com` ran and returned 200. With `--permission-mode manual`, the same call was refused with "This command requires approval" and the session reported `permissionMode=default`. Confirms the CLI flag overrides a settings-file default.
- Denials arrive as ordinary `is_error: true` tool results and the model continues; every probe exited 0 with `subtype: success`. Headless has no TTY, so nothing can block waiting for approval.
- With `--add-dir /`: reads outside the working directory succeed, including from a spawned subagent, so the reviewers keep their reach. Writes to `$HOME`, `/tmp` and a sibling repo were all still blocked, and network still required approval.
- Allowlist patterns match real invocations: `gh pr view 648 --repo alibaba/TorchEasyRec --json title` and `gh pr diff 648 --repo alibaba/TorchEasyRec` both succeeded, while `gh api repos/alibaba/TorchEasyRec` was denied — the prompt already tells the model not to use `gh api`, and that instruction is now enforced rather than advisory.
- `pre-commit run --files .github/workflows/code_review.yml` passes; the workflow parses and both jobs' timeouts read back as expected (60 / 30).

Not verified end to end on the runner itself — worth watching the first labelled run to confirm the reviewers behave normally under the enforced allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGSC6uRGTpmV3bSDh9oDyd
