### PR TITLE
[WIP][bugfix] restore LR scheduler progress on resume

### DIFF
--- a/docs/source/usage/train.md
+++ b/docs/source/usage/train.md
@@ -20,6 +20,11 @@ torchrun --master_addr=localhost --master_port=32555 \
 - --fine_tune_checkpoint: 增量训练的checkpoint路径，如experiments/multi_tower_din_taobao_local/model.ckpt-0，如果不设置，增量训练使用model_dir下最近的检查点
 - --edit_config_json: 命令行以json的方式动态修改配置文件，如{"model_dir":"experiments/","feature_configs[0].raw_feature.boundaries":[4,5,6,7]}
 - --ignore_restore_optimizer: 加载checkpoint参数时，忽略加载优化器的参数
+- --restore_lr_scheduler: 从选中的checkpoint恢复学习率调度器，默认false，保持旧版本从头调度的行为。该参数独立于`--ignore_restore_optimizer`，后者仍只控制优化器状态的恢复。
+  - 续训时使用`--continue_train --restore_lr_scheduler`，恢复稀疏、稠密和part optimizer的调度进度及当前学习率；续训第一批即使用恢复后的学习率。新checkpoint会保存调度状态，恢复时要求world size、调度器类型/顺序及各rank参数组数量一致。
+  - 旧checkpoint没有调度状态时，按checkpoint步数（从0开始）或已完成epoch数重建，要求学习率配置与原训练一致。按epoch调度但缺少已完成epoch数等无法确定进度的情况会报错，不会静默从头调度。
+  - 不传此参数时，即使checkpoint中有调度状态，也不会加载；切换版本无需修改旧配置。按step调度仍以训练batch计数，不改变梯度累积下现有的调度口径。
+  - 此开关不写入`pipeline.config`，复现任务时需保留启动命令；恢复checkpoint时会在日志中记录优化器和调度器恢复开关。
 
 ### 环境变量
 

--- a/tzrec/main.py
+++ b/tzrec/main.py
@@ -389,6 +389,7 @@ def _train_and_evaluate(
     pipeline_config_path: Optional[str] = None,
     dense_ema: Optional[DenseEMA] = None,
     export_config: Optional[ExportConfig] = None,
+    restore_lr_scheduler: bool = False,
 ) -> None:
     """Train and evaluate the model."""
     is_rank_zero = int(os.environ.get("RANK", 0)) == 0
@@ -562,6 +563,12 @@ def _train_and_evaluate(
 
             # Restore model and optimizer checkpoint
             if i_step == 0 and ckpt_path is not None:
+                if is_rank_zero:
+                    logger.info(
+                        "Checkpoint restore options: "
+                        f"ignore_restore_optimizer={ignore_restore_optimizer}, "
+                        f"restore_lr_scheduler={restore_lr_scheduler}."
+                    )
                 if ignore_restore_optimizer:
                     ckpt_manager.restore(
                         ckpt_path,
@@ -569,6 +576,7 @@ def _train_and_evaluate(
                         None,
                         train_config.fine_tune_ckpt_param_map,
                         dense_ema=dense_ema,
+                        lr_schedulers=lr_scheduler if restore_lr_scheduler else None,
                     )
                 else:
                     # optimizer state is lazy, so peek one batch to init it
@@ -582,6 +590,7 @@ def _train_and_evaluate(
                         optimizer,
                         train_config.fine_tune_ckpt_param_map,
                         dense_ema=dense_ema,
+                        lr_schedulers=lr_scheduler if restore_lr_scheduler else None,
                     )
                 if not restore_from_model_dir:
                     # a fine-tune checkpoint's train metric describes the source
@@ -642,6 +651,7 @@ def _train_and_evaluate(
                     dataloader_state,
                     dense_ema,
                     data_timestamp=data_timestamp,
+                    lr_schedulers=lr_scheduler,
                 ):
                     run_eval(i_step, i_epoch)
                 # Lockstep: the rank-uniform paired dump decision is the only
@@ -662,6 +672,11 @@ def _train_and_evaluate(
                 if prof is not None:
                     prof.step()
 
+            if not (use_step and i_step >= train_config.num_steps - 1):
+                for lr in lr_scheduler:
+                    if lr.by_epoch:
+                        lr.step()
+
             if ckpt_manager.maybe_save(
                 i_step,
                 model,
@@ -670,15 +685,12 @@ def _train_and_evaluate(
                 dense_ema,
                 epoch=i_epoch,
                 data_timestamp=data_timestamp,
+                lr_schedulers=lr_scheduler,
             ):
                 run_eval(i_step, i_epoch)
 
             if use_step and i_step >= train_config.num_steps - 1:
                 break
-
-            for lr in lr_scheduler:
-                if lr.by_epoch:
-                    lr.step()
 
         # One-shot end-of-loop hook (default no-op; e.g. SidRqkmeans fits its FAISS
         # codebook here). SID models run with periodic checkpointing disabled
@@ -716,6 +728,7 @@ def _train_and_evaluate(
             dense_ema,
             data_timestamp=data_timestamp,
             final=True,
+            lr_schedulers=lr_scheduler,
         ):
             run_eval(i_step, i_epoch)
         if final_dump_step is not None:
@@ -752,6 +765,7 @@ def train_and_evaluate(
     fine_tune_checkpoint: Optional[str] = None,
     edit_config_json: Optional[str] = None,
     ignore_restore_optimizer: bool = False,
+    restore_lr_scheduler: bool = False,
 ) -> None:
     """Train and evaluate a EasyRec model.
 
@@ -765,8 +779,10 @@ def train_and_evaluate(
         fine_tune_checkpoint (str, optional): path to an existing
             finetune checkpoint.
         edit_config_json (str, optional): edit pipeline config json str.
-        ignore_restore_optimizer (bool): whether to restore optimizer
+        ignore_restore_optimizer (bool): whether to skip restoring optimizer
             state from checkpoint.
+        restore_lr_scheduler (bool): whether to restore LR scheduler state
+            independently of optimizer state; defaults to a fresh schedule.
     """
     pipeline_config = config_util.load_pipeline_config(pipeline_config_path)
     train_config = pipeline_config.train_config
@@ -1027,6 +1043,7 @@ def train_and_evaluate(
         ckpt_path=ckpt_path,
         check_all_workers_data_status=check_all_workers_data_status,
         ignore_restore_optimizer=ignore_restore_optimizer,
+        restore_lr_scheduler=restore_lr_scheduler,
         restore_from_model_dir=restore_from_model_dir,
         dataloader_state=dataloader_state,
         delta_embedding_dumper=delta_embedding_dumper,

--- a/tzrec/main_test.py
+++ b/tzrec/main_test.py
@@ -13,6 +13,9 @@
 
 import itertools
 import os
+import runpy
+import shutil
+import sys
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -33,6 +36,7 @@ from tzrec.main import (
 )
 from tzrec.models.model import BaseModel
 from tzrec.optim.ema import DenseEMA
+from tzrec.optim.lr_scheduler import ExponentialDecayLR, LinearDecayLR
 from tzrec.protos.data_pb2 import DataConfig
 from tzrec.protos.eval_pb2 import EvalConfig
 from tzrec.protos.export_pb2 import ExportConfig
@@ -41,13 +45,24 @@ from tzrec.protos.module_pb2 import MLP
 from tzrec.protos.optimizer_pb2 import DenseOptimizer, EMAConfig
 from tzrec.protos.pipeline_pb2 import EasyRecConfig
 from tzrec.protos.train_pb2 import DeltaEmbeddingDumpConfig, TrainConfig
-from tzrec.utils import predict_util
+from tzrec.utils import checkpoint_util, predict_util
 from tzrec.utils.delta_embedding_dump import DumpDecision
-from tzrec.utils.test_util import parameterized_name_func
+from tzrec.utils.test_util import make_test_dir, parameterized_name_func
 
 
 class MainTest(unittest.TestCase):
     """Tests for tzrec.main orchestration."""
+
+    @parameterized.expand([(False,), (True,)], name_func=parameterized_name_func)
+    def test_train_cli_restore_lr_scheduler(self, restore):
+        argv = ["tzrec.train_eval"] + (["--restore_lr_scheduler"] if restore else [])
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch("tzrec.main.train_and_evaluate", autospec=True) as train,
+        ):
+            runpy.run_module("tzrec.train_eval", run_name="__main__")
+        train.assert_called_once()
+        self.assertIs(train.call_args.kwargs["restore_lr_scheduler"], restore)
 
     def test_create_custom_model(self) -> None:
         """A custom model receives its unpacked protobuf configuration."""
@@ -564,6 +579,163 @@ class PredictionLifecycleTest(unittest.TestCase):
                     self._run_predict_checkpoint(pipeline, writer)
                     self.assertEqual(writer.write.call_count, 2)
                     writer.close.assert_called_once_with()
+
+
+class TrainLRSchedulerResumeTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = make_test_dir()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+
+    def _run(
+        self,
+        model_dir,
+        *,
+        restore=None,
+        ignore_optimizer=False,
+        ckpt_path=None,
+        by_epoch=False,
+        save_by_epoch=False,
+    ):
+        parameter = torch.nn.Parameter(torch.ones(1))
+        parameter.grad = torch.ones_like(parameter)
+        optimizer = torch.optim.SGD([parameter], lr=0.01)
+        optimizer.params = {"weight": parameter}
+        scheduler = (
+            ExponentialDecayLR(optimizer, 1, 0.5, by_epoch=True)
+            if by_epoch
+            else LinearDecayLR(optimizer, num_training_steps=10)
+        )
+        used_lrs = []
+        model = mock.Mock()
+        model.module.model.compute_train_metric.return_value = {}
+        loader = mock.Mock()
+        skip_steps = (
+            checkpoint_util._get_checkpoint_step(ckpt_path) if ckpt_path else -1
+        )
+        pass_sizes = itertools.chain([3 - (skip_steps + 1) % 3], itertools.repeat(3))
+        loader.get_iterator.side_effect = lambda: iter(range(next(pass_sizes)))
+        batch = SimpleNamespace(checkpoint_info=None, data_timestamp=-1.0)
+        warming_up = ckpt_path is not None and not ignore_optimizer
+
+        def progress(iterator):
+            nonlocal warming_up
+            next(iterator)
+            if warming_up:
+                warming_up = False
+            else:
+                used_lrs.append(optimizer.param_groups[0]["lr"])
+            optimizer.step()
+            return {"loss": parameter.detach().sum()}, {}, batch
+
+        pipeline = mock.Mock()
+        pipeline.progress.side_effect = progress
+        manager = checkpoint_util.CheckpointManager(model_dir)
+        exporter = mock.Mock(enabled=False)
+        config = TrainConfig(
+            num_steps=0 if by_epoch else 6,
+            num_epochs=3 if by_epoch else 0,
+            save_checkpoints_steps=1,
+            save_checkpoints_epochs=1 if save_by_epoch else 0,
+            use_tensorboard=False,
+            dense_optimizer=DenseOptimizer(),
+        )
+        restore_kwargs = {} if restore is None else {"restore_lr_scheduler": restore}
+        with (
+            mock.patch.dict(os.environ, {"RANK": "0", "LOCAL_RANK": "0"}),
+            mock.patch("tzrec.main.create_train_pipeline", return_value=pipeline),
+            mock.patch("tzrec.main.OnlineDenseExportManager", return_value=exporter),
+            mock.patch("tzrec.main._log_train"),
+            mock.patch("tzrec.utils.checkpoint_util.save_model"),
+            mock.patch("tzrec.utils.checkpoint_util.restore_model") as restore_model,
+            mock.patch("tzrec.utils.hf_export_util.write_hf_assets"),
+        ):
+            _train_and_evaluate(
+                model,
+                optimizer,
+                loader,
+                None,
+                [scheduler],
+                model_dir,
+                config,
+                EvalConfig(),
+                manager,
+                ckpt_path=ckpt_path,
+                skip_steps=skip_steps,
+                ignore_restore_optimizer=ignore_optimizer,
+                restore_from_model_dir=ckpt_path is not None,
+                dataloader_state=checkpoint_util.restore_dataloader_state(ckpt_path)
+                if ckpt_path
+                else None,
+                **restore_kwargs,
+            )
+        if ckpt_path:
+            self.assertEqual(restore_model.call_count, 1)
+            self.assertIs(
+                restore_model.call_args.args[2], None if ignore_optimizer else optimizer
+            )
+        else:
+            restore_model.assert_not_called()
+        return used_lrs
+
+    def test_cold_start_with_restore_enabled(self):
+        reference = self._run(os.path.join(self.test_dir, "reference"))
+        actual = self._run(os.path.join(self.test_dir, "cold_start"), restore=True)
+        torch.testing.assert_close(actual, reference)
+
+    @parameterized.expand(
+        [
+            ("default", None, False, False),
+            ("weights_only", None, True, False),
+            ("resume", True, False, False),
+            ("resume_without_optimizer", True, True, False),
+            ("legacy_checkpoint", True, False, True),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_batch_resume_and_legacy_default(self, name, restore, ignore, legacy):
+        source = os.path.join(self.test_dir, "source")
+        reference = self._run(source)
+        ckpt = os.path.join(source, "model.ckpt-3")
+        if legacy:
+            os.remove(os.path.join(ckpt, checkpoint_util.LR_SCHEDULER_CKPT_FILENAME))
+        actual = self._run(
+            os.path.join(self.test_dir, "resumed"),
+            restore=restore,
+            ignore_optimizer=ignore,
+            ckpt_path=ckpt,
+        )
+        expected = reference[4:] if restore else reference[:2]
+        torch.testing.assert_close(actual, expected)
+
+    @parameterized.expand(
+        [
+            ("default", False, True, False),
+            ("mid_epoch", True, False, False),
+            ("epoch_boundary_step_save", True, True, False),
+            ("epoch_boundary_epoch_save", True, True, True),
+        ],
+        name_func=parameterized_name_func,
+    )
+    def test_epoch_resume(self, name, restore, boundary, save_by_epoch):
+        source = os.path.join(self.test_dir, "source")
+        reference = self._run(
+            source,
+            by_epoch=True,
+            save_by_epoch=save_by_epoch,
+        )
+        step = 2 if boundary else 4
+        ckpt = os.path.join(source, f"model.ckpt-{step}")
+        actual = self._run(
+            os.path.join(self.test_dir, "resumed"),
+            restore=restore,
+            ignore_optimizer=True,
+            ckpt_path=ckpt,
+            by_epoch=True,
+        )
+        expected = reference[step + 1 :]
+        if not restore:
+            expected = [lr * 2 for lr in expected]
+        torch.testing.assert_close(actual, expected)
 
 
 class TrainStepCounterMultiPassTest(unittest.TestCase):

--- a/tzrec/optim/lr_scheduler.py
+++ b/tzrec/optim/lr_scheduler.py
@@ -12,7 +12,7 @@
 
 import bisect
 import math
-from typing import List
+from typing import Any, Dict, List
 
 from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
@@ -47,6 +47,25 @@ class BaseLR(LRScheduler, metaclass=_meta_cls):
     def _get_lr(self) -> List[float]:
         """Calculates the learning rate."""
         raise NotImplementedError
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        """Restore scheduler state and the optimizer's next learning rates."""
+        group_count = len(self.optimizer.param_groups)
+        if any(len(state_dict[key]) != group_count for key in ("base_lrs", "_last_lr")):
+            raise ValueError("Restored LR scheduler parameter groups do not match.")
+        super().load_state_dict(state_dict)
+        for group, lr in zip(self.optimizer.param_groups, self._last_lr):
+            group["lr"] = lr
+
+    def set_step(self, step: int) -> None:
+        """Rebuild a legacy scheduler after this many batch or epoch advances."""
+        if step < 0:
+            raise ValueError(f"LR scheduler step must be non-negative, got {step}.")
+        self.last_epoch = step
+        self._step_count = step + 1
+        self._last_lr = [float(lr) for lr in self.get_lr()]
+        for group, lr in zip(self.optimizer.param_groups, self._last_lr):
+            group["lr"] = lr
 
     @property
     def by_epoch(self) -> bool:

--- a/tzrec/optim/lr_scheduler_test.py
+++ b/tzrec/optim/lr_scheduler_test.py
@@ -14,11 +14,59 @@ import math
 import unittest
 
 import torch
+from parameterized import parameterized
 
 from tzrec.optim import lr_scheduler
+from tzrec.utils.test_util import parameterized_name_func
 
 
 class LRSchedulerTest(unittest.TestCase):
+    @parameterized.expand(
+        [(count, legacy) for count in [1, 4, 12] for legacy in [False, True]],
+        name_func=parameterized_name_func,
+    )
+    def test_restore_progress(self, count, legacy):
+        def build():
+            opt = torch.optim.SGD(
+                [
+                    {"params": [torch.nn.Parameter(torch.ones(1))], "lr": 0.01},
+                    {"params": [torch.nn.Parameter(torch.ones(1))], "lr": 0.0},
+                ]
+            )
+            return opt, lr_scheduler.LinearDecayLR(
+                opt, num_training_steps=10, warmup_size=2
+            )
+
+        optimizer, scheduler = build()
+        for _ in range(count):
+            optimizer.step()
+            scheduler.step()
+        resumed_optimizer, resumed = build()
+        if legacy:
+            resumed.set_step(count)
+        else:
+            resumed.load_state_dict(scheduler.state_dict())
+        for _ in range(2):
+            self.assertEqual(resumed.last_epoch, scheduler.last_epoch)
+            self.assertEqual(resumed._step_count, scheduler._step_count)
+            self.assertEqual(resumed.get_last_lr(), scheduler.get_last_lr())
+            self.assertEqual(
+                [group["lr"] for group in resumed_optimizer.param_groups],
+                [group["lr"] for group in optimizer.param_groups],
+            )
+            optimizer.step()
+            resumed_optimizer.step()
+            scheduler.step()
+            resumed.step()
+
+    def test_restore_rejects_different_parameter_groups(self):
+        optimizer = torch.optim.SGD([torch.nn.Parameter(torch.ones(1))], lr=0.01)
+        scheduler = lr_scheduler.ConstantLR(optimizer)
+        state = scheduler.state_dict()
+        state["base_lrs"] = []
+        with self.assertRaisesRegex(ValueError, "parameter groups"):
+            scheduler.load_state_dict(state)
+
     def test_constant_lr(self) -> None:
         params = [torch.tensor([1.0, 2.0])]
         opt = torch.optim.Adam(params, lr=0.01)

--- a/tzrec/train_eval.py
+++ b/tzrec/train_eval.py
@@ -58,6 +58,12 @@ if __name__ == "__main__":
         default=False,
         help="ignore restore optimizer state from checkpoint.",
     )
+    parser.add_argument(
+        "--restore_lr_scheduler",
+        action="store_true",
+        default=False,
+        help="restore LR scheduler state from checkpoint.",
+    )
     args, extra_args = parser.parse_known_args()
 
     train_and_evaluate(
@@ -69,4 +75,5 @@ if __name__ == "__main__":
         args.fine_tune_checkpoint,
         args.edit_config_json,
         args.ignore_restore_optimizer,
+        restore_lr_scheduler=args.restore_lr_scheduler,
     )

--- a/tzrec/utils/checkpoint_util.py
+++ b/tzrec/utils/checkpoint_util.py
@@ -42,6 +42,7 @@ from torchrec.modules.mc_modules import MCHManagedCollisionModule
 from tzrec.acc.utils import is_input_tile_emb
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.optim.ema import DenseEMA
+from tzrec.optim.lr_scheduler import BaseLR, ConstantLR
 from tzrec.protos import export_pb2
 from tzrec.utils import env_util
 from tzrec.utils.dynamicemb_util import has_dynamicemb
@@ -427,6 +428,7 @@ class CheckpointManager:
         dataloader_state: Optional[Dict[str, Any]] = None,
         dense_ema: Optional[DenseEMA] = None,
         data_ts: Optional[float] = None,
+        lr_schedulers: Optional[List[BaseLR]] = None,
     ) -> str:
         """Save a checkpoint at the given step, then request an async prune.
 
@@ -436,6 +438,8 @@ class CheckpointManager:
         """
         ckpt_dir = os.path.join(self._model_dir, f"model.ckpt-{step}")
         save_model(ckpt_dir, model, optimizer, dense_ema)
+        if lr_schedulers is not None:
+            save_lr_schedulers(ckpt_dir, lr_schedulers)
         # Local import avoids a circular import (hf_export_util imports us).
         from tzrec.utils.hf_export_util import write_hf_assets
 
@@ -551,6 +555,7 @@ class CheckpointManager:
         epoch: Optional[int] = None,
         data_timestamp: float = -1.0,
         final: bool = False,
+        lr_schedulers: Optional[List[BaseLR]] = None,
     ) -> bool:
         """Save a checkpoint if a configured trigger fires; return whether it did.
 
@@ -571,6 +576,7 @@ class CheckpointManager:
             data_timestamp: this rank's consumed event-time (seconds), -1.0 if none;
                 reconciled across workers (quorum) for the event-time trigger.
             final: force a save (still subject to the dedupe), e.g. at train end.
+            lr_schedulers: learning rate schedulers to save on every rank.
 
         Returns:
             True if a checkpoint was saved.
@@ -615,6 +621,8 @@ class CheckpointManager:
                 and self._last_ckpt_dir is not None
             ):
                 save_dataloader_state(self._last_ckpt_dir, dataloader_state)
+                if lr_schedulers is not None:
+                    save_lr_schedulers(self._last_ckpt_dir, lr_schedulers)
             return False
 
         self._last_ckpt_step = step
@@ -630,7 +638,15 @@ class CheckpointManager:
         report_ts = data_ts
         if report_ts is None and not self.needs_worker_timestamps():
             report_ts = self._reconcile_event_time(data_timestamp, force=True)
-        self.save(step, model, optimizer, dataloader_state, dense_ema, report_ts)
+        self.save(
+            step,
+            model,
+            optimizer,
+            dataloader_state,
+            dense_ema,
+            report_ts,
+            lr_schedulers=lr_schedulers,
+        )
         return True
 
     def prune(self) -> None:
@@ -686,6 +702,7 @@ class CheckpointManager:
         ckpt_param_map_path: Optional[str] = None,
         dense_ema: Optional[DenseEMA] = None,
         use_dense_ema: bool = False,
+        lr_schedulers: Optional[List[BaseLR]] = None,
     ) -> None:
         """Restore model/optimizer state from a checkpoint dir."""
         restore_model(
@@ -696,6 +713,8 @@ class CheckpointManager:
             dense_ema=dense_ema,
             use_dense_ema=use_dense_ema,
         )
+        if lr_schedulers is not None:
+            restore_lr_schedulers(ckpt_path, lr_schedulers)
 
     def restore_dataloader_state(self, ckpt_path: str) -> Optional[Dict[str, Any]]:
         """Restore dataloader state saved alongside a checkpoint.
@@ -1244,6 +1263,88 @@ DATA_TS_WATERMARK = "__data_ts_watermark__"
 # reserved dataloader_state key: number of completed data passes; resume
 # continues the epoch budget from here. no ":" so per-source consumers skip it.
 EPOCHS_COMPLETED = "__epochs_completed__"
+LR_SCHEDULER_CKPT_FILENAME = "lr_scheduler.json"
+
+
+def save_lr_schedulers(checkpoint_dir: str, schedulers: List[BaseLR]) -> None:
+    """Save per-rank scheduler states, including rank-local parameter groups.
+
+    The JSON list is indexed by rank. Restoring requires the same world size,
+    scheduler types/order and local parameter-group counts. Atomic replacement
+    also supports refreshing an epoch boundary deduplicated against a step save.
+    """
+    local_state = [
+        {"type": type(scheduler).__name__, "state": scheduler.state_dict()}
+        for scheduler in schedulers
+    ]
+    states: List[Any] = [local_state]
+    if dist.is_initialized():
+        states = [None] * dist.get_world_size()
+        dist.all_gather_object(states, local_state)
+    if int(os.environ.get("RANK", 0)) == 0:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        path = os.path.join(checkpoint_dir, LR_SCHEDULER_CKPT_FILENAME)
+        with open(path + ".tmp", "w") as f:
+            json.dump(states, f)
+        os.replace(path + ".tmp", path)
+
+
+def restore_lr_schedulers(checkpoint_dir: str, schedulers: List[BaseLR]) -> None:
+    """Restore schedulers, or reconstruct legacy progress from unchanged config.
+
+    A stepped legacy checkpoint records a zero-based batch index. Epoch-based
+    schedules additionally require an explicit completed-epoch count; missing
+    progress is an error rather than silently restarting the learning rate.
+    """
+    path = os.path.join(checkpoint_dir, LR_SCHEDULER_CKPT_FILENAME)
+    if os.path.exists(path):
+        with open(path) as f:
+            states = json.load(f)
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        if len(states) != world_size:
+            raise ValueError("Restored LR scheduler world size does not match.")
+        local_state = states[rank]
+        if [state["type"] for state in local_state] != [
+            type(scheduler).__name__ for scheduler in schedulers
+        ]:
+            raise ValueError("Restored LR scheduler types/order do not match.")
+        for scheduler, state in zip(schedulers, local_state):
+            scheduler.load_state_dict(state["state"])
+    else:
+        meta_path = os.path.join(checkpoint_dir, CKPT_META_FILENAME)
+        meta = {}
+        if os.path.exists(meta_path):
+            with open(meta_path) as f:
+                meta = json.load(f)
+        step = meta.get("step")
+        if step is None:
+            match = re.search(r"model\.ckpt-(\d+)$", checkpoint_dir.rstrip("/"))
+            if match:
+                step = int(match.group(1))
+        dataloader_state = restore_dataloader_state(checkpoint_dir) or {}
+        counts = []
+        for scheduler in schedulers:
+            if isinstance(scheduler, ConstantLR):
+                count = 0
+            elif scheduler.by_epoch:
+                count = dataloader_state.get(EPOCHS_COMPLETED)
+            else:
+                count = step + 1 if step is not None else None
+            if count is None:
+                raise ValueError(
+                    "Cannot reconstruct legacy LR scheduler progress: checkpoint "
+                    "must record step / completed epochs. Omit --restore_lr_scheduler "
+                    "to keep the configured initial schedule."
+                )
+            counts.append(count)
+        logger.warning(
+            "Checkpoint has no LR scheduler state; reconstructing progress from "
+            "checkpoint metadata. The original LR configuration must be unchanged."
+        )
+        for scheduler, count in zip(schedulers, counts):
+            scheduler.set_step(count)
+    logger.info(f"Restored LR schedulers from {checkpoint_dir}.")
 
 
 def save_meta(

--- a/tzrec/utils/checkpoint_util_test.py
+++ b/tzrec/utils/checkpoint_util_test.py
@@ -38,9 +38,14 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 from tzrec.constant import TRAIN_EVAL_RESULT_FILENAME
 from tzrec.optim.ema import DenseEMA
+from tzrec.optim.lr_scheduler import (
+    ConstantLR,
+    ExponentialDecayLR,
+    LinearDecayLR,
+)
 from tzrec.protos.export_pb2 import ExportConfig
 from tzrec.utils import checkpoint_util, misc_util
-from tzrec.utils.test_util import make_test_dir
+from tzrec.utils.test_util import make_test_dir, parameterized_name_func
 
 
 def _create_test_model(large_table_cnt=2, small_table_cnt=2):
@@ -144,8 +149,24 @@ def _save_restore_worker(test_dir, rank, world_size, port):
     os.environ["MASTER_PORT"] = str(port)
     dist.init_process_group(backend="gloo")
     model, optimizer = _create_test_model()
+    for i, group in enumerate(optimizer.param_groups):
+        group["lr"] = 0.01 * (rank + 1) * (i + 1)
+    scheduler = LinearDecayLR(optimizer, num_training_steps=10)
+    scheduler.set_step(4)
+    expected = scheduler.get_last_lr()
     checkpoint_util.save_model(test_dir, model, optimizer)
+    checkpoint_util.save_lr_schedulers(test_dir, [scheduler])
+    dist.barrier()
     checkpoint_util.restore_model(test_dir, model, optimizer)
+    scheduler.set_step(0)
+    checkpoint_util.restore_lr_schedulers(test_dir, [scheduler])
+    torch.testing.assert_close(scheduler.get_last_lr(), expected)
+    torch.testing.assert_close(
+        [group["lr"] for group in optimizer.param_groups], expected
+    )
+    optimizer.step()
+    scheduler.step()
+    torch.testing.assert_close(scheduler.get_last_lr(), [lr * 5 / 6 for lr in expected])
 
 
 def _report_ts_worker(
@@ -891,6 +912,84 @@ class CheckpointUtilTest(unittest.TestCase):
         self.assertEqual(
             checkpoint_util.remap_input_tile_user_key(fqn, {target}), target
         )
+
+
+class LRSchedulerCheckpointTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = make_test_dir()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        env = mock.patch.dict(os.environ, {"RANK": "0", "LOCAL_RANK": "0"})
+        env.start()
+        self.addCleanup(env.stop)
+
+    def _scheduler(self, by_epoch=False):
+        optimizer = KeyedOptimizerWrapper(
+            {"weight": nn.Parameter(torch.ones(1))},
+            lambda params: torch.optim.Adam(params, lr=0.01),
+        )
+        return ExponentialDecayLR(optimizer, 1, 0.5, by_epoch=by_epoch)
+
+    def test_round_trip(self):
+        original = [self._scheduler(), self._scheduler(by_epoch=True)]
+        for scheduler in original:
+            scheduler.set_step(4)
+        manager = checkpoint_util.CheckpointManager(self.test_dir)
+        self.addCleanup(manager.close)
+        with (
+            mock.patch("tzrec.utils.checkpoint_util.save_model"),
+            mock.patch("tzrec.utils.hf_export_util.write_hf_assets"),
+        ):
+            ckpt = manager.save(3, nn.Linear(1, 1), lr_schedulers=original)
+        resumed = [self._scheduler(), self._scheduler(by_epoch=True)]
+        with mock.patch("tzrec.utils.checkpoint_util.restore_model"):
+            manager.restore(ckpt, nn.Linear(1, 1), lr_schedulers=resumed)
+        for expected, actual in zip(original, resumed):
+            self.assertEqual(expected.state_dict(), actual.state_dict())
+            self.assertEqual(
+                actual.optimizer.param_groups[0]["lr"], expected.get_last_lr()[0]
+            )
+
+    @parameterized.expand(
+        [("meta", True), ("filename", False)], name_func=parameterized_name_func
+    )
+    def test_legacy_step(self, name, with_meta):
+        ckpt = os.path.join(self.test_dir, "model.ckpt-3")
+        os.makedirs(ckpt)
+        if with_meta:
+            checkpoint_util.save_meta(ckpt, 3)
+        scheduler = self._scheduler()
+        checkpoint_util.restore_lr_schedulers(ckpt, [scheduler])
+        self.assertEqual(scheduler.last_epoch, 4)
+        self.assertAlmostEqual(scheduler.optimizer.param_groups[0]["lr"], 0.000625)
+
+    def test_legacy_epoch(self):
+        checkpoint_util.save_dataloader_state(
+            self.test_dir, {checkpoint_util.EPOCHS_COMPLETED: 2}
+        )
+        scheduler = self._scheduler(by_epoch=True)
+        checkpoint_util.restore_lr_schedulers(self.test_dir, [scheduler])
+        self.assertEqual(scheduler.last_epoch, 2)
+        self.assertAlmostEqual(scheduler.optimizer.param_groups[0]["lr"], 0.0025)
+
+    @parameterized.expand([(False,), (True,)], name_func=parameterized_name_func)
+    def test_legacy_missing_progress(self, by_epoch):
+        with self.assertRaisesRegex(ValueError, "Cannot reconstruct"):
+            checkpoint_util.restore_lr_schedulers(
+                self.test_dir, [self._scheduler(by_epoch=by_epoch)]
+            )
+
+    def test_legacy_constant_without_progress(self):
+        opt = torch.optim.SGD([nn.Parameter(torch.ones(1))], lr=0.01)
+        scheduler = ConstantLR(opt)
+        checkpoint_util.restore_lr_schedulers(self.test_dir, [scheduler])
+        self.assertEqual(opt.param_groups[0]["lr"], 0.01)
+
+    def test_scheduler_type_mismatch(self):
+        scheduler = self._scheduler()
+        schedulers = [scheduler, ConstantLR(scheduler.optimizer)]
+        checkpoint_util.save_lr_schedulers(self.test_dir, schedulers)
+        with self.assertRaisesRegex(ValueError, "types/order"):
+            checkpoint_util.restore_lr_schedulers(self.test_dir, schedulers[::-1])
 
 
 class DataloaderCheckpointTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Training checkpoints currently restore model and optimizer state but do not save LR scheduler progress, so resumed training restarts the learning rate schedule.

Add an opt-in `--restore_lr_scheduler` CLI flag, defaulting to false to preserve existing behavior. It works independently of `--ignore_restore_optimizer`. Checkpoints save per-rank scheduler state, and restoration also updates optimizer learning rates before the first resumed batch. Epoch-based schedules advance before the epoch checkpoint is saved.

For legacy checkpoints without scheduler state, reconstruct progress from the saved batch index or completed epoch count using the unchanged LR configuration. Report an error when the required progress is unavailable. Training with no existing checkpoint still starts normally.

The restore policy is a CLI option rather than a TrainConfig field: it is a launch-time decision, keeps existing configurations unchanged, and needs no protobuf change. Saved-state restoration requires the same world size, scheduler types/order, and local parameter-group counts.

## Test Plan

- Run scheduler, checkpoint, training-loop, optimizer, and prompt regression tests in the repository's PyTorch 2.13 environment: 179 tests passed. Coverage includes default behavior, cold start, independent optimizer restoration, legacy reconstruction, and step/epoch resume boundaries.
- Reuse the existing two-rank CPU/Gloo checkpoint test to verify rank-local learning rates and the next scheduler step after restoration.
- `pre-commit run -a`: all hooks passed. `pyrefly check`: 0 errors.
