### PR TITLE
[bugfix] post AI review inline comments instead of buffering them

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -186,8 +186,13 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Post inline comments as they are created. Left unset, the MCP server
+          # buffers them into /tmp for a post-step that only claude-code-action
+          # runs; these jobs drive the CLI directly, so nothing would post them.
+          CLASSIFY_INLINE_COMMENTS: "false"
           # No ANTHROPIC_API_KEY — uses stored OAuth from `claude /login` on the runner
-          # MCP server inherits env vars (GITHUB_TOKEN, REPO_OWNER, REPO_NAME, PR_NUMBER)
+          # MCP server inherits env vars (GITHUB_TOKEN, REPO_OWNER, REPO_NAME,
+          # PR_NUMBER, CLASSIFY_INLINE_COMMENTS)
         run: |
           set -euo pipefail
 
@@ -314,7 +319,9 @@ jobs:
           grep -q '^model *=' "$CODEX_HOME/config.toml" || {
             echo "::error::set model = \"...\" in the runner's ~/.codex/config.toml"; exit 1; }
 
-          # The MCP server gets its token here (config file, not argv or codex env)
+          # The MCP server gets its token here (config file, not argv or codex
+          # env), and this block is its whole environment, so the inline-comment
+          # buffer opt-out has to be repeated here
           cat >> "$CODEX_HOME/config.toml" << EOF
 
           [mcp_servers.github_inline_comment]
@@ -327,6 +334,7 @@ jobs:
           REPO_OWNER = "${REPO_OWNER}"
           REPO_NAME = "${REPO_NAME}"
           PR_NUMBER = "${PR_NUMBER}"
+          CLASSIFY_INLINE_COMMENTS = "false"
           EOF
           chmod 600 "$CODEX_HOME/config.toml"
 


### PR DESCRIPTION
## Problem

The AI code review stopped posting inline comments. In [run 34201597956](https://github.com/alibaba/TorchEasyRec/actions/runs/34201597956/job/101981409180) (PR #662) the reviewer made 11 `create_inline_comment` calls, every one succeeded, and none reached the PR (`GET /pulls/662/comments` returns 0). Only the top-level summary landed, because that goes through `gh pr comment`.

Each call came back:

```json
{"success": true, "buffered": true,
 "message": "Comment buffered. It will be classified and posted after this session
             completes ... Set confirmed=true to post immediately."}
```

## Root cause

`claude-code-action`'s `github-inline-comment-server.ts` appends every unconfirmed call to `/tmp/inline-comments-buffer.jsonl` instead of posting it:

```ts
const CLASSIFY_ENABLED = process.env.CLASSIFY_INLINE_COMMENTS !== "false";
if (CLASSIFY_ENABLED && confirmed !== true) { appendFileSync(BUFFER_PATH, ...); return buffered; }
```

The buffer is drained by a separate entrypoint, `src/entrypoints/post-buffered-inline-comments.ts`, which the composite action runs as a post-step. Both jobs here drive the CLI directly with only `--mcp-config` / `[mcp_servers]`, so that entrypoint never runs, the MCP server dies with the session, and the buffer stays on the runner.

The behavior has been upstream since March; the runner's `git clone --branch v1` of the action was older than that until its last update. Run `34120554588` (2026-09-07 12:41) still posted 11 inline comments live; run `34201597956` (2026-09-08 07:53) buffered all of them. Nothing in this repo changed — `.claude/commands/review-pr.md` has never mentioned `confirmed`.

## Fix

Set `CLASSIFY_INLINE_COMMENTS=false` in the MCP server's environment in both jobs, which restores immediate posting. The codex job needs its own copy of the variable: its `[mcp_servers.github_inline_comment.env]` block is the server's whole environment, not an inherited one, which is also why `GITHUB_TOKEN` and friends are listed there explicitly.

Two alternatives were rejected. Instructing the reviewers to pass `confirmed: true` depends on the model remembering the argument on every call and needs the same edit duplicated into the codex agent prompts. Adding the flush entrypoint as a post-step is worse still: `post-buffered-inline-comments.ts` reads the buffer but never truncates it, and on this persistent self-hosted runner the file has been accumulating since the regression — a flush without an `rm -f` first would spray one PR's comments onto the next.

## Test Plan

- `yaml.safe_load` on the workflow: parses, and the `RunCodeReview` step env carries `CLASSIFY_INLINE_COMMENTS: 'false'` (string, so the server's `!== "false"` check sees it).
- Replayed the codex heredoc through `tomllib`: the generated `config.toml` parses with its preserved indentation and `mcp_servers.github_inline_comment.env` carries the new key alongside the existing four.
- `pre-commit run --files .github/workflows/code_review.yml`: all applicable hooks pass.
- End-to-end verification is the next `claude-review` / `codex-review` label on a PR — inline comments should appear during the run rather than being reported as buffered.

Unrelated follow-up worth doing on the runner: the setup instructions clone the action from a moving `v1` branch, which is how a tool contract changed under CI unnoticed; pinning to a tag or SHA would prevent a repeat. The stale `/tmp/inline-comments-buffer.jsonl` there can also be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJg1zk3pFsjZdaUCWvjwBT
