### PR TITLE
[feat] resolve an unsuffixed model.ckpt when finding the latest checkpoint

### DIFF
--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -241,6 +241,10 @@ def _get_checkpoint_step(ckpt_path: str) -> int:
 def latest_checkpoint(model_dir: str) -> Tuple[Optional[str], int]:
     """Find latest checkpoint under a directory.
 
+    Resolves, in order: the newest ``model.ckpt-<step>`` under the directory, the
+    directory itself when it is a checkpoint, and a ``model.ckpt`` inside it. The
+    last two carry no step, so they report 0.
+
     Args:
         model_dir: model directory
 
@@ -253,12 +257,15 @@ def latest_checkpoint(model_dir: str) -> Tuple[Optional[str], int]:
         ckpt_metas = glob.glob(os.path.join(model_dir, "model.ckpt-*" + os.path.sep))
         ckpt_metas = list(map(lambda x: x.rstrip(os.path.sep), ckpt_metas))
         if len(ckpt_metas) == 0:
-            model_ckpt_dir = os.path.join(model_dir, "model")
-            optim_ckpt_dir = os.path.join(model_dir, "optimizer")
-            if os.path.exists(model_ckpt_dir) or os.path.exists(optim_ckpt_dir):
-                return model_dir, 0
-            else:
-                return None, -1
+            # no stepped checkpoint: the path may be a checkpoint itself, or hold
+            # a single one named without a step, as a producer of exactly one
+            # checkpoint tends to write.
+            for ckpt_dir in (model_dir, os.path.join(model_dir, "model.ckpt")):
+                model_ckpt_dir = os.path.join(ckpt_dir, "model")
+                optim_ckpt_dir = os.path.join(ckpt_dir, "optimizer")
+                if os.path.exists(model_ckpt_dir) or os.path.exists(optim_ckpt_dir):
+                    return ckpt_dir, 0
+            return None, -1
         if len(ckpt_metas) > 1:
             ckpt_metas.sort(key=lambda x: _get_checkpoint_step(x))
         latest_ckpt_path = ckpt_metas[-1]

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -241,9 +241,10 @@ def _get_checkpoint_step(ckpt_path: str) -> int:
 def latest_checkpoint(model_dir: str) -> Tuple[Optional[str], int]:
     """Find latest checkpoint under a directory.
 
-    Resolves, in order: the newest ``model.ckpt-<step>`` under the directory, the
-    directory itself when it is a checkpoint, and a ``model.ckpt`` inside it. The
-    last two carry no step, so they report 0.
+    A path that already names a checkpoint (contains ``model.ckpt-``) is returned
+    as given, without checking that it exists. Otherwise the directory is searched,
+    preferring the newest ``model.ckpt-<step>`` in it, then the directory itself,
+    then a ``model.ckpt`` in it. The last two carry no step, so they report 0.
 
     Args:
         model_dir: model directory
@@ -257,9 +258,7 @@ def latest_checkpoint(model_dir: str) -> Tuple[Optional[str], int]:
         ckpt_metas = glob.glob(os.path.join(model_dir, "model.ckpt-*" + os.path.sep))
         ckpt_metas = list(map(lambda x: x.rstrip(os.path.sep), ckpt_metas))
         if len(ckpt_metas) == 0:
-            # no stepped checkpoint: the path may be a checkpoint itself, or hold
-            # a single one named without a step, as a producer of exactly one
-            # checkpoint tends to write.
+            # a producer of exactly one checkpoint tends to drop the -<step>
             for ckpt_dir in (model_dir, os.path.join(model_dir, "model.ckpt")):
                 model_ckpt_dir = os.path.join(ckpt_dir, "model")
                 optim_ckpt_dir = os.path.join(ckpt_dir, "optimizer")

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -266,6 +266,25 @@ class CheckpointUtilTest(unittest.TestCase):
         self.assertEqual(ckpt_path, os.path.join(self.test_dir, "custom"))
         self.assertEqual(step, 0)
 
+    def test_latest_checkpoint_with_unsuffixed_ckpt(self):
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt/model"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(self.test_dir)
+        self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt"))
+        self.assertEqual(step, 0)
+
+    def test_latest_checkpoint_prefers_stepped_over_unsuffixed(self):
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt/model"))
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt-10/model"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(self.test_dir)
+        self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt-10"))
+        self.assertEqual(step, 10)
+
+    def test_latest_checkpoint_without_any_ckpt(self):
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(self.test_dir)
+        self.assertIsNone(ckpt_path)
+        self.assertEqual(step, -1)
+
     def _remaining_ckpt_steps(self):
         return sorted(
             int(p.rsplit("-", 1)[1])

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -285,6 +285,21 @@ class CheckpointUtilTest(unittest.TestCase):
         self.assertIsNone(ckpt_path)
         self.assertEqual(step, -1)
 
+    def test_latest_checkpoint_prefers_dir_itself_over_unsuffixed(self):
+        os.makedirs(os.path.join(self.test_dir, "model"))
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt/model"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(self.test_dir)
+        self.assertEqual(ckpt_path, self.test_dir)
+        self.assertEqual(step, 0)
+
+    def test_latest_checkpoint_on_unsuffixed_ckpt_path(self):
+        os.makedirs(os.path.join(self.test_dir, "model.ckpt/model"))
+        ckpt_path, step = checkpoint_util.latest_checkpoint(
+            os.path.join(self.test_dir, "model.ckpt")
+        )
+        self.assertEqual(ckpt_path, os.path.join(self.test_dir, "model.ckpt"))
+        self.assertEqual(step, 0)
+
     def _remaining_ckpt_steps(self):
         return sorted(
             int(p.rsplit("-", 1)[1])

--- a/tzrec/version.py
+++ b/tzrec/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"


### PR DESCRIPTION
## Motivation

`latest_checkpoint` already falls back to treating the given directory as a checkpoint itself, so `--fine_tune_checkpoint` accepts checkpoints produced outside TorchEasyRec. That fallback only looks at the directory it is handed, so a layout like

```
{date}/model.ckpt/model/
{date}/model.ckpt/optimizer/
```

resolves only when the caller points at `{date}/model.ckpt`. Pointing at `{date}` returns `(None, -1)` and the run dies with

```
RuntimeError: fine_tune_checkpoint[.../{date}] not exists.
```

which is misleading — the checkpoint is plainly there, one level down.

## Change

Extend the same fallback one level down to a `model.ckpt` inside the directory. A producer that writes exactly one checkpoint tends to drop the `-<step>` suffix, so this is the natural companion to the existing case.

`model.ckpt` is TorchEasyRec's own prefix rather than a foreign convention, which keeps the accepted set closed at `model.ckpt-<step>` and `model.ckpt` instead of opening the door to arbitrary third-party names. Both suffix-less forms report step 0, as the existing fallback already did.

Resolution order is now: newest `model.ckpt-<step>` under the directory, then the directory itself, then `model.ckpt` inside it. Stepped directories are globbed first, so they still win whenever both are present.

`best_checkpoint` and checkpoint pruning are untouched — they operate on a `model_dir` TorchEasyRec owns, where every checkpoint carries a step.

Also bumps the version to 1.4.2.

## Test Plan

Three tests added to `CheckpointUtilTest`:

- `test_latest_checkpoint_with_unsuffixed_ckpt` — `model.ckpt/model/` inside the directory resolves to that path at step 0
- `test_latest_checkpoint_prefers_stepped_over_unsuffixed` — with both `model.ckpt/` and `model.ckpt-10/` present, the stepped one wins
- `test_latest_checkpoint_without_any_ckpt` — a bare `model.ckpt` directory holding no `model/` or `optimizer/` still returns `(None, -1)`, so the name alone is not enough

Verified the new coverage actually pins the change: reverting only the `checkpoint_util.py` hunk makes exactly `test_latest_checkpoint_with_unsuffixed_ckpt` fail, while the other two hold either way as regression guards.

- `python -m unittest tzrec.utils.checkpoint_util_test.CheckpointUtilTest` — 28 tests, OK
- `pyrefly check` — 0 errors; `pre-commit` clean
- Full suite via `python tzrec/tests/run.py` in progress; will report before merge

Remote paths need no special handling: `os.path.exists` is monkeypatched in `tzrec/utils/filesystem_util.py` to route through fsspec with `check_dir=True`, and the new branch reuses the same `os.path.join` + `exists` pair the existing fallback relies on, so `oss://` behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sagd6kywrNNoBdC1fHbXci