### PR TITLE
[ci] hand the review subagents the PR diff as a file

### DIFF
--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: code-quality-reviewer
 description: Reviews code for quality, maintainability, and adherence to best practices in Python/PyTorch codebases.
-tools: Glob, Grep, Read
+tools: Glob, Grep, Read, WebFetch, mcp__dashscope-search__web_search
 model: inherit
 ---
 
 You are an expert code quality reviewer for a Python/PyTorch recommendation system framework (TorchEasyRec). Review for quality, readability, and long-term maintainability.
 
-**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`. Installed dependency sources are at the paths in `.pr-review/env` — read them there to check an API against the version in use, and do not go looking when it says none are present.
 
 **Clean Code Analysis:**
 - Evaluate naming conventions for clarity and descriptiveness

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are an expert code quality reviewer for a Python/PyTorch recommendation system framework (TorchEasyRec). Review for quality, readability, and long-term maintainability.
 
+**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+
 **Clean Code Analysis:**
 - Evaluate naming conventions for clarity and descriptiveness
 - Assess function and method sizes for single responsibility adherence

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -7,7 +7,7 @@ model: inherit
 
 You are an expert code quality reviewer for a Python/PyTorch recommendation system framework (TorchEasyRec). Review for quality, readability, and long-term maintainability.
 
-**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
 
 **Clean Code Analysis:**
 - Evaluate naming conventions for clarity and descriptiveness

--- a/.claude/agents/documentation-accuracy-reviewer.md
+++ b/.claude/agents/documentation-accuracy-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are a technical documentation reviewer for TorchEasyRec, a PyTorch recommendation system framework. Ensure documentation accurately reflects implementation.
 
+**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+
 **Code Documentation (Docstrings):**
 - Verify public functions, methods, and classes have Google-style docstrings (required for non-test files)
 - Check that parameter descriptions match actual parameter types and purposes

--- a/.claude/agents/documentation-accuracy-reviewer.md
+++ b/.claude/agents/documentation-accuracy-reviewer.md
@@ -7,7 +7,7 @@ model: inherit
 
 You are a technical documentation reviewer for TorchEasyRec, a PyTorch recommendation system framework. Ensure documentation accurately reflects implementation.
 
-**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
 
 **Code Documentation (Docstrings):**
 - Verify public functions, methods, and classes have Google-style docstrings (required for non-test files)

--- a/.claude/agents/documentation-accuracy-reviewer.md
+++ b/.claude/agents/documentation-accuracy-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: documentation-accuracy-reviewer
 description: Verifies code documentation accuracy for a Python ML framework with Google-style docstrings, protobuf configs, and model documentation.
-tools: Glob, Grep, Read
+tools: Glob, Grep, Read, WebFetch, mcp__dashscope-search__web_search
 model: inherit
 ---
 
 You are a technical documentation reviewer for TorchEasyRec, a PyTorch recommendation system framework. Ensure documentation accurately reflects implementation.
 
-**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`. Installed dependency sources are at the paths in `.pr-review/env` — read them there to check an API against the version in use, and do not go looking when it says none are present.
 
 **Code Documentation (Docstrings):**
 - Verify public functions, methods, and classes have Google-style docstrings (required for non-test files)

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -7,7 +7,7 @@ model: inherit
 
 You are a performance optimization specialist for a PyTorch-based distributed recommendation system framework (TorchEasyRec). Identify performance bottlenecks and provide actionable optimization recommendations.
 
-**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
 
 **Algorithmic & Computational Efficiency:**
 - Examine algorithmic complexity, flag O(n²) or worse that could be optimized

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are a performance optimization specialist for a PyTorch-based distributed recommendation system framework (TorchEasyRec). Identify performance bottlenecks and provide actionable optimization recommendations.
 
+**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+
 **Algorithmic & Computational Efficiency:**
 - Examine algorithmic complexity, flag O(n²) or worse that could be optimized
 - Detect unnecessary computations, redundant operations, or repeated work

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: performance-reviewer
 description: Analyzes code for performance issues in PyTorch/TorchRec training pipelines, GPU operations, and distributed systems.
-tools: Glob, Grep, Read
+tools: Glob, Grep, Read, WebFetch, mcp__dashscope-search__web_search
 model: inherit
 ---
 
 You are a performance optimization specialist for a PyTorch-based distributed recommendation system framework (TorchEasyRec). Identify performance bottlenecks and provide actionable optimization recommendations.
 
-**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`. Installed dependency sources are at the paths in `.pr-review/env` — read them there to check an API against the version in use, and do not go looking when it says none are present.
 
 **Algorithmic & Computational Efficiency:**
 - Examine algorithmic complexity, flag O(n²) or worse that could be optimized

--- a/.claude/agents/security-code-reviewer.md
+++ b/.claude/agents/security-code-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: security-code-reviewer
 description: Reviews ML training framework code for multi-process safety and input validation.
-tools: Glob, Grep, Read
+tools: Glob, Grep, Read, WebFetch, mcp__dashscope-search__web_search
 model: inherit
 ---
 
 You are a security reviewer for TorchEasyRec, a PyTorch-based ML training framework. This is NOT a web application — focus on ML pipeline security rather than web vulnerabilities.
 
-**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`. Installed dependency sources are at the paths in `.pr-review/env` — read them there to check an API against the version in use, and do not go looking when it says none are present.
 
 **Multi-Process & Distributed Safety:**
 - Check for race conditions in shared state across distributed workers

--- a/.claude/agents/security-code-reviewer.md
+++ b/.claude/agents/security-code-reviewer.md
@@ -7,7 +7,7 @@ model: inherit
 
 You are a security reviewer for TorchEasyRec, a PyTorch-based ML training framework. This is NOT a web application — focus on ML pipeline security rather than web vulnerabilities.
 
-**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
 
 **Multi-Process & Distributed Safety:**
 - Check for race conditions in shared state across distributed workers

--- a/.claude/agents/security-code-reviewer.md
+++ b/.claude/agents/security-code-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are a security reviewer for TorchEasyRec, a PyTorch-based ML training framework. This is NOT a web application — focus on ML pipeline security rather than web vulnerabilities.
 
+**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+
 **Multi-Process & Distributed Safety:**
 - Check for race conditions in shared state across distributed workers
 - Verify proper process group initialization and cleanup

--- a/.claude/agents/test-coverage-reviewer.md
+++ b/.claude/agents/test-coverage-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: test-coverage-reviewer
 description: Reviews testing implementation and coverage for Python/PyTorch ML code with unittest, parameterized tests, and GPU-conditional testing.
-tools: Glob, Grep, Read
+tools: Glob, Grep, Read, WebFetch, mcp__dashscope-search__web_search
 model: inherit
 ---
 
 You are a testing specialist for a PyTorch recommendation system framework (TorchEasyRec). Review test implementations for comprehensive coverage and robust quality validation.
 
-**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`. Installed dependency sources are at the paths in `.pr-review/env` — read them there to check an API against the version in use, and do not go looking when it says none are present.
 
 **Test Coverage Analysis:**
 - Identify untested code paths, branches, and edge cases

--- a/.claude/agents/test-coverage-reviewer.md
+++ b/.claude/agents/test-coverage-reviewer.md
@@ -7,7 +7,7 @@ model: inherit
 
 You are a testing specialist for a PyTorch recommendation system framework (TorchEasyRec). Review test implementations for comprehensive coverage and robust quality validation.
 
-**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+**Scope:** Review what this PR changed. Read the diffs first — the dispatcher gives you a `.pr-review/files/<path>.diff` path for each file your area owns, and `.pr-review/stat` lists every changed file if it gave you none — then read around each hunk for the context a diff fragment alone does not give. You have no shell, so those files are the only record of the change; never infer it from `HEAD`.
 
 **Test Coverage Analysis:**
 - Identify untested code paths, branches, and edge cases

--- a/.claude/agents/test-coverage-reviewer.md
+++ b/.claude/agents/test-coverage-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are a testing specialist for a PyTorch recommendation system framework (TorchEasyRec). Review test implementations for comprehensive coverage and robust quality validation.
 
+**Scope:** Review what this PR changed. Read the unified diff first — the dispatcher gives you its path, and it is `pr.diff` at the root of the working directory — then read around the changed files for the context a hunk alone does not give. Never reconstruct the change by inferring it from `HEAD`.
+
 **Test Coverage Analysis:**
 - Identify untested code paths, branches, and edge cases
 - Verify all public APIs and model classes have corresponding tests

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -3,9 +3,10 @@ allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 
-Fetch the PR context with `gh pr view`. The PR's full unified diff is
-already saved as `pr.diff` at the root of the working directory — read it
-from there instead of fetching it again.
+Fetch the PR context with `gh pr view`. The change itself is already on
+disk: `.pr-review/stat` lists every changed file, `.pr-review/files/<path>.diff`
+holds one file's diff, and `.pr-review/diff` is the whole change. Read it from
+there instead of fetching it again.
 Review statically — do not run tests or builds.
 
 Perform a comprehensive code review using subagents for key areas:
@@ -16,11 +17,14 @@ Perform a comprehensive code review using subagents for key areas:
 - documentation-accuracy-reviewer
 - security-code-reviewer
 
-Give every subagent the path to `pr.diff` and tell it to read that file
-first. Subagents start with an empty context and have only Glob/Grep/Read —
-no shell, no `gh`, and no git history to diff against — so that file is
-their only view of what changed. Do not paraphrase the change or paste diff
-text in its place, and never name a tool an agent does not have.
+Give each subagent the files its area owns and the
+`.pr-review/files/<path>.diff` path for each, and split the files between the
+areas rather than pointing all five at the whole change — say they may read
+another file's diff when a finding needs it. Subagents start with an empty
+context and have only Glob/Grep/Read — no shell, no `gh`, and no git history
+to diff against — so those files are their only view of what changed. Do not
+paraphrase the change or paste diff text in its place, and never name a tool
+an agent does not have.
 
 Instruct each to only provide noteworthy feedback. Once they finish, review
 the feedback and post only the feedback that you also deem noteworthy.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -7,7 +7,11 @@ Fetch the PR context with `gh pr view`. The change itself is already on
 disk: `.pr-review/stat` lists every changed file, `.pr-review/files/<path>.diff`
 holds one file's diff, and `.pr-review/diff` is the whole change. Read it from
 there instead of fetching it again.
-Review statically — do not run tests or builds.
+Review statically — do not run tests or builds. Installed dependency sources,
+when the runner has any, are listed in `.pr-review/env`. `WebFetch` and the
+web-search tool are available to you and to the subagents: use them to check an
+upstream API or an advisory for a changed dependency, not for anything the
+checkout already answers.
 
 Perform a comprehensive code review using subagents for key areas:
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -3,7 +3,9 @@ allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 
-Fetch the PR context with `gh pr view` and the changes with `gh pr diff`.
+Fetch the PR context with `gh pr view`. The PR's full unified diff is
+already saved as `pr.diff` at the root of the working directory — read it
+from there instead of fetching it again.
 Review statically — do not run tests or builds.
 
 Perform a comprehensive code review using subagents for key areas:
@@ -13,6 +15,12 @@ Perform a comprehensive code review using subagents for key areas:
 - test-coverage-reviewer
 - documentation-accuracy-reviewer
 - security-code-reviewer
+
+Give every subagent the path to `pr.diff` and tell it to read that file
+first. Subagents start with an empty context and have only Glob/Grep/Read —
+no shell, no `gh`, and no git history to diff against — so that file is
+their only view of what changed. Do not paraphrase the change or paste diff
+text in its place, and never name a tool an agent does not have.
 
 Instruct each to only provide noteworthy feedback. Once they finish, review
 the feedback and post only the feedback that you also deem noteworthy.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -25,10 +25,9 @@ Give each subagent the files its area owns and the
 `.pr-review/files/<path>.diff` path for each, and split the files between the
 areas rather than pointing all five at the whole change — say they may read
 another file's diff when a finding needs it. Subagents start with an empty
-context and have only Glob/Grep/Read — no shell, no `gh`, and no git history
-to diff against — so those files are their only view of what changed. Do not
-paraphrase the change or paste diff text in its place, and never name a tool
-an agent does not have.
+context and have no shell, no `gh`, and no git history to diff against — so
+those files are their only view of what changed. Do not paraphrase the change
+or paste diff text in its place, and never name a tool an agent does not have.
 
 Instruct each to only provide noteworthy feedback. Once they finish, review
 the feedback and post only the feedback that you also deem noteworthy.

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -129,6 +129,19 @@ jobs:
       - name: Use trusted agent files
         run: bash trusted-claude/scripts/ci/use_trusted_agent_files.sh trusted-claude pr-code
 
+      # The reviewers read the diff from a file because nothing else can hand it
+      # to them: the subagents have Read but no shell, fetch-depth: 1 leaves no
+      # merge base for git diff, and --permission-mode manual lets the model
+      # neither redirect nor Write the file for itself.
+      - name: Save PR diff for the reviewers
+        working-directory: pr-code
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} > pr.diff
+          wc -l pr.diff
+
       - name: RunCodeReview
         working-directory: pr-code
         env:
@@ -209,6 +222,17 @@ jobs:
             --prompt-out "${{ runner.temp }}/codex-prompt.md"
           bash trusted-claude/scripts/ci/use_trusted_agent_files.sh \
             trusted-claude pr-code "${{ runner.temp }}/codex-gen"
+
+      # Same file, same reason: the subagent sandboxes are read-only and offline,
+      # so `gh pr diff` is unreachable from inside a review.
+      - name: Save PR diff for the reviewers
+        working-directory: pr-code
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} > pr.diff
+          wc -l pr.diff
 
       - name: RunCodexReview
         working-directory: pr-code

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -129,18 +129,27 @@ jobs:
       - name: Use trusted agent files
         run: bash trusted-claude/scripts/ci/use_trusted_agent_files.sh trusted-claude pr-code
 
-      # The reviewers read the diff from a file because nothing else can hand it
-      # to them: the subagents have Read but no shell, fetch-depth: 1 leaves no
-      # merge base for git diff, and --permission-mode manual lets the model
-      # neither redirect nor Write the file for itself.
+      # The reviewers read the change from files because nothing else can hand
+      # it to them: the subagents have Read but no shell, fetch-depth: 1 leaves
+      # no merge base for git diff, and --permission-mode manual lets the model
+      # neither redirect nor Write a file for itself. Split per file because
+      # Read caps what it returns, so one combined diff reaches a reviewer
+      # truncated at its tail once a PR is large.
       - name: Save PR diff for the reviewers
         working-directory: pr-code
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # rm before mkdir: a PR can commit .pr-review as a symlink, and
+          # writing through one would escape the checkout
+          rm -rf .pr-review && mkdir .pr-review
           gh pr diff ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} > pr.diff
-          wc -l pr.diff
+            --repo ${{ github.repository }} > .pr-review/diff
+          python3 "${GITHUB_WORKSPACE}/trusted-claude/scripts/ci/split_pr_diff.py" \
+            --diff .pr-review/diff --out-dir .pr-review
+          EXCLUDE="$(git rev-parse --git-path info/exclude)"
+          mkdir -p "$(dirname "$EXCLUDE")"
+          echo '.pr-review/' >> "$EXCLUDE"
 
       - name: RunCodeReview
         working-directory: pr-code
@@ -223,16 +232,23 @@ jobs:
           bash trusted-claude/scripts/ci/use_trusted_agent_files.sh \
             trusted-claude pr-code "${{ runner.temp }}/codex-gen"
 
-      # Same file, same reason: the subagent sandboxes are read-only and offline,
-      # so `gh pr diff` is unreachable from inside a review.
+      # Same files, same reason: the subagent sandboxes are read-only and
+      # offline, so `gh pr diff` is unreachable from inside a review.
       - name: Save PR diff for the reviewers
         working-directory: pr-code
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # rm before mkdir: a PR can commit .pr-review as a symlink, and
+          # writing through one would escape the checkout
+          rm -rf .pr-review && mkdir .pr-review
           gh pr diff ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} > pr.diff
-          wc -l pr.diff
+            --repo ${{ github.repository }} > .pr-review/diff
+          python3 "${GITHUB_WORKSPACE}/trusted-claude/scripts/ci/split_pr_diff.py" \
+            --diff .pr-review/diff --out-dir .pr-review
+          EXCLUDE="$(git rev-parse --git-path info/exclude)"
+          mkdir -p "$(dirname "$EXCLUDE")"
+          echo '.pr-review/' >> "$EXCLUDE"
 
       - name: RunCodexReview
         working-directory: pr-code

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -71,10 +71,21 @@
 # Trust model: the collaborator-added label gates every run (review before labeling);
 # adding a label needs triage permission, so non-collaborators cannot trigger either job.
 # Codex confines model commands to a no-network sandbox, with only the gh pr
-# view/diff/comment allowlist (scripts/ci/codex_review.rules) running outside it. The
-# claude job reaches the same allowlist via --permission-mode manual, which is what makes
-# --allowedTools binding. A PR comment is the only exfil path out of either job, and
-# --add-dir / leaves everything readable on the runner reachable from that path.
+# view/diff/comment allowlist (scripts/ci/codex_review.rules) running outside it.
+#
+# The claude job is contained differently, and --allowedTools is NOT a command allowlist
+# for it: measured on claude 2.1.257, read-only commands (ls, grep, sed -n, git log) are
+# auto-approved whether or not they are listed, while writes and redirections are refused
+# and file access is confined to the working directories. So --add-dir is the boundary
+# that matters, and it is scoped to the conda root the reviewers read dependency sources
+# from (see .pr-review/env), never the whole runner.
+#
+# The claude job is also granted WebFetch and a web-search MCP tool, for the dispatcher and
+# all five reviewers, so it can check an API or an advisory against upstream. That is a
+# deliberate trade: unlike a PR comment, a fetch is silent, so exfil from this job is no
+# longer visible or auditable, and the collaborator label gate is the control. The codex
+# job has no web access -- its per-run CODEX_HOME drops any [tools] block -- so the two
+# jobs deliberately differ in capability.
 # ---- End Codex Setup ----
 
 name: Code Review
@@ -151,6 +162,15 @@ jobs:
           mkdir -p "$(dirname "$EXCLUDE")"
           echo '.pr-review/' >> "$EXCLUDE"
 
+          # ~/.bashrc is never sourced in a step, so conda's PATH block never runs --
+          # same trap as the bun path below. The manifest tells the reviewers where
+          # installed dependencies are; its root is all they are given to read.
+          CONDA="$(which conda 2>/dev/null || echo "$HOME/conda/bin/conda")"
+          ENV_ROOT="$(python3 \
+            "${GITHUB_WORKSPACE}/trusted-claude/scripts/ci/write_cr_env.py" \
+            --conda "$CONDA" --out .pr-review/env)"
+          echo "REVIEW_ENV_ROOT=$ENV_ROOT" >> "$GITHUB_ENV"
+
       - name: RunCodeReview
         working-directory: pr-code
         env:
@@ -170,17 +190,18 @@ jobs:
 
           MCP_CONFIG="{\"mcpServers\":{\"github_inline_comment\":{\"command\":\"${BUN_PATH}\",\"args\":[\"run\",\"/opt/claude-code-action/src/mcp/github-inline-comment-server.ts\"]}}}"
 
-          # --permission-mode manual makes --allowedTools binding; without it the
-          # runner's stored settings apply and every Bash command is permitted.
-          # --add-dir / keeps the cross-repo reads the reviewers depend on.
+          # Read access is scoped to the checkout plus the conda root resolved above,
+          # so the runner's $HOME -- which holds the stored OAuth credentials -- is not
+          # readable. It falls back to the working directory, which is already
+          # allowed, when the runner has no conda environment.
           claude -p \
             --output-format stream-json \
             --verbose \
             --permission-mode manual \
-            --add-dir / \
+            --add-dir "${REVIEW_ENV_ROOT:-$PWD}" \
             --settings '{"disableRemoteControl": true}' \
             --mcp-config "$MCP_CONFIG" \
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent" \
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,Agent,WebFetch,mcp__dashscope-search__web_search" \
             -- "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${PR_NUMBER}"
 
   codex-review:
@@ -249,6 +270,11 @@ jobs:
           EXCLUDE="$(git rev-parse --git-path info/exclude)"
           mkdir -p "$(dirname "$EXCLUDE")"
           echo '.pr-review/' >> "$EXCLUDE"
+
+          # Same manifest for the codex reviewers; this job has no --add-dir to scope.
+          CONDA="$(which conda 2>/dev/null || echo "$HOME/conda/bin/conda")"
+          python3 "${GITHUB_WORKSPACE}/trusted-claude/scripts/ci/write_cr_env.py" \
+            --conda "$CONDA" --out .pr-review/env > /dev/null
 
       - name: RunCodexReview
         working-directory: pr-code

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -37,6 +37,13 @@
 #   }
 #   EOF
 #
+#   # The web-search tool the reviewers are granted
+#   # (mcp__dashscope-search__web_search) is NOT provisioned here: it comes from
+#   # this user's own ~/.claude/mcp.json at user scope, which merges because
+#   # --strict-mcp-config is deliberately not passed. Re-add it when rebuilding
+#   # the runner, or the tool named in --allowedTools and in every agent roster
+#   # silently resolves to nothing.
+#
 #   # Login (stores OAuth credentials for headless use)
 #   claude /login
 #

--- a/scripts/ci/gen_codex_review.py
+++ b/scripts/ci/gen_codex_review.py
@@ -61,7 +61,8 @@ def gen_agent_toml(agent_md: Path, agents_dir: Path) -> None:
     lines = [
         f"name = {toml_str(name)}",
         f"description = {toml_str(fields.get('description', ''))}",
-        # Claude agents are read-only (tools: Glob, Grep, Read).
+        # Codex subagents stay offline and read-only whatever the Claude roster
+        # grants: this job's containment is the sandbox, not a tool list.
         'sandbox_mode = "read-only"',
         f"developer_instructions = {toml_str(body)}",
     ]

--- a/scripts/ci/split_pr_diff.py
+++ b/scripts/ci/split_pr_diff.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Split a pull request's diff into the per-file inputs an AI review reads.
+
+The reviewers hold Read but no shell, and the PR checkout is shallow, so the
+whole change reaches them as files. One combined diff is not enough: Read caps
+what it returns, and a diff is path-ordered, so a large PR silently arrives
+truncated at its alphabetical tail. Writing one diff per changed file lets each
+reviewer read its own area whole. Used by .github/workflows/code_review.yml.
+"""
+
+import argparse
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+_FILE_START = re.compile(rb"(?m)^diff --git ")
+# In fallback order: a rename names the new path, and only the header survives
+# for a binary, mode-only or pure-rename entry that carries no hunks.
+_RENAME_TO = re.compile(rb"(?m)^rename to (.+)$")
+_NEW_PATH = re.compile(rb"(?m)^\+\+\+ b/(.+)$")
+_OLD_PATH = re.compile(rb"(?m)^--- a/(.+)$")
+
+
+def chunk_path(chunk: bytes) -> str:
+    """Return the post-change path a single-file diff chunk describes.
+
+    Args:
+        chunk (bytes): one `diff --git` entry, header included.
+
+    Returns:
+        The path as it exists in the head tree, or the pre-change path for a
+        deletion.
+    """
+    for pattern in (_RENAME_TO, _NEW_PATH, _OLD_PATH):
+        match = pattern.search(chunk)
+        if match:
+            return match.group(1).decode()
+    header = chunk.split(b"\n", 1)[0][len(b"diff --git ") :].decode()
+    _, _, new_path = header.partition(" b/")
+    return new_path or header
+
+
+def split_diff(diff: bytes) -> List[Tuple[str, bytes]]:
+    """Split a unified diff into one self-contained chunk per changed file.
+
+    Args:
+        diff (bytes): the whole diff, as `gh pr diff` writes it.
+
+    Returns:
+        A (path, chunk) list in diff order; the chunks concatenate back to
+        `diff`.
+
+    Raises:
+        ValueError: the diff holds no entries, or does not begin with one.
+    """
+    starts = [match.start() for match in _FILE_START.finditer(diff)]
+    if not starts:
+        raise ValueError("the diff holds no 'diff --git' entries")
+    if starts[0] != 0:
+        raise ValueError("the diff has content before its first 'diff --git'")
+    bounds = starts + [len(diff)]
+    chunks = [diff[bounds[i] : bounds[i + 1]] for i in range(len(starts))]
+    if b"".join(chunks) != diff:
+        raise ValueError("splitting lost bytes; the chunks do not rebuild the diff")
+    return [(chunk_path(chunk), chunk) for chunk in chunks]
+
+
+def write_review_inputs(diff: bytes, out_dir: Path) -> List[Tuple[str, bytes]]:
+    """Write one diff per changed file, plus the change map, under `out_dir`.
+
+    Args:
+        diff (bytes): the whole diff.
+        out_dir (Path): review-inputs directory, already created.
+
+    Returns:
+        The (path, chunk) list that was written.
+    """
+    entries = split_diff(diff)
+    for path, chunk in entries:
+        target = out_dir / "files" / f"{path}.diff"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(chunk)
+
+    lines = [f"{len(diff.splitlines())} lines, {len(entries)} files", ""]
+    lines += [f"{len(chunk.splitlines()):>6}  {path}" for path, chunk in entries]
+    (out_dir / "stat").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return entries
+
+
+def main() -> None:
+    """Write the review inputs for one pull request diff."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff", required=True, help="the whole PR diff")
+    parser.add_argument("--out-dir", required=True, help="review-inputs directory")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    if out_dir.is_symlink():
+        # A PR can commit one, and writing through it escapes the checkout.
+        raise ValueError(f"{out_dir} is a symlink")
+
+    entries = write_review_inputs(Path(args.diff).read_bytes(), out_dir)
+    print(f"wrote {len(entries)} per-file diffs to {out_dir / 'files'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/split_pr_diff.py
+++ b/scripts/ci/split_pr_diff.py
@@ -20,19 +20,32 @@ reviewer read its own area whole. Used by .github/workflows/code_review.yml.
 
 import argparse
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Tuple
 
 _FILE_START = re.compile(rb"(?m)^diff --git ")
-# In fallback order: a rename names the new path, and only the header survives
-# for a binary, mode-only or pure-rename entry that carries no hunks.
-_RENAME_TO = re.compile(rb"(?m)^rename to (.+)$")
-_NEW_PATH = re.compile(rb"(?m)^\+\+\+ b/(.+)$")
-_OLD_PATH = re.compile(rb"(?m)^--- a/(.+)$")
+# Where an entry's header ends and its body begins. Everything after this is
+# attacker-authored: an added line reading "++ b/x" renders as "+++ b/x", so a
+# path must never be taken from it.
+_BODY_START = re.compile(rb"(?m)^(?:@@ |Binary files |GIT binary patch)")
+# In fallback order: a rename names the new path, and only the `diff --git`
+# line survives for a binary or mode-only entry. Each shape has a plain and a
+# C-quoted spelling -- git always quotes a path holding a control character,
+# whatever core.quotePath says.
+_PATH_PATTERNS = (
+    re.compile(rb'(?m)^rename to (?:"(.+)"|(.+))$'),
+    re.compile(rb'(?m)^\+\+\+ (?:"b/(.+)"|b/(.+))$'),
+    re.compile(rb'(?m)^--- (?:"a/(.+)"|a/(.+))$'),
+)
+_GIT_LINE = re.compile(rb'(?m)^diff --git (?:"a/.+" "b/(.+)"|a/.+ b/(.+))$')
 
 
 def chunk_path(chunk: bytes) -> str:
     """Return the post-change path a single-file diff chunk describes.
+
+    A C-quoted name keeps git's quoted spelling rather than being decoded:
+    decoding would put real tabs and newlines into filenames and into the
+    change map, whose one-entry-per-line format a newline would break.
 
     Args:
         chunk (bytes): one `diff --git` entry, header included.
@@ -41,13 +54,17 @@ def chunk_path(chunk: bytes) -> str:
         The path as it exists in the head tree, or the pre-change path for a
         deletion.
     """
-    for pattern in (_RENAME_TO, _NEW_PATH, _OLD_PATH):
-        match = pattern.search(chunk)
+    body = _BODY_START.search(chunk)
+    header = chunk[: body.start()] if body else chunk
+    for pattern in (*_PATH_PATTERNS, _GIT_LINE):
+        match = pattern.search(header)
         if match:
-            return match.group(1).decode()
-    header = chunk.split(b"\n", 1)[0][len(b"diff --git ") :].decode()
-    _, _, new_path = header.partition(" b/")
-    return new_path or header
+            quoted, plain = match.groups()
+            # An unquoted path holding a space is ambiguous on the `diff --git`
+            # line; git has the same ambiguity and only binary and mode-only
+            # entries reach it.
+            return (quoted or plain).decode()
+    return chunk.split(b"\n", 1)[0][len(b"diff --git ") :].decode()
 
 
 def split_diff(diff: bytes) -> List[Tuple[str, bytes]]:
@@ -70,8 +87,6 @@ def split_diff(diff: bytes) -> List[Tuple[str, bytes]]:
         raise ValueError("the diff has content before its first 'diff --git'")
     bounds = starts + [len(diff)]
     chunks = [diff[bounds[i] : bounds[i + 1]] for i in range(len(starts))]
-    if b"".join(chunks) != diff:
-        raise ValueError("splitting lost bytes; the chunks do not rebuild the diff")
     return [(chunk_path(chunk), chunk) for chunk in chunks]
 
 
@@ -84,11 +99,20 @@ def write_review_inputs(diff: bytes, out_dir: Path) -> List[Tuple[str, bytes]]:
 
     Returns:
         The (path, chunk) list that was written.
+
+    Raises:
+        ValueError: a path would be written outside `out_dir`.
     """
     entries = split_diff(diff)
     for path, chunk in entries:
+        if not path or path.startswith("/") or ".." in PurePosixPath(path).parts:
+            raise ValueError(f"refusing to write outside the review inputs: {path!r}")
         target = out_dir / "files" / f"{path}.diff"
         target.parent.mkdir(parents=True, exist_ok=True)
+        if target.is_symlink():
+            # The parents were just created here, so the leaf is the only place
+            # a PR-committed symlink could redirect the write.
+            raise ValueError(f"refusing to write through a symlink: {target}")
         target.write_bytes(chunk)
 
     lines = [f"{len(diff.splitlines())} lines, {len(entries)} files", ""]

--- a/scripts/ci/write_cr_env.py
+++ b/scripts/ci/write_cr_env.py
@@ -34,12 +34,16 @@ def conda_base(conda: Path) -> Optional[Path]:
         conda (Path): path to the conda executable, which may not exist.
 
     Returns:
-        The installation root, or None when `conda` is not there.
+        The installation root, or None when `conda` is not there or what it
+        resolves to is not a conda installation.
     """
     if not conda.exists():
         return None
-    # <base>/bin/conda and <base>/condabin/conda both resolve this way.
-    return conda.parent.parent
+    # resolve() first: `which conda` can be a cross-root symlink such as
+    # /usr/bin/conda -> /opt/conda/bin/conda, and a lexical parent.parent would
+    # hand /usr to --add-dir. <base>/bin and <base>/condabin both resolve here.
+    base = conda.resolve().parent.parent
+    return base if (base / "conda-meta").is_dir() else None
 
 
 def env_prefixes(base: Path) -> List[Path]:

--- a/scripts/ci/write_cr_env.py
+++ b/scripts/ci/write_cr_env.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Record where installed dependency sources live, for an AI code review.
+
+A reviewer that wants to check an API against the version actually in use has
+to read the installed package, which lives outside the PR checkout. Left to
+guess, it probes a handful of plausible conda layouts, misses, and gives up.
+This writes the answer to a file instead, and prints the root the review is
+granted read access to. Used by .github/workflows/code_review.yml.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Recorded per environment; enough to match one against requirements/runtime.txt.
+_INTERESTING = ("torch", "torchrec", "fbgemm_gpu", "transformers", "torchmetrics")
+
+
+def conda_base(conda: Path) -> Optional[Path]:
+    """Return the conda installation root that owns a `conda` executable.
+
+    Args:
+        conda (Path): path to the conda executable, which may not exist.
+
+    Returns:
+        The installation root, or None when `conda` is not there.
+    """
+    if not conda.exists():
+        return None
+    # <base>/bin/conda and <base>/condabin/conda both resolve this way.
+    return conda.parent.parent
+
+
+def env_prefixes(base: Path) -> List[Path]:
+    """List the environment prefixes belonging to a conda installation.
+
+    Only prefixes under `base` are returned. Conda's global registry
+    (~/.conda/environments.txt) can name environments from other installations,
+    but the review is granted read access to `base` alone, so listing those
+    would advertise paths it cannot open.
+
+    Args:
+        base (Path): the conda installation root.
+
+    Returns:
+        The base and its named environments, in a stable order.
+    """
+    found = [base] + sorted(base.glob("envs/*"))
+    return [p for p in found if p.is_dir()]
+
+
+def installed_versions(site_packages: Path) -> Dict[str, str]:
+    """Read package versions from dist-info directory names.
+
+    Nothing is imported and no interpreter is started, so a broken environment
+    is reported rather than raising.
+
+    Args:
+        site_packages (Path): a site-packages directory.
+
+    Returns:
+        Version by package name, for the packages worth recording.
+    """
+    versions = {}
+    for entry in site_packages.glob("*.dist-info"):
+        name, _, version = entry.name[: -len(".dist-info")].rpartition("-")
+        key = name.lower().replace("-", "_")
+        if key in _INTERESTING:
+            versions[key] = version
+    return versions
+
+
+def describe(base: Optional[Path], conda: Path) -> str:
+    """Build the manifest the reviewers read.
+
+    Args:
+        base (Path, optional): the conda installation root, if there is one.
+        conda (Path): where conda was looked for, for the negative message.
+
+    Returns:
+        The manifest text.
+    """
+    entries = []
+    # conda ships lib/python3.1 as a symlink to lib/python3.11, so resolve
+    # before de-duplicating or every environment is listed twice.
+    seen = set()
+    for prefix in env_prefixes(base) if base else []:
+        for site_packages in sorted(prefix.glob("lib/python*/site-packages")):
+            resolved = site_packages.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            versions = installed_versions(resolved)
+            if "torch" in versions:
+                listed = ", ".join(f"{k} {v}" for k, v in sorted(versions.items()))
+                entries.append(f"{resolved}\n    {listed}")
+    if not entries:
+        reason = (
+            f"no conda at {conda}"
+            if base is None
+            else f"no environment under {base} has torch installed"
+        )
+        return (
+            f"No Python environment on this runner ({reason}).\n"
+            "Installed dependency sources are not available here; do not search "
+            "for them.\n"
+        )
+    return (
+        "Installed dependency sources on this runner. Read these to check an API\n"
+        "against the version actually in use; match the environment to\n"
+        "requirements/runtime.txt.\n\n" + "\n".join(entries) + "\n"
+    )
+
+
+def main() -> None:
+    """Write the manifest, and print the root to grant read access to."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--conda", required=True, help="conda executable to look for")
+    parser.add_argument("--out", required=True, help="manifest to write")
+    args = parser.parse_args()
+
+    conda = Path(args.conda)
+    base = conda_base(conda)
+    manifest = describe(base, conda)
+    Path(args.out).write_text(manifest, encoding="utf-8")
+
+    print(manifest, file=sys.stderr)
+    # stdout is consumed by the workflow as the --add-dir root; keep it bare.
+    print(base if base else "")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The five reviewer subagents are declared `tools: Glob, Grep, Read` — no shell — and the PR checkout uses `fetch-depth: 1`, so there is no merge base on disk for any `git diff` to resolve against. `gh pr diff` is the only source of the change, and it is main-agent-only.

That left the subagents' view of the change entirely up to what the dispatcher managed to put in their prompts, and since `facfbd00` added `--permission-mode manual` the dispatcher can no longer create the file itself: shell redirection is refused (`Output redirection to '…' was blocked`), and `Write` is not in `--allowedTools`. The one channel still working was accidental — when `gh pr diff` output exceeds the harness inline limit, Claude Code spills it to a `tool-results/*.txt` file and the dispatcher can pass that path along. Under the limit, the output stays in the dispatcher's context and the subagents get a prose paraphrase instead, so they read files at `HEAD` and infer what is new.

**A single combined diff does not fix this on its own.** `Read` caps what it returns, and a diff is path-ordered, so a large PR arrives truncated at its alphabetical tail behind a notice the reviewer has to act on. Measured against #625 (36 files, +4452/−14, 5007 lines): one `Read` of the whole diff returns **lines 1–1273 of 5008 — 25% of the change**, and silently omits **27 of 36 files**, including every file of the `tzrec/prompt/` package the PR exists to add. Across the last 40 merged PRs, 8 exceed that cut point.

## Fix

A workflow step writes the change to disk before the model starts, split per file:

```
.pr-review/stat              # the change map: line count per file
.pr-review/diff              # the whole change
.pr-review/files/<path>.diff # one self-contained diff per changed file
```

The files exist for every PR at every size, with no write permission involved and no dependence on `--add-dir /` or on the dispatcher noticing a persisted-output notice. Each reviewer reads its own area whole — on #625 the largest per-file chunk is `tzrec/prompt/compile.py` at 36% of the cap, so every one of the 36 files fits in a single `Read`. `review-pr.md` tells the dispatcher to split the files between areas rather than pointing all five at the whole change, and each agent carries a one-line `**Scope:**` paragraph naming the layout and stating it has no shell, so the fix holds even when the dispatcher writes a sloppy prompt.

`scripts/ci/split_pr_diff.py` splits the diff itself rather than using the per-file patches `gh api /pulls/N/files` reports. Those turned out to be unusable: the `patch` field starts at `@@` with no `diff --git`/`---`/`+++` headers, so the file is not a valid diff and does not name itself, and a pure rename has no `patch` field at all — on #335 that is 11 of 20 files.

Ordering: the step runs after `use_trusted_agent_files.sh`, so `.pr-review/` stays untracked and the trusted-swap commit is unchanged, and after the PR checkout, so a PR cannot pre-seed it. `gh pr diff` stays the source rather than `fetch-depth: 0` plus a local `git diff --merge-base`, because it returns exactly the diff GitHub renders and therefore the line numbers `create_inline_comment` anchors against.

Both jobs get the step. The codex job needs it for the same reason and more strictly: its subagents run `sandbox_mode = "read-only"` with no network, so `gh pr diff` is unreachable from inside a review there.

## Test Plan

**Splitter, against three real diffs** — #625 (36 files), #335 (20 files, 42 rename lines, `similarity index 100%` blocks carrying no `---`/`+++`), and commit `7bcb2db4` (a `Binary files … differ` block). In every case the written bytes equal the source byte for byte, every chunk begins with its own `diff --git` header, and the extracted path set equals GitHub's filename set exactly — including renames landing under the **new** path (`tzrec/ops/_pytorch/…`, with the old `tzrec/ops/pytorch/…` absent).

**The change actually helps.** A `Read` of `.pr-review/files/tzrec/prompt/compile.py.diff` returns all 550 lines with no truncation notice; the same `Read` of the combined diff cuts at line 1273 of 5008.

**Self-checks negative-tested.** The script refuses a diff with content before its first `diff --git`, a diff with no entries, and a symlinked output directory — the last because a PR can commit `.pr-review` as a symlink and writing through one would escape the checkout.

**Full CI sequence rehearsed** in a `--depth 1` clone with the real `use_trusted_agent_files.sh`: the trusted swap still strips a PR-authored root `CLAUDE.md` and a nested `tzrec/.claude/`; 36 per-file diffs are written; `git status` is **empty** and `.pr-review/` appears only under `--ignored`. Repeated with a hostile `.pr-review -> /etc` symlink in the PR tree: neutralised, nothing written outside the checkout.

**Regression.** `pre-commit run -a` clean; workflow YAML parses with both jobs' steps in order; `gen_codex_review.py` regenerates five `.codex/agents/*.toml` all carrying the new layout, and the emitted prompt carries it too.

**End-to-end**, on a fork PR replicating #625's diff exactly (36 files, +4452/−14) with this branch as its base, so `pull_request_target` picks up the new workflow.
---

## Second change in this PR: web lookup, and reads scoped to the conda root

**The reviewers could not check an API against the version actually in use.** Installed packages live outside the checkout, so finding them meant guessing a conda layout — and a run log shows seven probes for torchrec's source (`/opt`, `/opt/conda`, `/usr`, `~/.venv`, `~/miniconda3`, and two under `/mnt/disk/...`), every one missing, because the codereview machine keeps conda at `~/conda`. `scripts/ci/write_cr_env.py` resolves it once and records the environments in `.pr-review/env`, so nothing has to guess — and says plainly when a runner has none, so the hunt stops either way.

**That resolved root is now the only thing outside the checkout the review may read** — `--add-dir` drops from `/` to it. This matters more than the allowlist does. Probing claude 2.1.257 with no settings file and `--allowedTools "Bash(gh pr view:*)"`:

| command | outcome |
|---|---|
| `ls -a`, `grep -c`, `sed -n`, `git log` | **ran**, though unlisted |
| `sed -i 's/x/y/' f` | blocked pending permission; no write landed |
| `echo hi > f` | `Output redirection ... was blocked`; no file created |
| `ls /tmp` (outside cwd) | `may only list files in the allowed working directories` |

So `--allowedTools` is not a command allowlist: read-only commands are auto-approved whether listed or not, while writes and redirections are refused and file access is confined to the working directories. `--add-dir /` was therefore what made the whole runner — including the stored OAuth credentials in `$HOME` — readable through an auto-approved `cat` or `grep`. Narrowing it is the effective hardening. (`--restricted` was evaluated and changed none of the above, so it is not used.)

**`WebFetch` and the web-search MCP tool are granted** to the dispatcher and all five reviewers. That takes two edits, since a subagent needs both the session `--allowedTools` and its own `tools:` roster; a probe confirmed a roster honours a non-default built-in. A fetch leaves no PR artifact, so exfil from this job is no longer visible or auditable — the header comment now states that rather than claiming a boundary that does not hold, and records that the codex job deliberately has no web access.

### Test Plan for this half

- `write_cr_env.py` in both real states: on a box with conda it resolves `~/miniforge3` via `which conda` and lists 6 torch environments with their versions; with `--conda /nonexistent` it writes the "no Python environment" guidance and exits 0, since a missing env is a legitimate runner state and must not fail a review.
- De-duplication is real, not assumed: conda ships `lib/python3.1` as a symlink to `lib/python3.11`, which listed every environment twice until paths were resolved before de-duplicating.
- `gen_codex_review.py` regenerates five TOMLs that carry the `.pr-review/env` line and remain `sandbox_mode = "read-only"`; its stale comment justifying that by "Claude agents are read-only (tools: Glob, Grep, Read)" is corrected, since the rosters now hold more.
- `pre-commit run -a` clean; workflow YAML parses; the per-file split still produces 36 files for #625.
- End-to-end on a fresh fork PR replicating #625, checking that `.pr-review/env` is written, that reads outside the conda root are refused, and that the review still posts.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KX52EswZ1UUySg2CN2nEg
